### PR TITLE
Channel invitation mock server updates

### DIFF
--- a/mm-mock-server/schema.graphql
+++ b/mm-mock-server/schema.graphql
@@ -162,6 +162,7 @@
     userId: ID!
     unseenMessages: [ChannelInboxItemMessage!]
     pendingInvitations: [ChannelInboxItemInvitation!]
+    invitations: [ChannelInboxItemInvitation!]
     updatedAt: DateTime
     updatedBy: ID
   }

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -22,7 +22,7 @@ export function mockMutations(serverState: MockServerState) {
             return channel;
         },
         createChannelInvitation: () => {
-            const invitation = generators.generateChannelInvitation([serverState.loggedInUser, serverState.otherUsers[1]])
+            const invitation = generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[1])
             serverState.channelInvitations.push(invitation);
             return invitation;
         },

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -18,11 +18,16 @@ export function mockQueries(serverState: MockServerState) {
                 generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]),
             ]
         },
-        findUsers: () => {
+        findChannelInvitationsForUser: () => {
             return [
-                serverState.loggedInUser,
-                serverState.otherUsers[0],
+                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, false),
+                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, true),
+                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, false),
+                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, true),
             ]
+        },
+        findUsers: () => {
+            return serverState.otherUsers.concat([serverState.loggedInUser]);
         },
         getAuthenticatedUser: () => {
             if (!serverState.loggedIn) {
@@ -39,16 +44,24 @@ export function mockQueries(serverState: MockServerState) {
         },
         myInbox: () => {
             var mockChannelId = faker.string.alphanumeric({length: 24});
+            var pendingInvitation = generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, false)
             return {
                 __typename: "UserInbox",
                 channels: {
                     __typename: "ChannelInbox",
+                    pendingInvitations: [
+                        pendingInvitation
+                    ],
+                    invitations: [
+                        generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, false),
+                        pendingInvitation
+                    ],
                     unseenMessages: [
                         generators.generateChannelInboxItemMessage(mockChannelId, serverState.loggedInUser),
                         generators.generateChannelInboxItemMessage(mockChannelId, serverState.otherUsers[0]),
                     ],
                 }
             }
-        }
+        },
     }
 }

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -18,14 +18,6 @@ export function mockQueries(serverState: MockServerState) {
                 generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]),
             ]
         },
-        findChannelInvitationsForUser: () => {
-            return [
-                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, false),
-                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, true),
-                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, false),
-                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, true),
-            ]
-        },
         findUsers: () => {
             return serverState.otherUsers.concat([serverState.loggedInUser]);
         },

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -104,12 +104,15 @@ export function generateUserLastUpdateTime() {
 }
 
 
-export function generateChannelInvitation(channelParticipants: any[], declined?: boolean, accepted?: boolean) {
+export function generateChannelInvitation(sender: any, recipient: any, declined?: boolean, accepted?: boolean) {
     var status: object | null;
+    var channel: object | null = null;
     if (declined || accepted) {
         var statusText: string;
-        if (accepted)
+        if (accepted) {
             statusText = "accepted";
+            channel = generateChannel([sender, recipient])
+        }
         else if (declined)
             statusText = "declined";
         else
@@ -125,15 +128,15 @@ export function generateChannelInvitation(channelParticipants: any[], declined?:
         __typename: "ChannelInvitation",
         id: faker.string.alphanumeric({length: 24}),
         channelName: faker.lorem.words(2),
-        channel: generateChannel(channelParticipants),
+        channel: channel,
         channelTopic: faker.lorem.sentence(),
         messageText: faker.lorem.sentence(),
-        createdBy: channelParticipants[0].id,
+        createdBy: sender.id,
         createdAt: faker.date.recent(),
-        recipientId: channelParticipants[0].id,
-        recipient: channelParticipants[0],
-        senderId: channelParticipants[1].id,
-        sender: channelParticipants[1],
+        recipientId: recipient.id,
+        recipient: recipient,
+        senderId: sender.id,
+        sender: sender,
         status: status,
     }
 }

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -105,25 +105,17 @@ export function generateUserLastUpdateTime() {
 
 
 export function generateChannelInvitation(sender: any, recipient: any, declined?: boolean, accepted?: boolean) {
-    var status: object | null;
+    var status: string;
     var channel: object | null = null;
-    if (declined || accepted) {
-        var statusText: string;
-        if (accepted) {
-            statusText = "accepted";
-            channel = generateChannel([sender, recipient])
-        }
-        else if (declined)
-            statusText = "declined";
-        else
-            statusText = "created";
-        status = {
-                __typename: "ChannelInvitationStatus",
-                status: statusText,
-            }
-    } else {
-        status = null;
+    if (accepted) {
+        status = "accepted";
+        channel = generateChannel([sender, recipient])
     }
+    else if (declined)
+        status = "declined";
+    else
+        status = "created";
+
     return {
         __typename: "ChannelInvitation",
         id: faker.string.alphanumeric({length: 24}),

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -23,12 +23,12 @@ export class MockServerState {
         ]
         this.channelInvitations = [
             // accepted invitation, channel exists
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[0]], false, true),
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[0], false, true),
             // pending invitation
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]]),
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[1]),
             // declined invitation
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[2]], true),
-            // TODO: accepted invitation, channel doesn't exist (a.k.a "match")
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[2], true),
+            // TODO: accepted invitation, message doesn't exist yet in channel (a.k.a "match")
             // generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]], false, true),
         ]
         this.channelMessages = [


### PR DESCRIPTION
Add findChannelInvitationsForUser.
Minor updates to state, myInbox, findUsers.

Goal is to get the API calls in for this iteration. 

For the invitations UI, we can use `findChannelInvitationsForUser` and `findUsers`.
The query for the invitations should return these fields:

```
senderId
recipientId
channelId
id
status
createdAt
```

The query for users should return these fields:
```
fullName
avatarUrl
```

The source for the text shown alongside the invitation, e.g. "CEO - Enron" is not yet defined. It might be the job title and the name of their company, which would require other updates to the mock server, but it's not clear yet.

---

For the overall Home page, we can use `getAuthenticatedUser` to get the user's first name and avatar URL.