### PR TITLE
Refactor GraphQL user queries and data models

### DIFF
--- a/lib/data/models/base/base_operation.dart
+++ b/lib/data/models/base/base_operation.dart
@@ -1,0 +1,8 @@
+abstract class BaseOperation {
+  String get operation;
+  String get gql;
+  Map<String, dynamic>? get variables;
+  BaseResult resultFromResponseData(Map<String, dynamic> data);
+}
+
+abstract class BaseResult {}

--- a/lib/data/models/base/base_provider.dart
+++ b/lib/data/models/base/base_provider.dart
@@ -11,9 +11,13 @@ import '../../../widgets/atoms/server_error.dart';
 abstract class BaseProvider extends ChangeNotifier {
   Widget runQuery<T extends BaseResult>({
     required BaseOperation operation,
-    required Widget Function(T? data, void Function()? refetch) onData,
+    required Widget Function(
+      T? data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
     Widget Function()? onLoading,
-    Widget Function(String error, void Function()? refetch)? onError,
+    Widget Function(String error, {void Function()? refetch})? onError,
   }) {
     const RetryOptions retryOptions = RetryOptions(
       maxAttempts: 2,
@@ -32,7 +36,10 @@ abstract class BaseProvider extends ChangeNotifier {
           if (isFailed) {
             final String error = result.exception.toString();
             if (onError != null) {
-              return onError(error, refetch != null ? () => refetch() : null);
+              return onError(
+                error,
+                refetch: refetch,
+              );
             }
             return ServerError(error: error);
           }
@@ -65,12 +72,13 @@ abstract class BaseProvider extends ChangeNotifier {
         }
 
         if (result.data == null) {
-          return onData(null, null);
+          return onData(null);
         }
 
         return onData(
           operation.resultFromResponseData(result.data!) as T,
-          refetch != null ? () => refetch() : null,
+          refetch: refetch,
+          fetchMore: fetchMore,
         );
       },
     );

--- a/lib/data/models/base/base_provider.dart
+++ b/lib/data/models/base/base_provider.dart
@@ -1,16 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mm_flutter_app/data/models/base/base_operation.dart';
+import 'package:mm_flutter_app/utilities/debug_logger.dart';
+import 'package:mm_flutter_app/utilities/errors/crash_handler.dart';
+import 'package:mm_flutter_app/utilities/errors/exceptions.dart';
+import 'package:retry/retry.dart';
 
 import '../../../widgets/atoms/server_error.dart';
 
 abstract class BaseProvider extends ChangeNotifier {
   Widget runQuery<T extends BaseResult>({
     required BaseOperation operation,
-    required Widget Function(T?) onData,
+    required Widget Function(T? data, void Function()? refetch) onData,
     Widget Function()? onLoading,
-    Widget Function(String)? onError,
+    Widget Function(String error, void Function()? refetch)? onError,
   }) {
+    const RetryOptions retryOptions = RetryOptions(
+      maxAttempts: 2,
+      delayFactor: Duration(milliseconds: 500),
+    );
+    bool isRetrying = false;
+    bool isFailed = false;
     return Query(
       options: QueryOptions(
         document: gql(operation.gql),
@@ -19,25 +29,60 @@ abstract class BaseProvider extends ChangeNotifier {
       ),
       builder: (result, {refetch, fetchMore}) {
         if (result.hasException) {
-          final String error = result.exception.toString();
-
-          if (onError != null) {
-            return onError(error);
+          if (isFailed) {
+            final String error = result.exception.toString();
+            if (onError != null) {
+              return onError(error, refetch != null ? () => refetch() : null);
+            }
+            return ServerError(error: error);
           }
-          return ServerError(error: error);
+          if (!isRetrying) {
+            isRetrying = true;
+            CrashHandler.logCrashReport(
+                'Exception while executing Query `${operation.operation}`:'
+                '\n${result.exception.toString()}\n'
+                'Retrying up to ${retryOptions.maxAttempts} additional times.');
+            WidgetsBinding.instance.addPostFrameCallback((_) async {
+              CrashHandler.retryOnException<void>(
+                () => _retryQuery(refetch!),
+                onFailOperation: () {
+                  isFailed = true;
+                  DebugLogger.warning(
+                      'Failed to complete Query `${operation.operation}`'
+                      ' after ${retryOptions.maxAttempts + 1} attempts.');
+                },
+                retryOptions: retryOptions,
+              );
+            });
+          }
         }
 
-        if (result.isLoading) {
+        if (result.isLoading || isRetrying) {
           if (onLoading != null) {
             return onLoading();
           }
           return const SizedBox(width: 0, height: 0);
         }
+
         if (result.data == null) {
-          return onData(null);
+          return onData(null, null);
         }
-        return onData(operation.resultFromResponseData(result.data!) as T);
+
+        return onData(
+          operation.resultFromResponseData(result.data!) as T,
+          refetch != null ? () => refetch() : null,
+        );
       },
     );
+  }
+
+  void _retryQuery(Future<QueryResult<Object?>?> Function() refetch) async {
+    QueryResult<Object?>? retryResult = await refetch();
+    if (retryResult == null || retryResult.hasException) {
+      throw RetryException(
+        message: retryResult!.exception.toString(),
+        originalException: retryResult.exception,
+      );
+    }
   }
 }

--- a/lib/data/models/base/base_provider.dart
+++ b/lib/data/models/base/base_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/data/models/base/base_operation.dart';
+
+import '../../../widgets/atoms/server_error.dart';
+
+abstract class BaseProvider extends ChangeNotifier {
+  Widget runQuery<T extends BaseResult>({
+    required BaseOperation operation,
+    required Widget Function(T?) onData,
+    Widget Function()? onLoading,
+    Widget Function(String)? onError,
+  }) {
+    return Query(
+      options: QueryOptions(
+        document: gql(operation.gql),
+        fetchPolicy: FetchPolicy.networkOnly,
+        variables: operation.variables ?? const {},
+      ),
+      builder: (result, {refetch, fetchMore}) {
+        if (result.hasException) {
+          final String error = result.exception.toString();
+
+          if (onError != null) {
+            return onError(error);
+          }
+          return ServerError(error: error);
+        }
+
+        if (result.isLoading) {
+          if (onLoading != null) {
+            return onLoading();
+          }
+          return const SizedBox(width: 0, height: 0);
+        }
+        if (result.data == null) {
+          return onData(null);
+        }
+        return onData(operation.resultFromResponseData(result.data!) as T);
+      },
+    );
+  }
+}

--- a/lib/data/models/user/queries/find_users.dart
+++ b/lib/data/models/user/queries/find_users.dart
@@ -1,0 +1,75 @@
+import 'package:mm_flutter_app/data/models/base/base_operation.dart';
+
+class FindUsers implements BaseOperation {
+  @override
+  String get operation => 'findUsers';
+
+  @override
+  String get gql => """
+  query Q(\$filter: UserListFilter) {
+    findUsers(filter: \$filter){
+      id
+      email
+      fullName
+      avatarUrl
+      userHandle
+    }
+  }
+""";
+
+  @override
+  Map<String, dynamic>? get variables => const {
+        "filter": {"searchText": ''}
+      };
+
+  @override
+  FindUsersResult resultFromResponseData(Map<String, dynamic> data) {
+    return FindUsersResult.fromJson(data[operation]);
+  }
+}
+
+class FindUsersResult extends BaseResult {
+  List<FindUsersResultElement> list;
+
+  FindUsersResult({required this.list});
+
+  FindUsersResult.fromJson(List jsonList)
+      : list = jsonList.map((e) => FindUsersResultElement.fromJson(e)).toList();
+
+  List<Map<String, dynamic>> toJson() {
+    return list.map((e) => e.toJson()).toList();
+  }
+}
+
+class FindUsersResultElement extends BaseResult {
+  String id;
+  String? email;
+  String? fullName;
+  String? avatarUrl;
+  String userHandle;
+
+  FindUsersResultElement({
+    required this.id,
+    this.email,
+    this.fullName,
+    this.avatarUrl,
+    required this.userHandle,
+  });
+
+  FindUsersResultElement.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        email = json['email'],
+        fullName = json['fullName'],
+        avatarUrl = json['avatarUrl'],
+        userHandle = json['userHandle'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'fullName': fullName,
+      'avatarUrl': avatarUrl,
+      'userHandle': userHandle,
+    };
+  }
+}

--- a/lib/data/models/user/queries/get_authenticated_user.dart
+++ b/lib/data/models/user/queries/get_authenticated_user.dart
@@ -1,0 +1,60 @@
+import 'package:mm_flutter_app/data/models/base/base_operation.dart';
+
+class GetAuthenticatedUser implements BaseOperation {
+  @override
+  String get operation => 'getAuthenticatedUser';
+
+  @override
+  String get gql => """
+  query Q {
+    getAuthenticatedUser {
+      id
+      email
+      fullName
+      avatarUrl
+      userHandle
+    }
+  }
+""";
+
+  @override
+  Map<String, dynamic>? get variables => null;
+
+  @override
+  GetAuthenticatedUserResult resultFromResponseData(Map<String, dynamic> data) {
+    return GetAuthenticatedUserResult.fromJson(data[operation]);
+  }
+}
+
+class GetAuthenticatedUserResult extends BaseResult {
+  String id;
+  String? email;
+  String? fullName;
+  String? avatarUrl;
+  String userHandle;
+
+  GetAuthenticatedUserResult({
+    required this.id,
+    this.email,
+    this.fullName,
+    this.avatarUrl,
+    required this.userHandle,
+  });
+
+  GetAuthenticatedUserResult.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        email = json['email'],
+        fullName = json['fullName'],
+        avatarUrl = json['avatarUrl'],
+        userHandle = json['userHandle'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'fullName': fullName,
+      'avatarUrl': avatarUrl,
+      'userHandle': userHandle,
+    };
+  }
+}

--- a/lib/data/models/user/queries/get_user_profile_info.dart
+++ b/lib/data/models/user/queries/get_user_profile_info.dart
@@ -1,0 +1,45 @@
+import 'package:mm_flutter_app/data/models/base/base_operation.dart';
+
+class GetUserProfileInfo implements BaseOperation {
+  @override
+  String get operation => 'getUserProfileInfo';
+
+  @override
+  String get gql => """
+  query Q {
+    getUserProfileInfo(){
+      profileCompletionPercentage
+      lastUpdateTime
+    }
+  }
+""";
+
+  @override
+  Map<String, dynamic>? get variables => null;
+
+  @override
+  GetUserProfileInfoResult resultFromResponseData(Map<String, dynamic> data) {
+    return GetUserProfileInfoResult.fromJson(data[operation]);
+  }
+}
+
+class GetUserProfileInfoResult extends BaseResult {
+  int profileCompletionPercentage;
+  DateTime lastUpdateTime;
+
+  GetUserProfileInfoResult({
+    required this.profileCompletionPercentage,
+    required this.lastUpdateTime,
+  });
+
+  GetUserProfileInfoResult.fromJson(Map<String, dynamic> json)
+      : profileCompletionPercentage = json['profileCompletionPercentage'],
+        lastUpdateTime = DateTime.parse(json['lastUpdateTime']);
+
+  Map<String, dynamic> toJson() {
+    return {
+      'profileCompletionPercentage': profileCompletionPercentage,
+      'lastUpdateTime': lastUpdateTime.toIso8601String(),
+    };
+  }
+}

--- a/lib/data/models/user/user_api.dart
+++ b/lib/data/models/user/user_api.dart
@@ -35,36 +35,3 @@ const String kUpdateUser = """
     updateUser(input: \$input)
   }
 """;
-
-const String kGetAuthenticatedUser = """
-  query Q {
-    getAuthenticatedUser {
-      id
-      email
-      fullName
-      avatarUrl
-      userHandle
-    }
-  }
-""";
-
-const String kGetAllUsers = """
-  query Q(\$filter: UserListFilter) {
-    findUsers(filter: \$filter){
-      id
-      email
-      fullName
-      avatarUrl
-      userHandle
-    }
-  }
-""";
-
-const String kGetUserProfileInfo = """
-  query Q {
-    getUserProfileInfo(){
-      profileCompletionPercentage
-      lastUpdateTime
-    }
-  }
-""";

--- a/lib/data/models/user/user_mock_provider.dart
+++ b/lib/data/models/user/user_mock_provider.dart
@@ -17,7 +17,7 @@ class UserMockProvider extends Mock implements UserProvider {
   // Query builders
   @override
   Widget queryUser({required onData, onLoading, onError}) {
-    return onData();
+    return onData(null);
   }
 
   // Query builders

--- a/lib/data/models/user/user_mock_provider.dart
+++ b/lib/data/models/user/user_mock_provider.dart
@@ -17,14 +17,17 @@ class UserMockProvider extends Mock implements UserProvider {
   // Query builders
   @override
   Widget queryUser({required onData, onLoading, onError}) {
-    return onData(null);
+    return onData(null, null);
   }
 
   // Query builders
   @override
   Widget queryAllUsers({required onData, onLoading, onError}) {
-    return onData(jsonDecode(
-        """[{"__typename": "User", "id": "640abd97587f51d992676942", "email": "raghav@gmail.com", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}, {"__typename": "User", "id": "640acf9055942518a6cdca38", "email": "shivam@gmail.com", "fullName": "shivam tyagi", "avatarUrl": "https://randomuser.me/api/portraits/med/men/78.jpg", "userHandle": "shivam"}, {"__typename": "User", "id": "640acfd255942518a6cdca3b", "email": "kunal@gmail.com", "fullName": "kunal kumar", "avatarUrl": "https://randomuser.me/api/portraits/med/men/75.jpg", "userHandle": "kunal0"}, {"__typename": "User", "id": "640ad02455942518a6cdca3e", "email": "ujjwal@gmail.com", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}]"""));
+    return onData(
+      jsonDecode(
+          """[{"__typename": "User", "id": "640abd97587f51d992676942", "email": "raghav@gmail.com", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}, {"__typename": "User", "id": "640acf9055942518a6cdca38", "email": "shivam@gmail.com", "fullName": "shivam tyagi", "avatarUrl": "https://randomuser.me/api/portraits/med/men/78.jpg", "userHandle": "shivam"}, {"__typename": "User", "id": "640acfd255942518a6cdca3b", "email": "kunal@gmail.com", "fullName": "kunal kumar", "avatarUrl": "https://randomuser.me/api/portraits/med/men/75.jpg", "userHandle": "kunal0"}, {"__typename": "User", "id": "640ad02455942518a6cdca3e", "email": "ujjwal@gmail.com", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}]"""),
+      null,
+    );
   }
 
   // Mutations

--- a/lib/data/models/user/user_mock_provider.dart
+++ b/lib/data/models/user/user_mock_provider.dart
@@ -17,17 +17,14 @@ class UserMockProvider extends Mock implements UserProvider {
   // Query builders
   @override
   Widget queryUser({required onData, onLoading, onError}) {
-    return onData(null, null);
+    return onData(null);
   }
 
   // Query builders
   @override
   Widget queryAllUsers({required onData, onLoading, onError}) {
-    return onData(
-      jsonDecode(
-          """[{"__typename": "User", "id": "640abd97587f51d992676942", "email": "raghav@gmail.com", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}, {"__typename": "User", "id": "640acf9055942518a6cdca38", "email": "shivam@gmail.com", "fullName": "shivam tyagi", "avatarUrl": "https://randomuser.me/api/portraits/med/men/78.jpg", "userHandle": "shivam"}, {"__typename": "User", "id": "640acfd255942518a6cdca3b", "email": "kunal@gmail.com", "fullName": "kunal kumar", "avatarUrl": "https://randomuser.me/api/portraits/med/men/75.jpg", "userHandle": "kunal0"}, {"__typename": "User", "id": "640ad02455942518a6cdca3e", "email": "ujjwal@gmail.com", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}]"""),
-      null,
-    );
+    return onData(jsonDecode(
+        """[{"__typename": "User", "id": "640abd97587f51d992676942", "email": "raghav@gmail.com", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}, {"__typename": "User", "id": "640acf9055942518a6cdca38", "email": "shivam@gmail.com", "fullName": "shivam tyagi", "avatarUrl": "https://randomuser.me/api/portraits/med/men/78.jpg", "userHandle": "shivam"}, {"__typename": "User", "id": "640acfd255942518a6cdca3b", "email": "kunal@gmail.com", "fullName": "kunal kumar", "avatarUrl": "https://randomuser.me/api/portraits/med/men/75.jpg", "userHandle": "kunal0"}, {"__typename": "User", "id": "640ad02455942518a6cdca3e", "email": "ujjwal@gmail.com", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}]"""));
   }
 
   // Mutations

--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -47,20 +47,22 @@ class UserProvider extends BaseProvider {
 
   Widget queryUser({
     required Widget Function(
-            GetAuthenticatedUserResult? data, void Function()? refetch)
-        onData,
+      GetAuthenticatedUserResult? data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
     Widget Function()? onLoading,
-    Widget Function(String error, void Function()? refetch)? onError,
+    Widget Function(String error, {void Function()? refetch})? onError,
   }) {
     return runQuery<GetAuthenticatedUserResult>(
       operation: GetAuthenticatedUser(),
-      onData: (data, refetch) {
+      onData: (data, {refetch, fetchMore}) {
         if (data != null) {
           _setUser(data.toJson());
         } else {
           _resetUser();
         }
-        return onData(data, refetch);
+        return onData(data, refetch: refetch, fetchMore: fetchMore);
       },
       onLoading: onLoading,
       onError: onError,
@@ -68,10 +70,13 @@ class UserProvider extends BaseProvider {
   }
 
   Widget queryAllUsers({
-    required Widget Function(FindUsersResult? data, void Function()? refetch)
-        onData,
+    required Widget Function(
+      FindUsersResult? data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
     Widget Function()? onLoading,
-    Widget Function(String error, void Function()? refetch)? onError,
+    Widget Function(String error, {void Function()? refetch})? onError,
   }) {
     return runQuery<FindUsersResult>(
       operation: FindUsers(),
@@ -83,10 +88,12 @@ class UserProvider extends BaseProvider {
 
   Widget queryUserProfileInfo({
     required Widget Function(
-            GetUserProfileInfoResult? data, void Function()? refetch)
-        onData,
+      GetUserProfileInfoResult? data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
     Widget Function()? onLoading,
-    Widget Function(String error, void Function()? refetch)? onError,
+    Widget Function(String error, {void Function()? refetch})? onError,
   }) {
     return runQuery<GetUserProfileInfoResult>(
       operation: GetUserProfileInfo(),

--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -1,22 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/data/models/base/base_provider.dart';
+import 'package:mm_flutter_app/data/models/user/queries/find_users.dart';
+import 'package:mm_flutter_app/data/models/user/queries/get_authenticated_user.dart';
+import 'package:mm_flutter_app/data/models/user/queries/get_user_profile_info.dart';
 import 'package:mm_flutter_app/data/models/user/user.dart';
 import 'package:mm_flutter_app/data/models/user/user_api.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
-import '../../../widgets/atoms/server_error.dart';
-
-class UserProvider extends ChangeNotifier {
+class UserProvider extends BaseProvider {
   GraphQLClient client;
 
   User? _user;
 
   UserProvider({required this.client});
 
-  void _setUser(QueryResult result) {
-    if (result.data != null && _user == null) {
-      _user = User.fromJson(result.data!['getAuthenticatedUser']);
+  void _setUser(Map<String, dynamic>? data) {
+    if (data != null && _user == null) {
+      _user = User.fromJson(data);
       debugPrint('Got this user from the server userId: ${_user!.id}');
     }
   }
@@ -43,95 +45,49 @@ class UserProvider extends ChangeNotifier {
     return _user;
   }
 
-  // Query builders
-  Widget queryUser({required onData, onLoading, onError}) {
-    return Query(
-      options: QueryOptions(
-        document: gql(kGetAuthenticatedUser),
-      ),
-      builder: (result, {refetch, fetchMore}) {
-        if (result.hasException) {
-          final error = result.exception.toString();
-
-          if (onError != null) {
-            return onError(error);
-          }
-          return ServerError(error: error);
-        }
-
-        if (result.isLoading) {
-          if (onLoading != null) {
-            return onLoading();
-          }
-          return const SizedBox.shrink();
-        }
-
-        if (result.data != null) {
-          _setUser(result);
+  Widget queryUser({
+    required Widget Function(GetAuthenticatedUserResult?) onData,
+    Widget Function()? onLoading,
+    Widget Function(String)? onError,
+  }) {
+    return runQuery<GetAuthenticatedUserResult>(
+      operation: GetAuthenticatedUser(),
+      onData: (GetAuthenticatedUserResult? data) {
+        if (data != null) {
+          _setUser(data.toJson());
         } else {
           _resetUser();
         }
-
-        return onData(result.data!['getAuthenticatedUser']);
+        return onData(data);
       },
+      onLoading: onLoading,
+      onError: onError,
     );
   }
 
-  // Query builders
-  Widget queryAllUsers({required onData, onLoading, onError}) {
-    return Query(
-      options: QueryOptions(
-        document: gql(kGetAllUsers),
-        fetchPolicy: FetchPolicy.networkOnly,
-        variables: const {
-          "filter": {"searchText": ''}
-        },
-      ),
-      builder: (result, {refetch, fetchMore}) {
-        if (result.hasException) {
-          final error = result.exception.toString();
-
-          if (onError != null) {
-            return onError(error);
-          }
-          return ServerError(error: error);
-        }
-
-        if (result.isLoading) {
-          if (onLoading != null) {
-            return onLoading();
-          }
-          return const SizedBox.shrink();
-        }
-        return onData(result.data!['findUsers']);
-      },
+  Widget queryAllUsers({
+    required Widget Function(FindUsersResult?) onData,
+    Widget Function()? onLoading,
+    Widget Function(String)? onError,
+  }) {
+    return runQuery<FindUsersResult>(
+      operation: FindUsers(),
+      onData: onData,
+      onLoading: onLoading,
+      onError: onError,
     );
   }
 
-  Widget queryUserProfileInfo({required onData, onLoading, onError}) {
-    return Query(
-      options: QueryOptions(
-        document: gql(kGetUserProfileInfo),
-        fetchPolicy: FetchPolicy.networkOnly,
-      ),
-      builder: (result, {refetch, fetchMore}) {
-        if (result.hasException) {
-          final error = result.exception.toString();
-
-          if (onError != null) {
-            return onError(error);
-          }
-          return ServerError(error: error);
-        }
-
-        if (result.isLoading) {
-          if (onLoading != null) {
-            return onLoading();
-          }
-          return const SizedBox.shrink();
-        }
-        return onData(result.data!['getUserProfileInfo']);
-      },
+  Widget queryUserProfileInfo({
+    required Widget Function(GetUserProfileInfoResult?) onData,
+    Widget Function()? onLoading,
+    Widget Function(String)? onError,
+  }) {
+    return runQuery<GetUserProfileInfoResult>(
+      operation: GetUserProfileInfo(),
+      onData: onData,
+      onLoading: onLoading,
+      onError: onError,
     );
   }
 

--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -46,19 +46,21 @@ class UserProvider extends BaseProvider {
   }
 
   Widget queryUser({
-    required Widget Function(GetAuthenticatedUserResult?) onData,
+    required Widget Function(
+            GetAuthenticatedUserResult? data, void Function()? refetch)
+        onData,
     Widget Function()? onLoading,
-    Widget Function(String)? onError,
+    Widget Function(String error, void Function()? refetch)? onError,
   }) {
     return runQuery<GetAuthenticatedUserResult>(
       operation: GetAuthenticatedUser(),
-      onData: (GetAuthenticatedUserResult? data) {
+      onData: (data, refetch) {
         if (data != null) {
           _setUser(data.toJson());
         } else {
           _resetUser();
         }
-        return onData(data);
+        return onData(data, refetch);
       },
       onLoading: onLoading,
       onError: onError,
@@ -66,9 +68,10 @@ class UserProvider extends BaseProvider {
   }
 
   Widget queryAllUsers({
-    required Widget Function(FindUsersResult?) onData,
+    required Widget Function(FindUsersResult? data, void Function()? refetch)
+        onData,
     Widget Function()? onLoading,
-    Widget Function(String)? onError,
+    Widget Function(String error, void Function()? refetch)? onError,
   }) {
     return runQuery<FindUsersResult>(
       operation: FindUsers(),
@@ -79,9 +82,11 @@ class UserProvider extends BaseProvider {
   }
 
   Widget queryUserProfileInfo({
-    required Widget Function(GetUserProfileInfoResult?) onData,
+    required Widget Function(
+            GetUserProfileInfoResult? data, void Function()? refetch)
+        onData,
     Widget Function()? onLoading,
-    Widget Function(String)? onError,
+    Widget Function(String error, void Function()? refetch)? onError,
   }) {
     return runQuery<GetUserProfileInfoResult>(
       operation: GetUserProfileInfo(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,10 +115,10 @@ class StartScreen extends StatelessWidget {
       onLoading: () {
         return const LoadingScreen();
       },
-      onError: (error, refetch) {
+      onError: (error, {refetch}) {
         return const SignInScreen();
       },
-      onData: (data, refetch) {
+      onData: (data, {refetch, fetchMore}) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           context.go('/home');
         });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -115,10 +115,10 @@ class StartScreen extends StatelessWidget {
       onLoading: () {
         return const LoadingScreen();
       },
-      onError: (error) {
+      onError: (error, refetch) {
         return const SignInScreen();
       },
-      onData: (data) {
+      onData: (data, refetch) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           context.go('/home');
         });

--- a/lib/utilities/errors/crash_handler.dart
+++ b/lib/utilities/errors/crash_handler.dart
@@ -35,12 +35,11 @@ class CrashHandler {
 
   static FutureOr<T> retryOnException<T>(
     FutureOr<T> Function() operation, {
-    int maxAttempts = 4,
     FutureOr<T> Function()? onFailOperation,
+    RetryOptions retryOptions = const RetryOptions(
+      maxAttempts: 4,
+    ),
   }) async {
-    final RetryOptions retryOptions = RetryOptions(
-      maxAttempts: maxAttempts,
-    );
     try {
       return await retryOptions.retry<T>(
         operation,

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-import 'package:mm_flutter_app/data/models/user/queries/get_user_profile_info.dart';
 import 'package:provider/provider.dart';
 
 import '../../data/models/user/user_provider.dart';
@@ -87,10 +86,10 @@ class MaybeReminderBanner extends StatelessWidget {
 
     return userProvider.queryUserProfileInfo(onLoading: () {
       return const SizedBox(width: 0.0, height: 0.0);
-    }, onError: (error) {
+    }, onError: (error, refetch) {
       debugPrint(error);
       return const SizedBox(width: 0.0, height: 0.0);
-    }, onData: (GetUserProfileInfoResult? data) {
+    }, onData: (data, refetch) {
       int profileCompletionPercentage = data!.profileCompletionPercentage;
       DateTime lastUpdateTime = data.lastUpdateTime;
       if (profileCompletionPercentage < 50) {

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -86,10 +86,10 @@ class MaybeReminderBanner extends StatelessWidget {
 
     return userProvider.queryUserProfileInfo(onLoading: () {
       return const SizedBox(width: 0.0, height: 0.0);
-    }, onError: (error, refetch) {
+    }, onError: (error, {refetch}) {
       debugPrint(error);
       return const SizedBox(width: 0.0, height: 0.0);
-    }, onData: (data, refetch) {
+    }, onData: (data, {refetch, fetchMore}) {
       int profileCompletionPercentage = data!.profileCompletionPercentage;
       DateTime lastUpdateTime = data.lastUpdateTime;
       if (profileCompletionPercentage < 50) {

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/data/models/user/queries/get_user_profile_info.dart';
 import 'package:provider/provider.dart';
 
 import '../../data/models/user/user_provider.dart';
@@ -89,9 +90,9 @@ class MaybeReminderBanner extends StatelessWidget {
     }, onError: (error) {
       debugPrint(error);
       return const SizedBox(width: 0.0, height: 0.0);
-    }, onData: (data) {
-      int profileCompletionPercentage = data['profileCompletionPercentage'];
-      DateTime lastUpdateTime = DateTime.parse(data['lastUpdateTime']);
+    }, onData: (GetUserProfileInfoResult? data) {
+      int profileCompletionPercentage = data!.profileCompletionPercentage;
+      DateTime lastUpdateTime = data.lastUpdateTime;
       if (profileCompletionPercentage < 50) {
         return ReminderBanner(
           titleText: l10n

--- a/lib/widgets/organisms/user_card.dart
+++ b/lib/widgets/organisms/user_card.dart
@@ -15,7 +15,8 @@ Widget userCard(users, index) {
                 child: ClipOval(
                   child: FadeInImage(
                       fit: BoxFit.cover,
-                      image: NetworkImage(users[index].avatarUrl),
+                      image: NetworkImage(users[index].avatarUrl ??
+                          'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png'),
                       placeholder: const NetworkImage(
                           'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png')),
                 )),

--- a/lib/widgets/screens/home/users_list.dart
+++ b/lib/widgets/screens/home/users_list.dart
@@ -1,6 +1,5 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/data/models/user/queries/find_users.dart';
 import 'package:provider/provider.dart';
 
 import '../../../data/models/channels/channel.dart';
@@ -95,10 +94,10 @@ class UsersList extends StatelessWidget {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error) {
+      onError: (error, refetch) {
         return Text('Error: $error');
       },
-      onData: (FindUsersResult? data) {
+      onData: (data, refetch) {
         List users = data!.list.reversed
             .where((element) => element.id != currentUser?.id)
             .toList();

--- a/lib/widgets/screens/home/users_list.dart
+++ b/lib/widgets/screens/home/users_list.dart
@@ -94,10 +94,10 @@ class UsersList extends StatelessWidget {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error, refetch) {
+      onError: (error, {refetch}) {
         return Text('Error: $error');
       },
-      onData: (data, refetch) {
+      onData: (data, {refetch, fetchMore}) {
         List users = data!.list.reversed
             .where((element) => element.id != currentUser?.id)
             .toList();

--- a/lib/widgets/screens/home/users_list.dart
+++ b/lib/widgets/screens/home/users_list.dart
@@ -1,10 +1,10 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/data/models/user/queries/find_users.dart';
 import 'package:provider/provider.dart';
 
 import '../../../data/models/channels/channel.dart';
 import '../../../data/models/channels/channels_provider.dart';
-import '../../../data/models/user/user.dart';
 import '../../../data/models/user/user_provider.dart';
 import '../../organisms/user_card.dart';
 import '../../organisms/user_expanded_card.dart';
@@ -98,11 +98,10 @@ class UsersList extends StatelessWidget {
       onError: (error) {
         return Text('Error: $error');
       },
-      onData: (data) {
-        List users = data.reversed
-            .where((item) => item['id'] != currentUser?.id)
+      onData: (FindUsersResult? data) {
+        List users = data!.list.reversed
+            .where((element) => element.id != currentUser?.id)
             .toList();
-        users = users.map((item) => User.fromJson(item)).toList();
         users = users
             .where((element) =>
                 element.fullName.toLowerCase().contains(search.toLowerCase()))

--- a/lib/widgets/screens/profile/profile_screen.dart
+++ b/lib/widgets/screens/profile/profile_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/data/models/user/queries/get_authenticated_user.dart';
 import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import 'package:mm_flutter_app/widgets/screens/profile/your_name.dart';
 import 'package:provider/provider.dart';
@@ -33,10 +32,10 @@ class UserProfile extends StatelessWidget {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error) {
+      onError: (error, refetch) {
         return Text('Error: $error');
       },
-      onData: (GetAuthenticatedUserResult? data) {
+      onData: (data, refetch) {
         return Profile(
           userFullName: data?.fullName,
           userAvatarUrl: data?.avatarUrl,

--- a/lib/widgets/screens/profile/profile_screen.dart
+++ b/lib/widgets/screens/profile/profile_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/data/models/user/user.dart';
+import 'package:mm_flutter_app/data/models/user/queries/get_authenticated_user.dart';
 import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import 'package:mm_flutter_app/widgets/screens/profile/your_name.dart';
 import 'package:provider/provider.dart';
@@ -36,17 +36,21 @@ class UserProfile extends StatelessWidget {
       onError: (error) {
         return Text('Error: $error');
       },
-      onData: (data) {
-        User user = User.fromJson(data);
-        return Profile(user: user);
+      onData: (GetAuthenticatedUserResult? data) {
+        return Profile(
+          userFullName: data?.fullName,
+          userAvatarUrl: data?.avatarUrl,
+        );
       },
     );
   }
 }
 
 class Profile extends StatelessWidget {
-  const Profile({Key? key, required this.user}) : super(key: key);
-  final User user;
+  const Profile({Key? key, this.userFullName, this.userAvatarUrl})
+      : super(key: key);
+  final String? userFullName;
+  final String? userAvatarUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +61,7 @@ class Profile extends StatelessWidget {
           children: [
             ListTile(
               title: Text(
-                user.fullName,
+                userFullName!,
                 style: const TextStyle(
                     color: Colors.black,
                     fontWeight: FontWeight.bold,
@@ -76,7 +80,7 @@ class Profile extends StatelessWidget {
                 child: ClipOval(
                   child: FadeInImage(
                     fit: BoxFit.fill,
-                    image: NetworkImage(user.avatarUrl ?? placeholderImage,
+                    image: NetworkImage(userAvatarUrl ?? placeholderImage,
                         scale: 2.75),
                     placeholder: NetworkImage(placeholderImage),
                   ),

--- a/lib/widgets/screens/profile/profile_screen.dart
+++ b/lib/widgets/screens/profile/profile_screen.dart
@@ -32,10 +32,10 @@ class UserProfile extends StatelessWidget {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error, refetch) {
+      onError: (error, {refetch}) {
         return Text('Error: $error');
       },
-      onData: (data, refetch) {
+      onData: (data, {refetch, fetchMore}) {
         return Profile(
           userFullName: data?.fullName,
           userAvatarUrl: data?.avatarUrl,

--- a/lib/widgets/screens/profile/your_email.dart
+++ b/lib/widgets/screens/profile/your_email.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/data/models/user/queries/get_authenticated_user.dart';
 import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -46,10 +45,10 @@ class _YourEmailState extends State<YourEmail> {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error) {
+      onError: (error, refetch) {
         return Text('Error: $error');
       },
-      onData: (GetAuthenticatedUserResult? data) {
+      onData: (data, refetch) {
         return Scaffold(
           appBar: AppBar(
             title: const Text('Your email'),

--- a/lib/widgets/screens/profile/your_email.dart
+++ b/lib/widgets/screens/profile/your_email.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/data/models/user/queries/get_authenticated_user.dart';
+import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import 'package:provider/provider.dart';
 
-import 'package:mm_flutter_app/data/models/user/user.dart';
-import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import '../../atoms/text_form_field_widget.dart';
 
 class EmailScreen extends StatelessWidget {
@@ -49,8 +49,7 @@ class _YourEmailState extends State<YourEmail> {
       onError: (error) {
         return Text('Error: $error');
       },
-      onData: (data) {
-        User user = User.fromJson(data);
+      onData: (GetAuthenticatedUserResult? data) {
         return Scaffold(
           appBar: AppBar(
             title: const Text('Your email'),
@@ -65,7 +64,7 @@ class _YourEmailState extends State<YourEmail> {
                     label: 'Email',
                     validator: (value) {
                       if (value!.isEmpty) {
-                        emailController.text = user.email!;
+                        emailController.text = data!.email!;
                         return '''Email can't be empty''';
                       }
                       return null;

--- a/lib/widgets/screens/profile/your_email.dart
+++ b/lib/widgets/screens/profile/your_email.dart
@@ -45,10 +45,10 @@ class _YourEmailState extends State<YourEmail> {
       onLoading: () {
         return const SizedBox.shrink();
       },
-      onError: (error, refetch) {
+      onError: (error, {refetch}) {
         return Text('Error: $error');
       },
-      onData: (data, refetch) {
+      onData: (data, {refetch, fetchMore}) {
         return Scaffold(
           appBar: AppBar(
             title: const Text('Your email'),


### PR DESCRIPTION
The purpose of this PR is to introduce some useful OOP design patterns, strong typing, and structure into the existing GraphQL query operations for _User_. The remaining models and operations will be later refactored in the same manner if this PR is accepted.

The big motivation behind this PR is the gotcha of using GraphQL, which is that queries can return any number of fields, and so a single model class (e.g. UserModel) cannot accurately represent the response received from the server. Some queries will populate some fields of the UserModel, some will populate others, but very rarely you will have an instance with all of the fields available. Meaning that all fields of the model must be nullable, and that caller must be extremely careful to access only the fields that contain data.

Having each query return a very specific result object with only the fields that they need removes this problem. It also makes the providers easier to use since the caller only has access to what they need, instead of having to manage a JSON object and extracting fields directly.

### Key changes

- **BaseProvider** abstract class that is extended by other provider classes. It contains a runQuery function that takes a BaseOperation as input, and returns a BaseResult as output.
- **BaseOperation** abstract class that represent a single GraphQL query. It contains the logic to convert a GQL json response into the corresponding BaseResult object.
- **BaseResult** abstract class that represents the response of a GQL query. Contains only the exact fields that the query can return, with proper typing and nullable fields.
- **Automatic query retries** while remaining on the 'Loading' state. Once the maximum number of attempts is reached the state changes to 'Error'.
- **Refetch** function callback is exposed to the caller to facilitate manually retrying (or refreshing) from the onData callback, without triggering the operation all over again.
- **FetchMore** function callback is exposed to callers to facilitate pagination of data. This might be revisited later to add more abstraction.

### Next steps (if this is approved)

- Implement a similar structure for Mutations
- Implement for all data models and operations
- Explore ways to make better use of the ChangeNotifiers, perhaps by breaking them up into smaller pieces and leveraging the notify function

