### PR TITLE
Split pre-commit into pre-push and pre-commit

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if ! [ -x "$(command -v flutter)" ] &>/dev/null; then
     echo "Please install flutter at version 3.10"
     exit 1
 fi
 
 dart format .
-
-if ! [ -x "$(command -v pandoc)" ] &>/dev/null; then
-    echo "Please install pandoc at version 2.19"
-    exit 1
-fi
-
-pandoc \
-    --columns=80 \
-    --standalone \
-    --from=gfm \
-    --to=gfm \
-    --output=README.md \
-    README.md
+flutter gen-l10n

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [ -x "$(command -v flutter)" ] &>/dev/null; then
+    echo "Please install flutter at version 3.10"
+    exit 1
+fi
+
+dart format .
+flutter test
+flutter analyze
+flutter gen-l10n
+
+if ! [ -x "$(command -v pandoc)" ] &>/dev/null; then
+    echo "Please install pandoc at version 2.19"
+    exit 1
+fi
+
+pandoc \
+    --columns=80 \
+    --standalone \
+    --from=gfm \
+    --to=gfm \
+    --output=README.md \
+    README.md


### PR DESCRIPTION
`pre-commit` should be as lightweight as possible (people commit often and a lot). `pre-push` may be a bit more heavy so it contains all the checks ran by GitHub workflows.