### PR TITLE
Don't reinstall flutter if it's already available

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,19 +1,18 @@
 source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
 
-export FLUTTER_DIR=$(expand_path ./.flutter)
+if ! [ -x "$(command -v flutter)" ] &>/dev/null; then
+    FLUTTER_DIR=$(expand_path ./.flutter)
 
-# Flutter is not supported on MacOS by nix so we install it "manually"
-if [ ! -d "$FLUTTER_DIR/.git" ]; then
-    git clone https://github.com/flutter/flutter.git -b stable "$FLUTTER_DIR" --depth=1
-else
-    (cd "$FLUTTER_DIR" && git pull) || true
+    # Flutter is not supported on MacOS by nix so we install it "manually"
+    if [ ! -d "$FLUTTER_DIR/.git" ]; then
+        git clone https://github.com/flutter/flutter.git -b stable "$FLUTTER_DIR" --depth=1
+    else
+        (cd "$FLUTTER_DIR" && git pull) || true
+    fi
+
+    PATH_add "$FLUTTER_DIR/bin"
 fi
 
 export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
 
 use devenv
-
-PATH_add "$HOME/.pub-cache/bin"
-PATH_add "$FLUTTER_DIR/bin"
-
-flutter config --android-sdk "$ANDROID_SDK_ROOT"

--- a/devenv.nix
+++ b/devenv.nix
@@ -8,6 +8,10 @@ let
   android-sdk      = android-comp.androidsdk;
   android-sdk-root = "${android-sdk}/libexec/android-sdk";
 in {
+  enterShell = ''
+    flutter config --android-sdk "${android-sdk-root}"
+  '';
+
   env = {
     ANDROID_HOME     = "${android-sdk-root}";
     ANDROID_SDK_ROOT = "${android-sdk-root}";


### PR DESCRIPTION
I modified direnv instructions so that `flutter` is not installed if it's already available.