### PR TITLE
Skip invalid entries

### DIFF
--- a/lib/data/models/user/queries/find_users.dart
+++ b/lib/data/models/user/queries/find_users.dart
@@ -34,7 +34,20 @@ class FindUsersResult extends BaseResult {
   FindUsersResult({required this.list});
 
   FindUsersResult.fromJson(List jsonList)
-      : list = jsonList.map((e) => FindUsersResultElement.fromJson(e)).toList();
+      : list = jsonList
+            .map((e) {
+              try {
+                var el = FindUsersResultElement.fromJson(e);
+                if (el.avatarUrl == "") {
+                  el.avatarUrl = null;
+                }
+                return el;
+              } catch (e) {
+                return null;
+              }
+            })
+            .nonNulls
+            .toList();
 
   List<Map<String, dynamic>> toJson() {
     return list.map((e) => e.toJson()).toList();


### PR DESCRIPTION
`queryAllUsers` may return corrupted data such as a user without a `userHandle` or `avatarUrl == "" (!= null)`. It breaks the app.

This PR is not a solution to this problem but rather a temporary fix. We should think what to do in such situations.