### PR TITLE
Add support for devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,19 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+
+export FLUTTER_DIR=$(expand_path ./.flutter)
+
+# Flutter is not supported on MacOS by nix so we install it "manually"
+if [ ! -d "$FLUTTER_DIR/.git" ]; then
+    git clone https://github.com/flutter/flutter.git -b stable "$FLUTTER_DIR" --depth=1
+else
+    (cd "$FLUTTER_DIR" && git pull) || true
+fi
+
+export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
+
+use devenv
+
+PATH_add "$HOME/.pub-cache/bin"
+PATH_add "$FLUTTER_DIR/bin"
+
+flutter config --android-sdk "$ANDROID_SDK_ROOT"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Devenv
+.direnv/
+.devenv*
+devenv.local.nix
+.flutter/
+

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,138 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1683566927,
+        "narHash": "sha256-pCJ9IPQeEbxKOuE6m++M9NRoweHid8r/9A1Uhbk1HQM=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "c90896345449b92d8f503cf8c2a339088bec0ddc",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683777345,
+        "narHash": "sha256-V2p/A4RpEGqEZussOnHYMU6XglxBJGCODdzoyvcwig8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "635a306fc8ede2e34cb3dd0d6d0a5d49362150ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1682596858,
+        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+
+let
+  android-comp     = pkgs.androidenv.composeAndroidPackages {
+    buildToolsVersions = [ "30.0.3" ];
+    platformVersions   = [ "29" "30" "31" "33" ];
+  };
+  android-sdk      = android-comp.androidsdk;
+  android-sdk-root = "${android-sdk}/libexec/android-sdk";
+in {
+  env = {
+    ANDROID_HOME     = "${android-sdk-root}";
+    ANDROID_SDK_ROOT = "${android-sdk-root}";
+  };
+
+  languages.java = {
+    enable      = true;
+    jdk.package = pkgs.jdk11;
+  };
+
+  name = "mm-flutter-app";
+
+  packages = [ android-sdk ];
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,4 @@
+allowUnfree: true
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable


### PR DESCRIPTION
[Devenv](https://devenv.sh/) is a tool that setups development environment by installing packages, configuring them, managing services, running processes, etc. Initial definition takes care of flutter, JDK and Android SDK.

This PR is entirely optional and may be declined. In such a case I'll move commited files to `.git/info/exclude`. My hope is that it may be of some value to you as it simplifies setup of all the development tools (and setting up Android SDK is PITA). Feel free to check out the [Getting Started](https://devenv.sh/getting-started/) steps. Mind the fact that with these files already existing you need to run `devenv shell` instead of `devenv init` unless you already use [direnv](https://direnv.net/).

If merged then it's still optional to use it so if you don't want to swallow the Nix pill it's totally fine. ;)

You may feel encouraged to use it in other projects, it can for instance set up [MongoDB](https://devenv.sh/reference/options/#servicesmongodbenable) or [Redis](https://devenv.sh/reference/options/#servicesredisenable). It's easier to use than Docker as it runs everything natively on OS and is configured declaratively.

Since it works in a terminal session after entering `devenv shell`, any development tool must be started in this session only afterwards (this applies to programs such as `code` or `vim`). It may not work properly with Android Studio.