### PR TITLE
Add explore view

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,5 +3,14 @@
     "navExploreText": "Explore",
     "navJourneyText": "Journey",
     "navInboxText": "Inbox",
-    "navProfileText": "Profile"
+    "navProfileText": "Profile",
+    "mentors": "Mentors",
+    "entrepeneurs": "Entrepeneurs",
+    "india": "India",
+    "marketing": "Marketing",
+    "online": "Online",
+    "filters": "Show filters",
+    "searchHint": "Search by name or keyword",
+    "quickMatchDesc": "Find a mentor",
+    "quickMatch": "Quick match"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'data/models/user/user_provider.dart';
+import 'widgets/screens/explore/explore.dart';
 
 class MainApp extends StatelessWidget {
   const MainApp({super.key});
@@ -57,8 +58,7 @@ class MainApp extends StatelessWidget {
           GoRoute(
             path: '/explore',
             builder: (BuildContext context, GoRouterState state) {
-              return Center(
-                  child: Text(AppLocalizations.of(context)!.navExploreText));
+              return const Explore();
             },
           ),
           GoRoute(

--- a/lib/widgets/screens/explore/entrepreneurs.dart
+++ b/lib/widgets/screens/explore/entrepreneurs.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class Entrepreneurs extends StatelessWidget {
+  const Entrepreneurs({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/widgets/screens/explore/explore.dart
+++ b/lib/widgets/screens/explore/explore.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'entrepreneurs.dart';
+import 'mentors.dart';
+
+class Explore extends StatefulWidget {
+  const Explore({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _Explore();
+}
+
+class _Explore extends State<Explore> {
+  int index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = AppLocalizations.of(context)!;
+
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              TextButton(
+                onPressed: () => setState(() => index = 0),
+                child: Text(
+                  locale.mentors,
+                  textScaleFactor: 2.0,
+                  style: TextStyle(
+                      fontWeight:
+                          (index == 0) ? FontWeight.bold : FontWeight.normal),
+                ),
+              ),
+              TextButton(
+                onPressed: () => setState(() => index = 1),
+                child: Text(
+                  locale.entrepeneurs,
+                  textScaleFactor: 2.0,
+                  style: TextStyle(
+                      fontWeight:
+                          (index == 1) ? FontWeight.bold : FontWeight.normal),
+                ),
+              ),
+            ],
+          ),
+          Expanded(
+              child: (index == 0) ? const Mentors() : const Entrepreneurs()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/screens/explore/mentors.dart
+++ b/lib/widgets/screens/explore/mentors.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/widgets/screens/home/users_list.dart';
+
+class Mentors extends StatefulWidget {
+  const Mentors({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _Mentors();
+}
+
+class _Mentors extends State<Mentors> {
+  late final TextEditingController _searchController;
+
+  @override
+  void initState() {
+    _searchController = TextEditingController();
+    _searchController.addListener(() => setState(() {}));
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = AppLocalizations.of(context)!;
+
+    return Column(
+      children: [
+        Row(
+          children: [
+            Row(
+              children: [
+                TextButton(
+                  onPressed: () {
+                    // TODO: Implement filter logic
+                  },
+                  child: Text(locale.india),
+                ),
+                TextButton(
+                  onPressed: () {
+                    // TODO: Implement filter logic
+                  },
+                  child: Text(locale.marketing),
+                ),
+                TextButton(
+                  onPressed: () {
+                    // TODO: Implement filter logic
+                  },
+                  child: Text(locale.online),
+                ),
+              ],
+            ),
+            const Spacer(),
+            OutlinedButton(
+              onPressed: () {
+                // TODO: Implement filter logic
+              },
+              style: OutlinedButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: Text(locale.filters, textScaleFactor: 1.4),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Center(
+          child: TextFormField(
+            controller: _searchController,
+            decoration: InputDecoration(
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              contentPadding: const EdgeInsets.all(5),
+              hintText: locale.searchHint,
+            ),
+          ),
+        ),
+        const SizedBox(height: 20),
+        Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey),
+            borderRadius: const BorderRadius.all(Radius.circular(16.0)),
+          ),
+          height: 80.0,
+          width: double.infinity,
+          child: Column(
+            children: [
+              Row(children: [
+                const SizedBox(width: 10),
+                Text(locale.quickMatchDesc),
+                const Spacer(),
+              ]),
+              Padding(
+                padding: const EdgeInsets.only(left: 8, right: 8),
+                child: OutlinedButton(
+                  onPressed: () {
+                    // TODO: Implement quick match functionality
+                  },
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size.fromHeight(40),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: Text(locale.quickMatch, textScaleFactor: 1.4),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(children: [
+              Users(_searchController.text),
+            ]),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This is a draft of "Explore" view. Things missing at this moment:
* Filtering (search phrase works)
* Quick match
* Entrepreneurs view

We may consider merging this as is and add tickets for missing functionality.

Additional questions/notes to the UX:
1. The quick match button is at awkward position. It is not affected by search or filtering.
2. What should the entrepreneurs view look like? Can we have a wireframe for that?
3. What should a user list item look like? What should be visible before and after expanding (tapping it)? For now I'm reusing `Users` widget in this PR.
4. The search mechanism forces refresh after every character. This is very resource consuming, especially w. r. t. network usage. We should have a button confirmation instead.
5. "Find a mentor" label does not make sense being in the middle of the view. The entire view is about finding a mentor.

I'd personally recommend removing "Find a mentor" rectangle and having two buttons next to a search box: "Search" and "Quick match" ("I feel lucky" 😄).

Additional questions to the backend team:
1. Does the backend support filters for querying user list?
2. How does handling of entrepreneurs work? What is a difference between a mentor and entrepreneur? Does it support the same operations (filtering, search, etc.)?

@LucasMagnum @shadowbrush