### PR TITLE
Quick fix on loading screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -130,7 +130,7 @@ class LoadingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Loading();
+    return const Scaffold(body: Loading());
   }
 }
 


### PR DESCRIPTION
signin crashes the app when there's errors (eg. the input user doesn't exist in the database), the problem is scaffoldManager.showSnackBar in signin screen requires that a scaffold always exists