### PR TITLE
Mock server profile, getAuthenticatedUser, and graphql schema updates

### DIFF
--- a/lib/__generated/schema/operations.graphql.dart
+++ b/lib/__generated/schema/operations.graphql.dart
@@ -194,6 +194,20 @@ const documentNodeQueryGetAuthenticatedUser = DocumentNode(definitions: [
             selectionSet: null,
           ),
           FieldNode(
+            name: NameNode(value: 'profileCompletionPercentage'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'updatedAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
             name: NameNode(value: '__typename'),
             alias: null,
             arguments: [],
@@ -220,6 +234,8 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     this.fullName,
     this.avatarUrl,
     this.userHandle,
+    required this.profileCompletionPercentage,
+    this.updatedAt,
     this.$__typename = 'User',
   });
 
@@ -230,6 +246,8 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     final l$fullName = json['fullName'];
     final l$avatarUrl = json['avatarUrl'];
     final l$userHandle = json['userHandle'];
+    final l$profileCompletionPercentage = json['profileCompletionPercentage'];
+    final l$updatedAt = json['updatedAt'];
     final l$$__typename = json['__typename'];
     return Query$GetAuthenticatedUser$getAuthenticatedUser(
       id: (l$id as String),
@@ -237,6 +255,9 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
       fullName: (l$fullName as String?),
       avatarUrl: (l$avatarUrl as String?),
       userHandle: (l$userHandle as String?),
+      profileCompletionPercentage: (l$profileCompletionPercentage as int),
+      updatedAt:
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
       $__typename: (l$$__typename as String),
     );
   }
@@ -250,6 +271,10 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
   final String? avatarUrl;
 
   final String? userHandle;
+
+  final int profileCompletionPercentage;
+
+  final DateTime? updatedAt;
 
   final String $__typename;
 
@@ -265,6 +290,10 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     _resultData['avatarUrl'] = l$avatarUrl;
     final l$userHandle = userHandle;
     _resultData['userHandle'] = l$userHandle;
+    final l$profileCompletionPercentage = profileCompletionPercentage;
+    _resultData['profileCompletionPercentage'] = l$profileCompletionPercentage;
+    final l$updatedAt = updatedAt;
+    _resultData['updatedAt'] = l$updatedAt?.toIso8601String();
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -277,6 +306,8 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     final l$fullName = fullName;
     final l$avatarUrl = avatarUrl;
     final l$userHandle = userHandle;
+    final l$profileCompletionPercentage = profileCompletionPercentage;
+    final l$updatedAt = updatedAt;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$id,
@@ -284,6 +315,8 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
       l$fullName,
       l$avatarUrl,
       l$userHandle,
+      l$profileCompletionPercentage,
+      l$updatedAt,
       l$$__typename,
     ]);
   }
@@ -322,6 +355,17 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     if (l$userHandle != lOther$userHandle) {
       return false;
     }
+    final l$profileCompletionPercentage = profileCompletionPercentage;
+    final lOther$profileCompletionPercentage =
+        other.profileCompletionPercentage;
+    if (l$profileCompletionPercentage != lOther$profileCompletionPercentage) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
     if (l$$__typename != lOther$$__typename) {
@@ -357,6 +401,8 @@ abstract class CopyWith$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes> {
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    int? profileCompletionPercentage,
+    DateTime? updatedAt,
     String? $__typename,
   });
 }
@@ -380,6 +426,8 @@ class _CopyWithImpl$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes>
     Object? fullName = _undefined,
     Object? avatarUrl = _undefined,
     Object? userHandle = _undefined,
+    Object? profileCompletionPercentage = _undefined,
+    Object? updatedAt = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$GetAuthenticatedUser$getAuthenticatedUser(
@@ -393,6 +441,14 @@ class _CopyWithImpl$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes>
         userHandle: userHandle == _undefined
             ? _instance.userHandle
             : (userHandle as String?),
+        profileCompletionPercentage:
+            profileCompletionPercentage == _undefined ||
+                    profileCompletionPercentage == null
+                ? _instance.profileCompletionPercentage
+                : (profileCompletionPercentage as int),
+        updatedAt: updatedAt == _undefined
+            ? _instance.updatedAt
+            : (updatedAt as DateTime?),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
@@ -411,342 +467,8 @@ class _CopyWithStubImpl$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes>
     String? fullName,
     String? avatarUrl,
     String? userHandle,
-    String? $__typename,
-  }) =>
-      _res;
-}
-
-class Query$GetUserProfileInfo {
-  Query$GetUserProfileInfo({
-    required this.getUserProfileInfo,
-    this.$__typename = 'Query',
-  });
-
-  factory Query$GetUserProfileInfo.fromJson(Map<String, dynamic> json) {
-    final l$getUserProfileInfo = json['getUserProfileInfo'];
-    final l$$__typename = json['__typename'];
-    return Query$GetUserProfileInfo(
-      getUserProfileInfo: Query$GetUserProfileInfo$getUserProfileInfo.fromJson(
-          (l$getUserProfileInfo as Map<String, dynamic>)),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final Query$GetUserProfileInfo$getUserProfileInfo getUserProfileInfo;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$getUserProfileInfo = getUserProfileInfo;
-    _resultData['getUserProfileInfo'] = l$getUserProfileInfo.toJson();
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$getUserProfileInfo = getUserProfileInfo;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$getUserProfileInfo,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Query$GetUserProfileInfo) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$getUserProfileInfo = getUserProfileInfo;
-    final lOther$getUserProfileInfo = other.getUserProfileInfo;
-    if (l$getUserProfileInfo != lOther$getUserProfileInfo) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$GetUserProfileInfo
-    on Query$GetUserProfileInfo {
-  CopyWith$Query$GetUserProfileInfo<Query$GetUserProfileInfo> get copyWith =>
-      CopyWith$Query$GetUserProfileInfo(
-        this,
-        (i) => i,
-      );
-}
-
-abstract class CopyWith$Query$GetUserProfileInfo<TRes> {
-  factory CopyWith$Query$GetUserProfileInfo(
-    Query$GetUserProfileInfo instance,
-    TRes Function(Query$GetUserProfileInfo) then,
-  ) = _CopyWithImpl$Query$GetUserProfileInfo;
-
-  factory CopyWith$Query$GetUserProfileInfo.stub(TRes res) =
-      _CopyWithStubImpl$Query$GetUserProfileInfo;
-
-  TRes call({
-    Query$GetUserProfileInfo$getUserProfileInfo? getUserProfileInfo,
-    String? $__typename,
-  });
-  CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
-      get getUserProfileInfo;
-}
-
-class _CopyWithImpl$Query$GetUserProfileInfo<TRes>
-    implements CopyWith$Query$GetUserProfileInfo<TRes> {
-  _CopyWithImpl$Query$GetUserProfileInfo(
-    this._instance,
-    this._then,
-  );
-
-  final Query$GetUserProfileInfo _instance;
-
-  final TRes Function(Query$GetUserProfileInfo) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? getUserProfileInfo = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(Query$GetUserProfileInfo(
-        getUserProfileInfo:
-            getUserProfileInfo == _undefined || getUserProfileInfo == null
-                ? _instance.getUserProfileInfo
-                : (getUserProfileInfo
-                    as Query$GetUserProfileInfo$getUserProfileInfo),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-  CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
-      get getUserProfileInfo {
-    final local$getUserProfileInfo = _instance.getUserProfileInfo;
-    return CopyWith$Query$GetUserProfileInfo$getUserProfileInfo(
-        local$getUserProfileInfo, (e) => call(getUserProfileInfo: e));
-  }
-}
-
-class _CopyWithStubImpl$Query$GetUserProfileInfo<TRes>
-    implements CopyWith$Query$GetUserProfileInfo<TRes> {
-  _CopyWithStubImpl$Query$GetUserProfileInfo(this._res);
-
-  TRes _res;
-
-  call({
-    Query$GetUserProfileInfo$getUserProfileInfo? getUserProfileInfo,
-    String? $__typename,
-  }) =>
-      _res;
-  CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
-      get getUserProfileInfo =>
-          CopyWith$Query$GetUserProfileInfo$getUserProfileInfo.stub(_res);
-}
-
-const documentNodeQueryGetUserProfileInfo = DocumentNode(definitions: [
-  OperationDefinitionNode(
-    type: OperationType.query,
-    name: NameNode(value: 'GetUserProfileInfo'),
-    variableDefinitions: [],
-    directives: [],
-    selectionSet: SelectionSetNode(selections: [
-      FieldNode(
-        name: NameNode(value: 'getUserProfileInfo'),
-        alias: null,
-        arguments: [],
-        directives: [],
-        selectionSet: SelectionSetNode(selections: [
-          FieldNode(
-            name: NameNode(value: 'profileCompletionPercentage'),
-            alias: null,
-            arguments: [],
-            directives: [],
-            selectionSet: null,
-          ),
-          FieldNode(
-            name: NameNode(value: 'lastUpdateTime'),
-            alias: null,
-            arguments: [],
-            directives: [],
-            selectionSet: null,
-          ),
-          FieldNode(
-            name: NameNode(value: '__typename'),
-            alias: null,
-            arguments: [],
-            directives: [],
-            selectionSet: null,
-          ),
-        ]),
-      ),
-      FieldNode(
-        name: NameNode(value: '__typename'),
-        alias: null,
-        arguments: [],
-        directives: [],
-        selectionSet: null,
-      ),
-    ]),
-  ),
-]);
-
-class Query$GetUserProfileInfo$getUserProfileInfo {
-  Query$GetUserProfileInfo$getUserProfileInfo({
-    this.profileCompletionPercentage,
-    this.lastUpdateTime,
-    this.$__typename = 'User',
-  });
-
-  factory Query$GetUserProfileInfo$getUserProfileInfo.fromJson(
-      Map<String, dynamic> json) {
-    final l$profileCompletionPercentage = json['profileCompletionPercentage'];
-    final l$lastUpdateTime = json['lastUpdateTime'];
-    final l$$__typename = json['__typename'];
-    return Query$GetUserProfileInfo$getUserProfileInfo(
-      profileCompletionPercentage: (l$profileCompletionPercentage as int?),
-      lastUpdateTime: l$lastUpdateTime == null
-          ? null
-          : DateTime.parse((l$lastUpdateTime as String)),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final int? profileCompletionPercentage;
-
-  final DateTime? lastUpdateTime;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$profileCompletionPercentage = profileCompletionPercentage;
-    _resultData['profileCompletionPercentage'] = l$profileCompletionPercentage;
-    final l$lastUpdateTime = lastUpdateTime;
-    _resultData['lastUpdateTime'] = l$lastUpdateTime?.toIso8601String();
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$profileCompletionPercentage = profileCompletionPercentage;
-    final l$lastUpdateTime = lastUpdateTime;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$profileCompletionPercentage,
-      l$lastUpdateTime,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Query$GetUserProfileInfo$getUserProfileInfo) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$profileCompletionPercentage = profileCompletionPercentage;
-    final lOther$profileCompletionPercentage =
-        other.profileCompletionPercentage;
-    if (l$profileCompletionPercentage != lOther$profileCompletionPercentage) {
-      return false;
-    }
-    final l$lastUpdateTime = lastUpdateTime;
-    final lOther$lastUpdateTime = other.lastUpdateTime;
-    if (l$lastUpdateTime != lOther$lastUpdateTime) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$GetUserProfileInfo$getUserProfileInfo
-    on Query$GetUserProfileInfo$getUserProfileInfo {
-  CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<
-          Query$GetUserProfileInfo$getUserProfileInfo>
-      get copyWith => CopyWith$Query$GetUserProfileInfo$getUserProfileInfo(
-            this,
-            (i) => i,
-          );
-}
-
-abstract class CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes> {
-  factory CopyWith$Query$GetUserProfileInfo$getUserProfileInfo(
-    Query$GetUserProfileInfo$getUserProfileInfo instance,
-    TRes Function(Query$GetUserProfileInfo$getUserProfileInfo) then,
-  ) = _CopyWithImpl$Query$GetUserProfileInfo$getUserProfileInfo;
-
-  factory CopyWith$Query$GetUserProfileInfo$getUserProfileInfo.stub(TRes res) =
-      _CopyWithStubImpl$Query$GetUserProfileInfo$getUserProfileInfo;
-
-  TRes call({
     int? profileCompletionPercentage,
-    DateTime? lastUpdateTime,
-    String? $__typename,
-  });
-}
-
-class _CopyWithImpl$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
-    implements CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes> {
-  _CopyWithImpl$Query$GetUserProfileInfo$getUserProfileInfo(
-    this._instance,
-    this._then,
-  );
-
-  final Query$GetUserProfileInfo$getUserProfileInfo _instance;
-
-  final TRes Function(Query$GetUserProfileInfo$getUserProfileInfo) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? profileCompletionPercentage = _undefined,
-    Object? lastUpdateTime = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(Query$GetUserProfileInfo$getUserProfileInfo(
-        profileCompletionPercentage: profileCompletionPercentage == _undefined
-            ? _instance.profileCompletionPercentage
-            : (profileCompletionPercentage as int?),
-        lastUpdateTime: lastUpdateTime == _undefined
-            ? _instance.lastUpdateTime
-            : (lastUpdateTime as DateTime?),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-}
-
-class _CopyWithStubImpl$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
-    implements CopyWith$Query$GetUserProfileInfo$getUserProfileInfo<TRes> {
-  _CopyWithStubImpl$Query$GetUserProfileInfo$getUserProfileInfo(this._res);
-
-  TRes _res;
-
-  call({
-    int? profileCompletionPercentage,
-    DateTime? lastUpdateTime,
+    DateTime? updatedAt,
     String? $__typename,
   }) =>
       _res;

--- a/lib/data/models/user/user.dart
+++ b/lib/data/models/user/user.dart
@@ -1,6 +1,8 @@
 class User {
   final String id;
   String? userHandle, fullName, avatarUrl, email, adminNotes;
+  int? profileCompletionPercentage;
+  DateTime? updatedAt;
 
   User(
       {required this.id,
@@ -8,7 +10,9 @@ class User {
       this.fullName,
       this.avatarUrl,
       this.email,
-      this.adminNotes});
+      this.adminNotes,
+      this.profileCompletionPercentage,
+      this.updatedAt});
 
   // this a named constructor to build a class from Json
   // used to extract the class from a graphQL response for example
@@ -19,7 +23,9 @@ class User {
         avatarUrl = json['avatarUrl'] ??
             'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png',
         email = json['email'] ?? '',
-        adminNotes = json['adminNotes'] ?? '';
+        adminNotes = json['adminNotes'] ?? '',
+        profileCompletionPercentage = json['profileCompletionPercentage'],
+        updatedAt = json['updatedAt'];
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -28,5 +34,7 @@ class User {
         'avatarUrl': avatarUrl,
         'email': email,
         'adminNotes': adminNotes,
+        'profileCompletionPercentage': profileCompletionPercentage,
+        'updatedAt': updatedAt,
       };
 }

--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -154,36 +154,6 @@ class UserProvider extends BaseProvider {
     );
   }
 
-  Widget queryUserProfileInfo({
-    required Widget Function(
-      OperationResult<Query$GetUserProfileInfo$getUserProfileInfo> data, {
-      void Function()? refetch,
-      void Function(FetchMoreOptions)? fetchMore,
-    }) onData,
-    Widget Function()? onLoading,
-    Widget Function(String error, {void Function()? refetch})? onError,
-  }) {
-    return runQuery(
-      document: documentNodeQueryGetUserProfileInfo,
-      onData: (queryResult, {refetch, fetchMore}) {
-        return onData(
-          OperationResult(
-            gqlQueryResult: queryResult,
-            response: queryResult.data != null
-                ? Query$GetUserProfileInfo.fromJson(
-                    queryResult.data!,
-                  ).getUserProfileInfo
-                : null,
-          ),
-          refetch: refetch,
-          fetchMore: fetchMore,
-        );
-      },
-      onLoading: onLoading,
-      onError: onError,
-    );
-  }
-
   // Mutations
   Future<OperationResult<Mutation$SignUpUser$signUpUser>> signUpUser(
       Input$UserSignUpInput input) async {

--- a/lib/schema/operations.graphql
+++ b/lib/schema/operations.graphql
@@ -5,13 +5,8 @@ query GetAuthenticatedUser {
         fullName
         avatarUrl
         userHandle
-    }
-}
-
-query GetUserProfileInfo {
-    getUserProfileInfo(){
         profileCompletionPercentage
-        lastUpdateTime
+        updatedAt
     }
 }
 

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -119,7 +119,6 @@ type Query {
   findUsers(options: FindObjectsOptions, match: UserInput, filter: UserListFilter): [User!]!
   getAvailableUserHandleField(startValue: String!): User!
   getAuthenticatedUser: User!
-  getUserProfileInfo: User!
   findUserDeviceById(id: String!): UserDevice!
   findUserDevices(options: FindObjectsOptions, match: UserDeviceInput, filter: SidUserDeviceListFilter): [UserDevice!]!
   findChannelInvitationById(id: String!): ChannelInvitation!
@@ -277,7 +276,6 @@ type User {
   yearsOwnershipExperience: Int
   ssoIdp: String
   profileCompletionPercentage: Int
-  lastUpdateTime: DateTime
 
   """This attribute is only used by the MM2 synchronizer."""
   mm2Id: String

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -84,15 +84,15 @@ class MaybeReminderBanner extends StatelessWidget {
     final userProvider = Provider.of<UserProvider>(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    return userProvider.queryUserProfileInfo(onLoading: () {
+    return userProvider.queryUser(onLoading: () {
       return const SizedBox(width: 0.0, height: 0.0);
     }, onError: (error, {refetch}) {
       debugPrint(error);
       return const SizedBox(width: 0.0, height: 0.0);
     }, onData: (data, {refetch, fetchMore}) {
       int profileCompletionPercentage =
-          data.response!.profileCompletionPercentage!;
-      DateTime lastUpdateTime = data.response!.lastUpdateTime!;
+          data.response!.profileCompletionPercentage;
+      DateTime updatedAt = data.response!.updatedAt!;
       if (profileCompletionPercentage < 50) {
         return ReminderBanner(
           titleText: l10n
@@ -100,7 +100,7 @@ class MaybeReminderBanner extends StatelessWidget {
           subtitleText: l10n.reminderBannerProfileCompleteSubtitle,
           ctaText: l10n.reminderBannerProfileCompleteCta,
         );
-      } else if (DateTime.now().difference(lastUpdateTime).inDays > 30 * 6) {
+      } else if (DateTime.now().difference(updatedAt).inDays > 30 * 6) {
         return ReminderBanner(
             titleText: l10n.reminderBannerProfileUpdateTitle,
             subtitleText: l10n.reminderBannerProfileUpdateSubtitle,

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -22,7 +22,7 @@ export function mockMutations(serverState: MockServerState) {
             return channel;
         },
         createChannelInvitation: () => {
-            const invitation = generators.generateChannelInvitation([serverState.loggedInUser, serverState.otherUsers[1]])
+            const invitation = generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[1])
             serverState.channelInvitations.push(invitation);
             return invitation;
         },

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -27,13 +27,6 @@ export function mockQueries(serverState: MockServerState) {
             }
             return serverState.loggedInUser;
         },
-        getUserProfileInfo: () => {
-            return {
-                __typename: "User",
-                profileCompletionPercentage: serverState.loggedInUser.profileCompletionPercentage,
-                lastUpdateTime: serverState.loggedInUser.lastUpdateTime,
-            };
-        },
         myInbox: () => {
             var mockChannelId = faker.string.alphanumeric({length: 24});
             var mockInvitations = [

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -18,14 +18,16 @@ export function mockQueries(serverState: MockServerState) {
                 generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]),
             ]
         },
-        findUsers: () => {
+        findChannelInvitationsForUser: () => {
             return [
-                serverState.loggedInUser,
-                serverState.otherUsers[0],
-                serverState.otherUsers[1],
-                serverState.otherUsers[2],
-                serverState.otherUsers[3],
+                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, false),
+                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, true),
+                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, false),
+                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, true),
             ]
+        },
+        findUsers: () => {
+            return serverState.otherUsers.concat([serverState.loggedInUser]);
         },
         getAuthenticatedUser: () => {
             if (!serverState.loggedIn) {
@@ -63,6 +65,6 @@ export function mockQueries(serverState: MockServerState) {
                     ],
                 }
             }
-        }
+        },
     }
 }

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -18,14 +18,6 @@ export function mockQueries(serverState: MockServerState) {
                 generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]),
             ]
         },
-        findChannelInvitationsForUser: () => {
-            return [
-                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, false),
-                generators.generateChannelInvitation(serverState.loggedInUser, serverState.otherUsers[0], false, true),
-                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, false),
-                generators.generateChannelInvitation(serverState.otherUsers[0], serverState.loggedInUser, false, true),
-            ]
-        },
         findUsers: () => {
             return serverState.otherUsers.concat([serverState.loggedInUser]);
         },

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -7,7 +7,6 @@ export function generateUser() {
     var mockUserHandle = mockFirstName.toLowerCase().charAt(0) + mockLastName.toLowerCase();
     var mockEmail = `${mockUserHandle}@${faker.internet.domainName()}`;
     var mockProfileCompletionPercentage = generateUserProfileCompletionPercentage();
-    var mockLastUpdateTime = faker.date.past(); 
     return {
         __typename: "User",
         id: faker.string.alphanumeric({length: 24}),
@@ -19,7 +18,7 @@ export function generateUser() {
         avatarUrl: faker.image.urlPicsumPhotos(),
         jobTitle: faker.person.jobTitle(),
         profileCompletionPercentage: mockProfileCompletionPercentage,
-        lastUpdateTime: mockLastUpdateTime,
+        updatedAt: faker.date.recent(),
     }
 }
 
@@ -54,7 +53,7 @@ export function generateChannel(channelParticipants: any[]) {
                 __typename: "ChannelParticipant",
                 user: channelParticipants[1],
             },
-        ]
+        ],
     }
 }
 
@@ -121,13 +120,6 @@ export function generateUserProfileCompletionPercentage() {
     // Returns a random integer between 0 and 100
     return  Math.floor(Math.random() * 100); 
 }
-
-
-export function generateUserLastUpdateTime() {
-    // Returns a random date time from one year before to now
-    return faker.date.past(); 
-}
-
 
 export function generateChannelInvitation(sender: any, recipient: any, declined?: boolean, accepted?: boolean) {
     var status: string;

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -129,12 +129,15 @@ export function generateUserLastUpdateTime() {
 }
 
 
-export function generateChannelInvitation(channelParticipants: any[], declined?: boolean, accepted?: boolean) {
+export function generateChannelInvitation(sender: any, recipient: any, declined?: boolean, accepted?: boolean) {
     var status: object | null;
+    var channel: object | null = null;
     if (declined || accepted) {
         var statusText: string;
-        if (accepted)
+        if (accepted) {
             statusText = "accepted";
+            channel = generateChannel([sender, recipient])
+        }
         else if (declined)
             statusText = "declined";
         else
@@ -150,15 +153,15 @@ export function generateChannelInvitation(channelParticipants: any[], declined?:
         __typename: "ChannelInvitation",
         id: faker.string.alphanumeric({length: 24}),
         channelName: faker.lorem.words(2),
-        channel: generateChannel(channelParticipants),
+        channel: channel,
         channelTopic: faker.lorem.sentence(),
         messageText: faker.lorem.sentence(),
-        createdBy: channelParticipants[0].id,
+        createdBy: sender.id,
         createdAt: faker.date.recent(),
-        recipientId: channelParticipants[0].id,
-        recipient: channelParticipants[0],
-        senderId: channelParticipants[1].id,
-        sender: channelParticipants[1],
+        recipientId: recipient.id,
+        recipient: recipient,
+        senderId: sender.id,
+        sender: sender,
         status: status,
     }
 }

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -130,25 +130,17 @@ export function generateUserLastUpdateTime() {
 
 
 export function generateChannelInvitation(sender: any, recipient: any, declined?: boolean, accepted?: boolean) {
-    var status: object | null;
+    var status: string;
     var channel: object | null = null;
-    if (declined || accepted) {
-        var statusText: string;
-        if (accepted) {
-            statusText = "accepted";
-            channel = generateChannel([sender, recipient])
-        }
-        else if (declined)
-            statusText = "declined";
-        else
-            statusText = "created";
-        status = {
-                __typename: "ChannelInvitationStatus",
-                status: statusText,
-            }
-    } else {
-        status = null;
+    if (accepted) {
+        status = "accepted";
+        channel = generateChannel([sender, recipient])
     }
+    else if (declined)
+        status = "declined";
+    else
+        status = "created";
+
     return {
         __typename: "ChannelInvitation",
         id: faker.string.alphanumeric({length: 24}),

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -23,12 +23,12 @@ export class MockServerState {
         ]
         this.channelInvitations = [
             // accepted invitation, channel exists
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[0]], false, true),
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[0], false, true),
             // pending invitation
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]]),
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[1]),
             // declined invitation
-            generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[2]], true),
-            // TODO: accepted invitation, channel doesn't exist (a.k.a "match")
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[2], true),
+            // TODO: accepted invitation, message doesn't exist yet in channel (a.k.a "match")
             // generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]], false, true),
         ]
         this.channelMessages = [


### PR DESCRIPTION
This PR introduces 4 minor changes:
1. Move profile completion logic to the User in the mock backend
2. ~~Don't return `null` for `getAuthenticatedUser` when the user is logged out. Do we want the mock backend to throw an error in this case in order to match the mmdata backend functionality? See [this trello task](https://trello.com/c/KeSnySPu/49-servererror-when-launching-app-without-being-logged-in) for more context.~~ no longer needed
3. Bulk updates to graphql schema, copied in directly from the Apollo Server ui.
4. ~~In the `myInbox` query, return channel messages with a channelId stored in `channels` in the `state.ts` file. I don't know if this is really necessary.~~ this was implemented in #46