### PR TITLE
Implement dashboard Invitations section with backend data

### DIFF
--- a/lib/__generated/schema/operations.graphql.dart
+++ b/lib/__generated/schema/operations.graphql.dart
@@ -752,15 +752,15 @@ class _CopyWithStubImpl$Query$GetUserProfileInfo$getUserProfileInfo<TRes>
       _res;
 }
 
-class Variables$Query$FindUsers {
-  factory Variables$Query$FindUsers({Input$UserListFilter? filter}) =>
-      Variables$Query$FindUsers._({
+class Variables$Query$FindAllUsers {
+  factory Variables$Query$FindAllUsers({Input$UserListFilter? filter}) =>
+      Variables$Query$FindAllUsers._({
         if (filter != null) r'filter': filter,
       });
 
-  Variables$Query$FindUsers._(this._$data);
+  Variables$Query$FindAllUsers._(this._$data);
 
-  factory Variables$Query$FindUsers.fromJson(Map<String, dynamic> data) {
+  factory Variables$Query$FindAllUsers.fromJson(Map<String, dynamic> data) {
     final result$data = <String, dynamic>{};
     if (data.containsKey('filter')) {
       final l$filter = data['filter'];
@@ -768,7 +768,7 @@ class Variables$Query$FindUsers {
           ? null
           : Input$UserListFilter.fromJson((l$filter as Map<String, dynamic>));
     }
-    return Variables$Query$FindUsers._(result$data);
+    return Variables$Query$FindAllUsers._(result$data);
   }
 
   Map<String, dynamic> _$data;
@@ -784,17 +784,17 @@ class Variables$Query$FindUsers {
     return result$data;
   }
 
-  CopyWith$Variables$Query$FindUsers<Variables$Query$FindUsers> get copyWith =>
-      CopyWith$Variables$Query$FindUsers(
-        this,
-        (i) => i,
-      );
+  CopyWith$Variables$Query$FindAllUsers<Variables$Query$FindAllUsers>
+      get copyWith => CopyWith$Variables$Query$FindAllUsers(
+            this,
+            (i) => i,
+          );
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }
-    if (!(other is Variables$Query$FindUsers) ||
+    if (!(other is Variables$Query$FindAllUsers) ||
         runtimeType != other.runtimeType) {
       return false;
     }
@@ -816,66 +816,66 @@ class Variables$Query$FindUsers {
   }
 }
 
-abstract class CopyWith$Variables$Query$FindUsers<TRes> {
-  factory CopyWith$Variables$Query$FindUsers(
-    Variables$Query$FindUsers instance,
-    TRes Function(Variables$Query$FindUsers) then,
-  ) = _CopyWithImpl$Variables$Query$FindUsers;
+abstract class CopyWith$Variables$Query$FindAllUsers<TRes> {
+  factory CopyWith$Variables$Query$FindAllUsers(
+    Variables$Query$FindAllUsers instance,
+    TRes Function(Variables$Query$FindAllUsers) then,
+  ) = _CopyWithImpl$Variables$Query$FindAllUsers;
 
-  factory CopyWith$Variables$Query$FindUsers.stub(TRes res) =
-      _CopyWithStubImpl$Variables$Query$FindUsers;
+  factory CopyWith$Variables$Query$FindAllUsers.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindAllUsers;
 
   TRes call({Input$UserListFilter? filter});
 }
 
-class _CopyWithImpl$Variables$Query$FindUsers<TRes>
-    implements CopyWith$Variables$Query$FindUsers<TRes> {
-  _CopyWithImpl$Variables$Query$FindUsers(
+class _CopyWithImpl$Variables$Query$FindAllUsers<TRes>
+    implements CopyWith$Variables$Query$FindAllUsers<TRes> {
+  _CopyWithImpl$Variables$Query$FindAllUsers(
     this._instance,
     this._then,
   );
 
-  final Variables$Query$FindUsers _instance;
+  final Variables$Query$FindAllUsers _instance;
 
-  final TRes Function(Variables$Query$FindUsers) _then;
+  final TRes Function(Variables$Query$FindAllUsers) _then;
 
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({Object? filter = _undefined}) =>
-      _then(Variables$Query$FindUsers._({
+      _then(Variables$Query$FindAllUsers._({
         ..._instance._$data,
         if (filter != _undefined) 'filter': (filter as Input$UserListFilter?),
       }));
 }
 
-class _CopyWithStubImpl$Variables$Query$FindUsers<TRes>
-    implements CopyWith$Variables$Query$FindUsers<TRes> {
-  _CopyWithStubImpl$Variables$Query$FindUsers(this._res);
+class _CopyWithStubImpl$Variables$Query$FindAllUsers<TRes>
+    implements CopyWith$Variables$Query$FindAllUsers<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindAllUsers(this._res);
 
   TRes _res;
 
   call({Input$UserListFilter? filter}) => _res;
 }
 
-class Query$FindUsers {
-  Query$FindUsers({
+class Query$FindAllUsers {
+  Query$FindAllUsers({
     required this.findUsers,
     this.$__typename = 'Query',
   });
 
-  factory Query$FindUsers.fromJson(Map<String, dynamic> json) {
+  factory Query$FindAllUsers.fromJson(Map<String, dynamic> json) {
     final l$findUsers = json['findUsers'];
     final l$$__typename = json['__typename'];
-    return Query$FindUsers(
+    return Query$FindAllUsers(
       findUsers: (l$findUsers as List<dynamic>)
-          .map((e) =>
-              Query$FindUsers$findUsers.fromJson((e as Map<String, dynamic>)))
+          .map((e) => Query$FindAllUsers$findUsers.fromJson(
+              (e as Map<String, dynamic>)))
           .toList(),
       $__typename: (l$$__typename as String),
     );
   }
 
-  final List<Query$FindUsers$findUsers> findUsers;
+  final List<Query$FindAllUsers$findUsers> findUsers;
 
   final String $__typename;
 
@@ -903,7 +903,7 @@ class Query$FindUsers {
     if (identical(this, other)) {
       return true;
     }
-    if (!(other is Query$FindUsers) || runtimeType != other.runtimeType) {
+    if (!(other is Query$FindAllUsers) || runtimeType != other.runtimeType) {
       return false;
     }
     final l$findUsers = findUsers;
@@ -927,45 +927,45 @@ class Query$FindUsers {
   }
 }
 
-extension UtilityExtension$Query$FindUsers on Query$FindUsers {
-  CopyWith$Query$FindUsers<Query$FindUsers> get copyWith =>
-      CopyWith$Query$FindUsers(
+extension UtilityExtension$Query$FindAllUsers on Query$FindAllUsers {
+  CopyWith$Query$FindAllUsers<Query$FindAllUsers> get copyWith =>
+      CopyWith$Query$FindAllUsers(
         this,
         (i) => i,
       );
 }
 
-abstract class CopyWith$Query$FindUsers<TRes> {
-  factory CopyWith$Query$FindUsers(
-    Query$FindUsers instance,
-    TRes Function(Query$FindUsers) then,
-  ) = _CopyWithImpl$Query$FindUsers;
+abstract class CopyWith$Query$FindAllUsers<TRes> {
+  factory CopyWith$Query$FindAllUsers(
+    Query$FindAllUsers instance,
+    TRes Function(Query$FindAllUsers) then,
+  ) = _CopyWithImpl$Query$FindAllUsers;
 
-  factory CopyWith$Query$FindUsers.stub(TRes res) =
-      _CopyWithStubImpl$Query$FindUsers;
+  factory CopyWith$Query$FindAllUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllUsers;
 
   TRes call({
-    List<Query$FindUsers$findUsers>? findUsers,
+    List<Query$FindAllUsers$findUsers>? findUsers,
     String? $__typename,
   });
   TRes findUsers(
-      Iterable<Query$FindUsers$findUsers> Function(
+      Iterable<Query$FindAllUsers$findUsers> Function(
               Iterable<
-                  CopyWith$Query$FindUsers$findUsers<
-                      Query$FindUsers$findUsers>>)
+                  CopyWith$Query$FindAllUsers$findUsers<
+                      Query$FindAllUsers$findUsers>>)
           _fn);
 }
 
-class _CopyWithImpl$Query$FindUsers<TRes>
-    implements CopyWith$Query$FindUsers<TRes> {
-  _CopyWithImpl$Query$FindUsers(
+class _CopyWithImpl$Query$FindAllUsers<TRes>
+    implements CopyWith$Query$FindAllUsers<TRes> {
+  _CopyWithImpl$Query$FindAllUsers(
     this._instance,
     this._then,
   );
 
-  final Query$FindUsers _instance;
+  final Query$FindAllUsers _instance;
 
-  final TRes Function(Query$FindUsers) _then;
+  final TRes Function(Query$FindAllUsers) _then;
 
   static const _undefined = <dynamic, dynamic>{};
 
@@ -973,46 +973,46 @@ class _CopyWithImpl$Query$FindUsers<TRes>
     Object? findUsers = _undefined,
     Object? $__typename = _undefined,
   }) =>
-      _then(Query$FindUsers(
+      _then(Query$FindAllUsers(
         findUsers: findUsers == _undefined || findUsers == null
             ? _instance.findUsers
-            : (findUsers as List<Query$FindUsers$findUsers>),
+            : (findUsers as List<Query$FindAllUsers$findUsers>),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
       ));
   TRes findUsers(
-          Iterable<Query$FindUsers$findUsers> Function(
+          Iterable<Query$FindAllUsers$findUsers> Function(
                   Iterable<
-                      CopyWith$Query$FindUsers$findUsers<
-                          Query$FindUsers$findUsers>>)
+                      CopyWith$Query$FindAllUsers$findUsers<
+                          Query$FindAllUsers$findUsers>>)
               _fn) =>
       call(
-          findUsers: _fn(
-              _instance.findUsers.map((e) => CopyWith$Query$FindUsers$findUsers(
+          findUsers: _fn(_instance.findUsers
+              .map((e) => CopyWith$Query$FindAllUsers$findUsers(
                     e,
                     (i) => i,
                   ))).toList());
 }
 
-class _CopyWithStubImpl$Query$FindUsers<TRes>
-    implements CopyWith$Query$FindUsers<TRes> {
-  _CopyWithStubImpl$Query$FindUsers(this._res);
+class _CopyWithStubImpl$Query$FindAllUsers<TRes>
+    implements CopyWith$Query$FindAllUsers<TRes> {
+  _CopyWithStubImpl$Query$FindAllUsers(this._res);
 
   TRes _res;
 
   call({
-    List<Query$FindUsers$findUsers>? findUsers,
+    List<Query$FindAllUsers$findUsers>? findUsers,
     String? $__typename,
   }) =>
       _res;
   findUsers(_fn) => _res;
 }
 
-const documentNodeQueryFindUsers = DocumentNode(definitions: [
+const documentNodeQueryFindAllUsers = DocumentNode(definitions: [
   OperationDefinitionNode(
     type: OperationType.query,
-    name: NameNode(value: 'FindUsers'),
+    name: NameNode(value: 'FindAllUsers'),
     variableDefinitions: [
       VariableDefinitionNode(
         variable: VariableNode(name: NameNode(value: 'filter')),
@@ -1092,8 +1092,8 @@ const documentNodeQueryFindUsers = DocumentNode(definitions: [
   ),
 ]);
 
-class Query$FindUsers$findUsers {
-  Query$FindUsers$findUsers({
+class Query$FindAllUsers$findUsers {
+  Query$FindAllUsers$findUsers({
     required this.id,
     this.email,
     this.fullName,
@@ -1102,14 +1102,14 @@ class Query$FindUsers$findUsers {
     this.$__typename = 'User',
   });
 
-  factory Query$FindUsers$findUsers.fromJson(Map<String, dynamic> json) {
+  factory Query$FindAllUsers$findUsers.fromJson(Map<String, dynamic> json) {
     final l$id = json['id'];
     final l$email = json['email'];
     final l$fullName = json['fullName'];
     final l$avatarUrl = json['avatarUrl'];
     final l$userHandle = json['userHandle'];
     final l$$__typename = json['__typename'];
-    return Query$FindUsers$findUsers(
+    return Query$FindAllUsers$findUsers(
       id: (l$id as String),
       email: (l$email as String?),
       fullName: (l$fullName as String?),
@@ -1171,7 +1171,7 @@ class Query$FindUsers$findUsers {
     if (identical(this, other)) {
       return true;
     }
-    if (!(other is Query$FindUsers$findUsers) ||
+    if (!(other is Query$FindAllUsers$findUsers) ||
         runtimeType != other.runtimeType) {
       return false;
     }
@@ -1209,23 +1209,23 @@ class Query$FindUsers$findUsers {
   }
 }
 
-extension UtilityExtension$Query$FindUsers$findUsers
-    on Query$FindUsers$findUsers {
-  CopyWith$Query$FindUsers$findUsers<Query$FindUsers$findUsers> get copyWith =>
-      CopyWith$Query$FindUsers$findUsers(
-        this,
-        (i) => i,
-      );
+extension UtilityExtension$Query$FindAllUsers$findUsers
+    on Query$FindAllUsers$findUsers {
+  CopyWith$Query$FindAllUsers$findUsers<Query$FindAllUsers$findUsers>
+      get copyWith => CopyWith$Query$FindAllUsers$findUsers(
+            this,
+            (i) => i,
+          );
 }
 
-abstract class CopyWith$Query$FindUsers$findUsers<TRes> {
-  factory CopyWith$Query$FindUsers$findUsers(
-    Query$FindUsers$findUsers instance,
-    TRes Function(Query$FindUsers$findUsers) then,
-  ) = _CopyWithImpl$Query$FindUsers$findUsers;
+abstract class CopyWith$Query$FindAllUsers$findUsers<TRes> {
+  factory CopyWith$Query$FindAllUsers$findUsers(
+    Query$FindAllUsers$findUsers instance,
+    TRes Function(Query$FindAllUsers$findUsers) then,
+  ) = _CopyWithImpl$Query$FindAllUsers$findUsers;
 
-  factory CopyWith$Query$FindUsers$findUsers.stub(TRes res) =
-      _CopyWithStubImpl$Query$FindUsers$findUsers;
+  factory CopyWith$Query$FindAllUsers$findUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllUsers$findUsers;
 
   TRes call({
     String? id,
@@ -1237,16 +1237,16 @@ abstract class CopyWith$Query$FindUsers$findUsers<TRes> {
   });
 }
 
-class _CopyWithImpl$Query$FindUsers$findUsers<TRes>
-    implements CopyWith$Query$FindUsers$findUsers<TRes> {
-  _CopyWithImpl$Query$FindUsers$findUsers(
+class _CopyWithImpl$Query$FindAllUsers$findUsers<TRes>
+    implements CopyWith$Query$FindAllUsers$findUsers<TRes> {
+  _CopyWithImpl$Query$FindAllUsers$findUsers(
     this._instance,
     this._then,
   );
 
-  final Query$FindUsers$findUsers _instance;
+  final Query$FindAllUsers$findUsers _instance;
 
-  final TRes Function(Query$FindUsers$findUsers) _then;
+  final TRes Function(Query$FindAllUsers$findUsers) _then;
 
   static const _undefined = <dynamic, dynamic>{};
 
@@ -1258,7 +1258,7 @@ class _CopyWithImpl$Query$FindUsers$findUsers<TRes>
     Object? userHandle = _undefined,
     Object? $__typename = _undefined,
   }) =>
-      _then(Query$FindUsers$findUsers(
+      _then(Query$FindAllUsers$findUsers(
         id: id == _undefined || id == null ? _instance.id : (id as String),
         email: email == _undefined ? _instance.email : (email as String?),
         fullName:
@@ -1275,9 +1275,9 @@ class _CopyWithImpl$Query$FindUsers$findUsers<TRes>
       ));
 }
 
-class _CopyWithStubImpl$Query$FindUsers$findUsers<TRes>
-    implements CopyWith$Query$FindUsers$findUsers<TRes> {
-  _CopyWithStubImpl$Query$FindUsers$findUsers(this._res);
+class _CopyWithStubImpl$Query$FindAllUsers$findUsers<TRes>
+    implements CopyWith$Query$FindAllUsers$findUsers<TRes> {
+  _CopyWithStubImpl$Query$FindAllUsers$findUsers(this._res);
 
   TRes _res;
 
@@ -1287,6 +1287,1711 @@ class _CopyWithStubImpl$Query$FindUsers$findUsers<TRes>
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindUsersWithFilter {
+  factory Variables$Query$FindUsersWithFilter({Input$UserListFilter? filter}) =>
+      Variables$Query$FindUsersWithFilter._({
+        if (filter != null) r'filter': filter,
+      });
+
+  Variables$Query$FindUsersWithFilter._(this._$data);
+
+  factory Variables$Query$FindUsersWithFilter.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('filter')) {
+      final l$filter = data['filter'];
+      result$data['filter'] = l$filter == null
+          ? null
+          : Input$UserListFilter.fromJson((l$filter as Map<String, dynamic>));
+    }
+    return Variables$Query$FindUsersWithFilter._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Input$UserListFilter? get filter =>
+      (_$data['filter'] as Input$UserListFilter?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('filter')) {
+      final l$filter = filter;
+      result$data['filter'] = l$filter?.toJson();
+    }
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindUsersWithFilter<
+          Variables$Query$FindUsersWithFilter>
+      get copyWith => CopyWith$Variables$Query$FindUsersWithFilter(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindUsersWithFilter) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$filter = filter;
+    final lOther$filter = other.filter;
+    if (_$data.containsKey('filter') != other._$data.containsKey('filter')) {
+      return false;
+    }
+    if (l$filter != lOther$filter) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$filter = filter;
+    return Object.hashAll([_$data.containsKey('filter') ? l$filter : const {}]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindUsersWithFilter<TRes> {
+  factory CopyWith$Variables$Query$FindUsersWithFilter(
+    Variables$Query$FindUsersWithFilter instance,
+    TRes Function(Variables$Query$FindUsersWithFilter) then,
+  ) = _CopyWithImpl$Variables$Query$FindUsersWithFilter;
+
+  factory CopyWith$Variables$Query$FindUsersWithFilter.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindUsersWithFilter;
+
+  TRes call({Input$UserListFilter? filter});
+}
+
+class _CopyWithImpl$Variables$Query$FindUsersWithFilter<TRes>
+    implements CopyWith$Variables$Query$FindUsersWithFilter<TRes> {
+  _CopyWithImpl$Variables$Query$FindUsersWithFilter(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindUsersWithFilter _instance;
+
+  final TRes Function(Variables$Query$FindUsersWithFilter) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? filter = _undefined}) =>
+      _then(Variables$Query$FindUsersWithFilter._({
+        ..._instance._$data,
+        if (filter != _undefined) 'filter': (filter as Input$UserListFilter?),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindUsersWithFilter<TRes>
+    implements CopyWith$Variables$Query$FindUsersWithFilter<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindUsersWithFilter(this._res);
+
+  TRes _res;
+
+  call({Input$UserListFilter? filter}) => _res;
+}
+
+class Query$FindUsersWithFilter {
+  Query$FindUsersWithFilter({
+    required this.findUsers,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindUsersWithFilter.fromJson(Map<String, dynamic> json) {
+    final l$findUsers = json['findUsers'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUsersWithFilter(
+      findUsers: (l$findUsers as List<dynamic>)
+          .map((e) => Query$FindUsersWithFilter$findUsers.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindUsersWithFilter$findUsers> findUsers;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUsers = findUsers;
+    _resultData['findUsers'] = l$findUsers.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUsers = findUsers;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findUsers.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUsersWithFilter) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUsers = findUsers;
+    final lOther$findUsers = other.findUsers;
+    if (l$findUsers.length != lOther$findUsers.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findUsers.length; i++) {
+      final l$findUsers$entry = l$findUsers[i];
+      final lOther$findUsers$entry = lOther$findUsers[i];
+      if (l$findUsers$entry != lOther$findUsers$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUsersWithFilter
+    on Query$FindUsersWithFilter {
+  CopyWith$Query$FindUsersWithFilter<Query$FindUsersWithFilter> get copyWith =>
+      CopyWith$Query$FindUsersWithFilter(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindUsersWithFilter<TRes> {
+  factory CopyWith$Query$FindUsersWithFilter(
+    Query$FindUsersWithFilter instance,
+    TRes Function(Query$FindUsersWithFilter) then,
+  ) = _CopyWithImpl$Query$FindUsersWithFilter;
+
+  factory CopyWith$Query$FindUsersWithFilter.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindUsersWithFilter;
+
+  TRes call({
+    List<Query$FindUsersWithFilter$findUsers>? findUsers,
+    String? $__typename,
+  });
+  TRes findUsers(
+      Iterable<Query$FindUsersWithFilter$findUsers> Function(
+              Iterable<
+                  CopyWith$Query$FindUsersWithFilter$findUsers<
+                      Query$FindUsersWithFilter$findUsers>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUsersWithFilter<TRes>
+    implements CopyWith$Query$FindUsersWithFilter<TRes> {
+  _CopyWithImpl$Query$FindUsersWithFilter(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUsersWithFilter _instance;
+
+  final TRes Function(Query$FindUsersWithFilter) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUsers = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUsersWithFilter(
+        findUsers: findUsers == _undefined || findUsers == null
+            ? _instance.findUsers
+            : (findUsers as List<Query$FindUsersWithFilter$findUsers>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findUsers(
+          Iterable<Query$FindUsersWithFilter$findUsers> Function(
+                  Iterable<
+                      CopyWith$Query$FindUsersWithFilter$findUsers<
+                          Query$FindUsersWithFilter$findUsers>>)
+              _fn) =>
+      call(
+          findUsers: _fn(_instance.findUsers
+              .map((e) => CopyWith$Query$FindUsersWithFilter$findUsers(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUsersWithFilter<TRes>
+    implements CopyWith$Query$FindUsersWithFilter<TRes> {
+  _CopyWithStubImpl$Query$FindUsersWithFilter(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindUsersWithFilter$findUsers>? findUsers,
+    String? $__typename,
+  }) =>
+      _res;
+  findUsers(_fn) => _res;
+}
+
+const documentNodeQueryFindUsersWithFilter = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindUsersWithFilter'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'filter')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserListFilter'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUsers'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'filter'),
+            value: VariableNode(name: NameNode(value: 'filter')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'email'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userHandle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindUsersWithFilter$findUsers {
+  Query$FindUsersWithFilter$findUsers({
+    required this.id,
+    this.email,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    this.jobTitle,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindUsersWithFilter$findUsers.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$jobTitle = json['jobTitle'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUsersWithFilter$findUsers(
+      id: (l$id as String),
+      email: (l$email as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      jobTitle: (l$jobTitle as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final String? jobTitle;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$jobTitle = jobTitle;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$jobTitle,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUsersWithFilter$findUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUsersWithFilter$findUsers
+    on Query$FindUsersWithFilter$findUsers {
+  CopyWith$Query$FindUsersWithFilter$findUsers<
+          Query$FindUsersWithFilter$findUsers>
+      get copyWith => CopyWith$Query$FindUsersWithFilter$findUsers(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUsersWithFilter$findUsers<TRes> {
+  factory CopyWith$Query$FindUsersWithFilter$findUsers(
+    Query$FindUsersWithFilter$findUsers instance,
+    TRes Function(Query$FindUsersWithFilter$findUsers) then,
+  ) = _CopyWithImpl$Query$FindUsersWithFilter$findUsers;
+
+  factory CopyWith$Query$FindUsersWithFilter$findUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindUsersWithFilter$findUsers;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? jobTitle,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUsersWithFilter$findUsers<TRes>
+    implements CopyWith$Query$FindUsersWithFilter$findUsers<TRes> {
+  _CopyWithImpl$Query$FindUsersWithFilter$findUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUsersWithFilter$findUsers _instance;
+
+  final TRes Function(Query$FindUsersWithFilter$findUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? jobTitle = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUsersWithFilter$findUsers(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUsersWithFilter$findUsers<TRes>
+    implements CopyWith$Query$FindUsersWithFilter$findUsers<TRes> {
+  _CopyWithStubImpl$Query$FindUsersWithFilter$findUsers(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? jobTitle,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$GetInboxInvitations {
+  Query$GetInboxInvitations({
+    required this.myInbox,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$GetInboxInvitations.fromJson(Map<String, dynamic> json) {
+    final l$myInbox = json['myInbox'];
+    final l$$__typename = json['__typename'];
+    return Query$GetInboxInvitations(
+      myInbox: Query$GetInboxInvitations$myInbox.fromJson(
+          (l$myInbox as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$GetInboxInvitations$myInbox myInbox;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$myInbox = myInbox;
+    _resultData['myInbox'] = l$myInbox.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$myInbox = myInbox;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$myInbox,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$GetInboxInvitations) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$myInbox = myInbox;
+    final lOther$myInbox = other.myInbox;
+    if (l$myInbox != lOther$myInbox) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$GetInboxInvitations
+    on Query$GetInboxInvitations {
+  CopyWith$Query$GetInboxInvitations<Query$GetInboxInvitations> get copyWith =>
+      CopyWith$Query$GetInboxInvitations(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$GetInboxInvitations<TRes> {
+  factory CopyWith$Query$GetInboxInvitations(
+    Query$GetInboxInvitations instance,
+    TRes Function(Query$GetInboxInvitations) then,
+  ) = _CopyWithImpl$Query$GetInboxInvitations;
+
+  factory CopyWith$Query$GetInboxInvitations.stub(TRes res) =
+      _CopyWithStubImpl$Query$GetInboxInvitations;
+
+  TRes call({
+    Query$GetInboxInvitations$myInbox? myInbox,
+    String? $__typename,
+  });
+  CopyWith$Query$GetInboxInvitations$myInbox<TRes> get myInbox;
+}
+
+class _CopyWithImpl$Query$GetInboxInvitations<TRes>
+    implements CopyWith$Query$GetInboxInvitations<TRes> {
+  _CopyWithImpl$Query$GetInboxInvitations(
+    this._instance,
+    this._then,
+  );
+
+  final Query$GetInboxInvitations _instance;
+
+  final TRes Function(Query$GetInboxInvitations) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? myInbox = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$GetInboxInvitations(
+        myInbox: myInbox == _undefined || myInbox == null
+            ? _instance.myInbox
+            : (myInbox as Query$GetInboxInvitations$myInbox),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$GetInboxInvitations$myInbox<TRes> get myInbox {
+    final local$myInbox = _instance.myInbox;
+    return CopyWith$Query$GetInboxInvitations$myInbox(
+        local$myInbox, (e) => call(myInbox: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$GetInboxInvitations<TRes>
+    implements CopyWith$Query$GetInboxInvitations<TRes> {
+  _CopyWithStubImpl$Query$GetInboxInvitations(this._res);
+
+  TRes _res;
+
+  call({
+    Query$GetInboxInvitations$myInbox? myInbox,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$GetInboxInvitations$myInbox<TRes> get myInbox =>
+      CopyWith$Query$GetInboxInvitations$myInbox.stub(_res);
+}
+
+const documentNodeQueryGetInboxInvitations = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'GetInboxInvitations'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'myInbox'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'channels'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'invitations'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'channelId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'createdAt'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'createdBy'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'id'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'messageText'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'status'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'pendingInvitations'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'channelId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'createdAt'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'createdBy'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'id'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'messageText'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'status'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$GetInboxInvitations$myInbox {
+  Query$GetInboxInvitations$myInbox({
+    this.channels,
+    this.$__typename = 'UserInbox',
+  });
+
+  factory Query$GetInboxInvitations$myInbox.fromJson(
+      Map<String, dynamic> json) {
+    final l$channels = json['channels'];
+    final l$$__typename = json['__typename'];
+    return Query$GetInboxInvitations$myInbox(
+      channels: l$channels == null
+          ? null
+          : Query$GetInboxInvitations$myInbox$channels.fromJson(
+              (l$channels as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$GetInboxInvitations$myInbox$channels? channels;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$channels = channels;
+    _resultData['channels'] = l$channels?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$channels = channels;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$channels,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$GetInboxInvitations$myInbox) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$channels = channels;
+    final lOther$channels = other.channels;
+    if (l$channels != lOther$channels) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$GetInboxInvitations$myInbox
+    on Query$GetInboxInvitations$myInbox {
+  CopyWith$Query$GetInboxInvitations$myInbox<Query$GetInboxInvitations$myInbox>
+      get copyWith => CopyWith$Query$GetInboxInvitations$myInbox(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$GetInboxInvitations$myInbox<TRes> {
+  factory CopyWith$Query$GetInboxInvitations$myInbox(
+    Query$GetInboxInvitations$myInbox instance,
+    TRes Function(Query$GetInboxInvitations$myInbox) then,
+  ) = _CopyWithImpl$Query$GetInboxInvitations$myInbox;
+
+  factory CopyWith$Query$GetInboxInvitations$myInbox.stub(TRes res) =
+      _CopyWithStubImpl$Query$GetInboxInvitations$myInbox;
+
+  TRes call({
+    Query$GetInboxInvitations$myInbox$channels? channels,
+    String? $__typename,
+  });
+  CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> get channels;
+}
+
+class _CopyWithImpl$Query$GetInboxInvitations$myInbox<TRes>
+    implements CopyWith$Query$GetInboxInvitations$myInbox<TRes> {
+  _CopyWithImpl$Query$GetInboxInvitations$myInbox(
+    this._instance,
+    this._then,
+  );
+
+  final Query$GetInboxInvitations$myInbox _instance;
+
+  final TRes Function(Query$GetInboxInvitations$myInbox) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? channels = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$GetInboxInvitations$myInbox(
+        channels: channels == _undefined
+            ? _instance.channels
+            : (channels as Query$GetInboxInvitations$myInbox$channels?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> get channels {
+    final local$channels = _instance.channels;
+    return local$channels == null
+        ? CopyWith$Query$GetInboxInvitations$myInbox$channels.stub(
+            _then(_instance))
+        : CopyWith$Query$GetInboxInvitations$myInbox$channels(
+            local$channels, (e) => call(channels: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$GetInboxInvitations$myInbox<TRes>
+    implements CopyWith$Query$GetInboxInvitations$myInbox<TRes> {
+  _CopyWithStubImpl$Query$GetInboxInvitations$myInbox(this._res);
+
+  TRes _res;
+
+  call({
+    Query$GetInboxInvitations$myInbox$channels? channels,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> get channels =>
+      CopyWith$Query$GetInboxInvitations$myInbox$channels.stub(_res);
+}
+
+class Query$GetInboxInvitations$myInbox$channels {
+  Query$GetInboxInvitations$myInbox$channels({
+    this.invitations,
+    this.pendingInvitations,
+    this.$__typename = 'ChannelInbox',
+  });
+
+  factory Query$GetInboxInvitations$myInbox$channels.fromJson(
+      Map<String, dynamic> json) {
+    final l$invitations = json['invitations'];
+    final l$pendingInvitations = json['pendingInvitations'];
+    final l$$__typename = json['__typename'];
+    return Query$GetInboxInvitations$myInbox$channels(
+      invitations: (l$invitations as List<dynamic>?)
+          ?.map((e) =>
+              Query$GetInboxInvitations$myInbox$channels$invitations.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
+      pendingInvitations: (l$pendingInvitations as List<dynamic>?)
+          ?.map((e) =>
+              Query$GetInboxInvitations$myInbox$channels$pendingInvitations
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$GetInboxInvitations$myInbox$channels$invitations>?
+      invitations;
+
+  final List<Query$GetInboxInvitations$myInbox$channels$pendingInvitations>?
+      pendingInvitations;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$invitations = invitations;
+    _resultData['invitations'] = l$invitations?.map((e) => e.toJson()).toList();
+    final l$pendingInvitations = pendingInvitations;
+    _resultData['pendingInvitations'] =
+        l$pendingInvitations?.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$invitations = invitations;
+    final l$pendingInvitations = pendingInvitations;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$invitations == null
+          ? null
+          : Object.hashAll(l$invitations.map((v) => v)),
+      l$pendingInvitations == null
+          ? null
+          : Object.hashAll(l$pendingInvitations.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$GetInboxInvitations$myInbox$channels) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$invitations = invitations;
+    final lOther$invitations = other.invitations;
+    if (l$invitations != null && lOther$invitations != null) {
+      if (l$invitations.length != lOther$invitations.length) {
+        return false;
+      }
+      for (int i = 0; i < l$invitations.length; i++) {
+        final l$invitations$entry = l$invitations[i];
+        final lOther$invitations$entry = lOther$invitations[i];
+        if (l$invitations$entry != lOther$invitations$entry) {
+          return false;
+        }
+      }
+    } else if (l$invitations != lOther$invitations) {
+      return false;
+    }
+    final l$pendingInvitations = pendingInvitations;
+    final lOther$pendingInvitations = other.pendingInvitations;
+    if (l$pendingInvitations != null && lOther$pendingInvitations != null) {
+      if (l$pendingInvitations.length != lOther$pendingInvitations.length) {
+        return false;
+      }
+      for (int i = 0; i < l$pendingInvitations.length; i++) {
+        final l$pendingInvitations$entry = l$pendingInvitations[i];
+        final lOther$pendingInvitations$entry = lOther$pendingInvitations[i];
+        if (l$pendingInvitations$entry != lOther$pendingInvitations$entry) {
+          return false;
+        }
+      }
+    } else if (l$pendingInvitations != lOther$pendingInvitations) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$GetInboxInvitations$myInbox$channels
+    on Query$GetInboxInvitations$myInbox$channels {
+  CopyWith$Query$GetInboxInvitations$myInbox$channels<
+          Query$GetInboxInvitations$myInbox$channels>
+      get copyWith => CopyWith$Query$GetInboxInvitations$myInbox$channels(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> {
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels(
+    Query$GetInboxInvitations$myInbox$channels instance,
+    TRes Function(Query$GetInboxInvitations$myInbox$channels) then,
+  ) = _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels;
+
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels.stub(TRes res) =
+      _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels;
+
+  TRes call({
+    List<Query$GetInboxInvitations$myInbox$channels$invitations>? invitations,
+    List<Query$GetInboxInvitations$myInbox$channels$pendingInvitations>?
+        pendingInvitations,
+    String? $__typename,
+  });
+  TRes invitations(
+      Iterable<Query$GetInboxInvitations$myInbox$channels$invitations>? Function(
+              Iterable<
+                  CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<
+                      Query$GetInboxInvitations$myInbox$channels$invitations>>?)
+          _fn);
+  TRes pendingInvitations(
+      Iterable<Query$GetInboxInvitations$myInbox$channels$pendingInvitations>? Function(
+              Iterable<
+                  CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+                      Query$GetInboxInvitations$myInbox$channels$pendingInvitations>>?)
+          _fn);
+}
+
+class _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels<TRes>
+    implements CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> {
+  _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels(
+    this._instance,
+    this._then,
+  );
+
+  final Query$GetInboxInvitations$myInbox$channels _instance;
+
+  final TRes Function(Query$GetInboxInvitations$myInbox$channels) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? invitations = _undefined,
+    Object? pendingInvitations = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$GetInboxInvitations$myInbox$channels(
+        invitations: invitations == _undefined
+            ? _instance.invitations
+            : (invitations as List<
+                Query$GetInboxInvitations$myInbox$channels$invitations>?),
+        pendingInvitations: pendingInvitations == _undefined
+            ? _instance.pendingInvitations
+            : (pendingInvitations as List<
+                Query$GetInboxInvitations$myInbox$channels$pendingInvitations>?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes invitations(
+          Iterable<Query$GetInboxInvitations$myInbox$channels$invitations>? Function(
+                  Iterable<
+                      CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<
+                          Query$GetInboxInvitations$myInbox$channels$invitations>>?)
+              _fn) =>
+      call(
+          invitations: _fn(_instance.invitations?.map((e) =>
+              CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations(
+                e,
+                (i) => i,
+              )))?.toList());
+  TRes pendingInvitations(
+          Iterable<Query$GetInboxInvitations$myInbox$channels$pendingInvitations>? Function(
+                  Iterable<
+                      CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+                          Query$GetInboxInvitations$myInbox$channels$pendingInvitations>>?)
+              _fn) =>
+      call(
+          pendingInvitations: _fn(_instance.pendingInvitations?.map((e) =>
+              CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+                e,
+                (i) => i,
+              )))?.toList());
+}
+
+class _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels<TRes>
+    implements CopyWith$Query$GetInboxInvitations$myInbox$channels<TRes> {
+  _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$GetInboxInvitations$myInbox$channels$invitations>? invitations,
+    List<Query$GetInboxInvitations$myInbox$channels$pendingInvitations>?
+        pendingInvitations,
+    String? $__typename,
+  }) =>
+      _res;
+  invitations(_fn) => _res;
+  pendingInvitations(_fn) => _res;
+}
+
+class Query$GetInboxInvitations$myInbox$channels$invitations {
+  Query$GetInboxInvitations$myInbox$channels$invitations({
+    this.channelId,
+    required this.createdAt,
+    this.createdBy,
+    required this.id,
+    this.messageText,
+    required this.status,
+    this.$__typename = 'ChannelInboxItemInvitation',
+  });
+
+  factory Query$GetInboxInvitations$myInbox$channels$invitations.fromJson(
+      Map<String, dynamic> json) {
+    final l$channelId = json['channelId'];
+    final l$createdAt = json['createdAt'];
+    final l$createdBy = json['createdBy'];
+    final l$id = json['id'];
+    final l$messageText = json['messageText'];
+    final l$status = json['status'];
+    final l$$__typename = json['__typename'];
+    return Query$GetInboxInvitations$myInbox$channels$invitations(
+      channelId: (l$channelId as String?),
+      createdAt: DateTime.parse((l$createdAt as String)),
+      createdBy: (l$createdBy as String?),
+      id: (l$id as String),
+      messageText: (l$messageText as String?),
+      status: fromJson$Enum$ChannelInvitationStatus((l$status as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? channelId;
+
+  final DateTime createdAt;
+
+  final String? createdBy;
+
+  final String id;
+
+  final String? messageText;
+
+  final Enum$ChannelInvitationStatus status;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$channelId = channelId;
+    _resultData['channelId'] = l$channelId;
+    final l$createdAt = createdAt;
+    _resultData['createdAt'] = l$createdAt.toIso8601String();
+    final l$createdBy = createdBy;
+    _resultData['createdBy'] = l$createdBy;
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$messageText = messageText;
+    _resultData['messageText'] = l$messageText;
+    final l$status = status;
+    _resultData['status'] = toJson$Enum$ChannelInvitationStatus(l$status);
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$channelId = channelId;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$id = id;
+    final l$messageText = messageText;
+    final l$status = status;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$channelId,
+      l$createdAt,
+      l$createdBy,
+      l$id,
+      l$messageText,
+      l$status,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$GetInboxInvitations$myInbox$channels$invitations) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$channelId = channelId;
+    final lOther$channelId = other.channelId;
+    if (l$channelId != lOther$channelId) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$messageText = messageText;
+    final lOther$messageText = other.messageText;
+    if (l$messageText != lOther$messageText) {
+      return false;
+    }
+    final l$status = status;
+    final lOther$status = other.status;
+    if (l$status != lOther$status) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$GetInboxInvitations$myInbox$channels$invitations
+    on Query$GetInboxInvitations$myInbox$channels$invitations {
+  CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<
+          Query$GetInboxInvitations$myInbox$channels$invitations>
+      get copyWith =>
+          CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<
+    TRes> {
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations(
+    Query$GetInboxInvitations$myInbox$channels$invitations instance,
+    TRes Function(Query$GetInboxInvitations$myInbox$channels$invitations) then,
+  ) = _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$invitations;
+
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$invitations;
+
+  TRes call({
+    String? channelId,
+    DateTime? createdAt,
+    String? createdBy,
+    String? id,
+    String? messageText,
+    Enum$ChannelInvitationStatus? status,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$invitations<TRes>
+    implements
+        CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<TRes> {
+  _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$invitations(
+    this._instance,
+    this._then,
+  );
+
+  final Query$GetInboxInvitations$myInbox$channels$invitations _instance;
+
+  final TRes Function(Query$GetInboxInvitations$myInbox$channels$invitations)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? channelId = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? id = _undefined,
+    Object? messageText = _undefined,
+    Object? status = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$GetInboxInvitations$myInbox$channels$invitations(
+        channelId: channelId == _undefined
+            ? _instance.channelId
+            : (channelId as String?),
+        createdAt: createdAt == _undefined || createdAt == null
+            ? _instance.createdAt
+            : (createdAt as DateTime),
+        createdBy: createdBy == _undefined
+            ? _instance.createdBy
+            : (createdBy as String?),
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        messageText: messageText == _undefined
+            ? _instance.messageText
+            : (messageText as String?),
+        status: status == _undefined || status == null
+            ? _instance.status
+            : (status as Enum$ChannelInvitationStatus),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$invitations<
+        TRes>
+    implements
+        CopyWith$Query$GetInboxInvitations$myInbox$channels$invitations<TRes> {
+  _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$invitations(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? channelId,
+    DateTime? createdAt,
+    String? createdBy,
+    String? id,
+    String? messageText,
+    Enum$ChannelInvitationStatus? status,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$GetInboxInvitations$myInbox$channels$pendingInvitations {
+  Query$GetInboxInvitations$myInbox$channels$pendingInvitations({
+    this.channelId,
+    required this.createdAt,
+    this.createdBy,
+    required this.id,
+    this.messageText,
+    required this.status,
+    this.$__typename = 'ChannelInboxItemInvitation',
+  });
+
+  factory Query$GetInboxInvitations$myInbox$channels$pendingInvitations.fromJson(
+      Map<String, dynamic> json) {
+    final l$channelId = json['channelId'];
+    final l$createdAt = json['createdAt'];
+    final l$createdBy = json['createdBy'];
+    final l$id = json['id'];
+    final l$messageText = json['messageText'];
+    final l$status = json['status'];
+    final l$$__typename = json['__typename'];
+    return Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+      channelId: (l$channelId as String?),
+      createdAt: DateTime.parse((l$createdAt as String)),
+      createdBy: (l$createdBy as String?),
+      id: (l$id as String),
+      messageText: (l$messageText as String?),
+      status: fromJson$Enum$ChannelInvitationStatus((l$status as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? channelId;
+
+  final DateTime createdAt;
+
+  final String? createdBy;
+
+  final String id;
+
+  final String? messageText;
+
+  final Enum$ChannelInvitationStatus status;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$channelId = channelId;
+    _resultData['channelId'] = l$channelId;
+    final l$createdAt = createdAt;
+    _resultData['createdAt'] = l$createdAt.toIso8601String();
+    final l$createdBy = createdBy;
+    _resultData['createdBy'] = l$createdBy;
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$messageText = messageText;
+    _resultData['messageText'] = l$messageText;
+    final l$status = status;
+    _resultData['status'] = toJson$Enum$ChannelInvitationStatus(l$status);
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$channelId = channelId;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$id = id;
+    final l$messageText = messageText;
+    final l$status = status;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$channelId,
+      l$createdAt,
+      l$createdBy,
+      l$id,
+      l$messageText,
+      l$status,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$GetInboxInvitations$myInbox$channels$pendingInvitations) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$channelId = channelId;
+    final lOther$channelId = other.channelId;
+    if (l$channelId != lOther$channelId) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$messageText = messageText;
+    final lOther$messageText = other.messageText;
+    if (l$messageText != lOther$messageText) {
+      return false;
+    }
+    final l$status = status;
+    final lOther$status = other.status;
+    if (l$status != lOther$status) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$GetInboxInvitations$myInbox$channels$pendingInvitations
+    on Query$GetInboxInvitations$myInbox$channels$pendingInvitations {
+  CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+          Query$GetInboxInvitations$myInbox$channels$pendingInvitations>
+      get copyWith =>
+          CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+    TRes> {
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+    Query$GetInboxInvitations$myInbox$channels$pendingInvitations instance,
+    TRes Function(Query$GetInboxInvitations$myInbox$channels$pendingInvitations)
+        then,
+  ) = _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations;
+
+  factory CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations;
+
+  TRes call({
+    String? channelId,
+    DateTime? createdAt,
+    String? createdBy,
+    String? id,
+    String? messageText,
+    Enum$ChannelInvitationStatus? status,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+        TRes>
+    implements
+        CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+            TRes> {
+  _CopyWithImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+    this._instance,
+    this._then,
+  );
+
+  final Query$GetInboxInvitations$myInbox$channels$pendingInvitations _instance;
+
+  final TRes Function(
+      Query$GetInboxInvitations$myInbox$channels$pendingInvitations) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? channelId = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? id = _undefined,
+    Object? messageText = _undefined,
+    Object? status = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+        channelId: channelId == _undefined
+            ? _instance.channelId
+            : (channelId as String?),
+        createdAt: createdAt == _undefined || createdAt == null
+            ? _instance.createdAt
+            : (createdAt as DateTime),
+        createdBy: createdBy == _undefined
+            ? _instance.createdBy
+            : (createdBy as String?),
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        messageText: messageText == _undefined
+            ? _instance.messageText
+            : (messageText as String?),
+        status: status == _undefined || status == null
+            ? _instance.status
+            : (status as Enum$ChannelInvitationStatus),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+        TRes>
+    implements
+        CopyWith$Query$GetInboxInvitations$myInbox$channels$pendingInvitations<
+            TRes> {
+  _CopyWithStubImpl$Query$GetInboxInvitations$myInbox$channels$pendingInvitations(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? channelId,
+    DateTime? createdAt,
+    String? createdBy,
+    String? id,
+    String? messageText,
+    Enum$ChannelInvitationStatus? status,
     String? $__typename,
   }) =>
       _res;

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -15216,7 +15216,7 @@ class Input$GenGroupsInput {
     String? deletedAt,
     String? deletedBy,
     int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
+    required List<Input$GenSpecificGroupInput> specificGroups,
   }) =>
       Input$GenGroupsInput._({
         if (id != null) r'id': id,
@@ -15230,7 +15230,7 @@ class Input$GenGroupsInput {
         if (deletedAt != null) r'deletedAt': deletedAt,
         if (deletedBy != null) r'deletedBy': deletedBy,
         if (count != null) r'count': count,
-        if (specificGroups != null) r'specificGroups': specificGroups,
+        r'specificGroups': specificGroups,
       });
 
   Input$GenGroupsInput._(this._$data);
@@ -15287,13 +15287,11 @@ class Input$GenGroupsInput {
       final l$count = data['count'];
       result$data['count'] = (l$count as int);
     }
-    if (data.containsKey('specificGroups')) {
-      final l$specificGroups = data['specificGroups'];
-      result$data['specificGroups'] = (l$specificGroups as List<dynamic>)
-          .map((e) =>
-              Input$GenSpecificGroupInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
+    final l$specificGroups = data['specificGroups'];
+    result$data['specificGroups'] = (l$specificGroups as List<dynamic>)
+        .map((e) =>
+            Input$GenSpecificGroupInput.fromJson((e as Map<String, dynamic>)))
+        .toList();
     return Input$GenGroupsInput._(result$data);
   }
 
@@ -15312,8 +15310,8 @@ class Input$GenGroupsInput {
   String? get deletedAt => (_$data['deletedAt'] as String?);
   String? get deletedBy => (_$data['deletedBy'] as String?);
   int? get count => (_$data['count'] as int?);
-  List<Input$GenSpecificGroupInput>? get specificGroups =>
-      (_$data['specificGroups'] as List<Input$GenSpecificGroupInput>?);
+  List<Input$GenSpecificGroupInput> get specificGroups =>
+      (_$data['specificGroups'] as List<Input$GenSpecificGroupInput>);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -15360,13 +15358,9 @@ class Input$GenGroupsInput {
       final l$count = count;
       result$data['count'] = (l$count as int);
     }
-    if (_$data.containsKey('specificGroups')) {
-      final l$specificGroups = specificGroups;
-      result$data['specificGroups'] =
-          (l$specificGroups as List<Input$GenSpecificGroupInput>)
-              .map((e) => e.toJson())
-              .toList();
-    }
+    final l$specificGroups = specificGroups;
+    result$data['specificGroups'] =
+        l$specificGroups.map((e) => e.toJson()).toList();
     return result$data;
   }
 
@@ -15492,23 +15486,15 @@ class Input$GenGroupsInput {
     }
     final l$specificGroups = specificGroups;
     final lOther$specificGroups = other.specificGroups;
-    if (_$data.containsKey('specificGroups') !=
-        other._$data.containsKey('specificGroups')) {
+    if (l$specificGroups.length != lOther$specificGroups.length) {
       return false;
     }
-    if (l$specificGroups != null && lOther$specificGroups != null) {
-      if (l$specificGroups.length != lOther$specificGroups.length) {
+    for (int i = 0; i < l$specificGroups.length; i++) {
+      final l$specificGroups$entry = l$specificGroups[i];
+      final lOther$specificGroups$entry = lOther$specificGroups[i];
+      if (l$specificGroups$entry != lOther$specificGroups$entry) {
         return false;
       }
-      for (int i = 0; i < l$specificGroups.length; i++) {
-        final l$specificGroups$entry = l$specificGroups[i];
-        final lOther$specificGroups$entry = lOther$specificGroups[i];
-        if (l$specificGroups$entry != lOther$specificGroups$entry) {
-          return false;
-        }
-      }
-    } else if (l$specificGroups != lOther$specificGroups) {
-      return false;
     }
     return true;
   }
@@ -15543,11 +15529,7 @@ class Input$GenGroupsInput {
       _$data.containsKey('deletedAt') ? l$deletedAt : const {},
       _$data.containsKey('deletedBy') ? l$deletedBy : const {},
       _$data.containsKey('count') ? l$count : const {},
-      _$data.containsKey('specificGroups')
-          ? l$specificGroups == null
-              ? null
-              : Object.hashAll(l$specificGroups.map((v) => v))
-          : const {},
+      Object.hashAll(l$specificGroups.map((v) => v)),
     ]);
   }
 }
@@ -15660,7 +15642,7 @@ class _CopyWithImpl$Input$GenGroupsInput<TRes>
                           Input$GenSpecificGroupInput>>)
               _fn) =>
       call(
-          specificGroups: _fn(_instance.specificGroups!
+          specificGroups: _fn(_instance.specificGroups
               .map((e) => CopyWith$Input$GenSpecificGroupInput(
                     e,
                     (i) => i,
@@ -25067,7 +25049,7 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
     case Enum$ServiceRequestType.graphQlQueryFindChannelParticipantById:
       return r'graphQlQueryFindChannelParticipantById';
     case Enum$ServiceRequestType
-          .graphQlQueryFindPendingChannelInvitationsForUser:
+        .graphQlQueryFindPendingChannelInvitationsForUser:
       return r'graphQlQueryFindPendingChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryMyInbox:
       return r'graphQlQueryMyInbox';

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -25049,7 +25049,7 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
     case Enum$ServiceRequestType.graphQlQueryFindChannelParticipantById:
       return r'graphQlQueryFindChannelParticipantById';
     case Enum$ServiceRequestType
-        .graphQlQueryFindPendingChannelInvitationsForUser:
+          .graphQlQueryFindPendingChannelInvitationsForUser:
       return r'graphQlQueryFindPendingChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryMyInbox:
       return r'graphQlQueryMyInbox';

--- a/lib/data/models/channels/channels_provider.dart
+++ b/lib/data/models/channels/channels_provider.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations.graphql.dart';
+import 'package:mm_flutter_app/data/models/base/base_provider.dart';
 
 import '../../../widgets/atoms/server_error.dart';
+import '../base/operation_result.dart';
 import 'channels_api.dart';
 import 'create_channel.dart';
 
-class ChannelsProvider extends ChangeNotifier {
-  GraphQLClient client;
-
-  ChannelsProvider({required this.client}) {
+class ChannelsProvider extends BaseProvider {
+  ChannelsProvider({required super.client}) {
     debugPrint('ChannelsProvider initialized');
     // subscribeToChannels();
   }
@@ -74,6 +75,34 @@ class ChannelsProvider extends ChangeNotifier {
         // print(result);
         return onData(result.data!['findChannelById']);
       },
+    );
+  }
+
+  Widget getInboxInvitations({
+    required Widget Function(
+      OperationResult<Query$GetInboxInvitations$myInbox> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return runQuery(
+      document: documentNodeQueryGetInboxInvitations,
+      onData: (queryResult, {refetch, fetchMore}) {
+        final OperationResult<Query$GetInboxInvitations$myInbox> result =
+            OperationResult(
+          gqlQueryResult: queryResult,
+          response: queryResult.data != null
+              ? Query$GetInboxInvitations.fromJson(
+                  queryResult.data!,
+                ).myInbox
+              : null,
+        );
+        return onData(result, refetch: refetch, fetchMore: fetchMore);
+      },
+      onLoading: onLoading,
+      onError: onError,
     );
   }
 

--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -78,7 +78,7 @@ class UserProvider extends BaseProvider {
 
   Widget queryAllUsers({
     required Widget Function(
-      OperationResult<List<Query$FindUsers$findUsers>> data, {
+      OperationResult<List<Query$FindAllUsers$findUsers>> data, {
       void Function()? refetch,
       void Function(FetchMoreOptions)? fetchMore,
     }) onData,
@@ -86,14 +86,53 @@ class UserProvider extends BaseProvider {
     Widget Function(String error, {void Function()? refetch})? onError,
   }) {
     return runQuery(
-      document: documentNodeQueryFindUsers,
+      document: documentNodeQueryFindAllUsers,
       onData: (queryResult, {refetch, fetchMore}) {
-        final OperationResult<List<Query$FindUsers$findUsers>> result =
+        final OperationResult<List<Query$FindAllUsers$findUsers>> result =
             OperationResult(
           gqlQueryResult: queryResult,
           response: queryResult.data == null
               ? null
-              : Query$FindUsers.fromJson(
+              : Query$FindAllUsers.fromJson(
+                  queryResult.data!,
+                ).findUsers.map((element) {
+                  if (element.avatarUrl == "") {
+                    return element.copyWith(avatarUrl: null);
+                  }
+                  return element;
+                }).toList(),
+        );
+        return onData(
+          result,
+          refetch: refetch,
+          fetchMore: fetchMore,
+        );
+      },
+      onLoading: onLoading,
+      onError: onError,
+    );
+  }
+
+  Widget findUsersWithFilter(
+    Input$UserListFilter input, {
+    required Widget Function(
+      OperationResult<List<Query$FindUsersWithFilter$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return runQuery(
+      document: documentNodeQueryFindUsersWithFilter,
+      variables: Variables$Query$FindUsersWithFilter(filter: input).toJson(),
+      onData: (queryResult, {refetch, fetchMore}) {
+        final OperationResult<List<Query$FindUsersWithFilter$findUsers>>
+            result = OperationResult(
+          gqlQueryResult: queryResult,
+          response: queryResult.data == null
+              ? null
+              : Query$FindUsersWithFilter.fromJson(
                   queryResult.data!,
                 ).findUsers.map((element) {
                   if (element.avatarUrl == "") {

--- a/lib/schema/operations.graphql
+++ b/lib/schema/operations.graphql
@@ -15,7 +15,7 @@ query GetUserProfileInfo {
     }
 }
 
-query FindUsers ($filter: UserListFilter) {
+query FindAllUsers ($filter: UserListFilter) {
     findUsers(filter: $filter){
         id
         email
@@ -25,7 +25,39 @@ query FindUsers ($filter: UserListFilter) {
     }
 }
 
+query FindUsersWithFilter ($filter: UserListFilter) {
+    findUsers(filter: $filter){
+        id
+        email
+        fullName
+        avatarUrl
+        userHandle
+        jobTitle
+    }
+}
 
+query GetInboxInvitations {
+  myInbox {
+    channels {
+      invitations {
+        channelId
+        createdAt
+        createdBy
+        id
+        messageText
+        status
+      }
+      pendingInvitations {
+        channelId
+        createdAt
+        createdBy
+        id
+        messageText
+        status
+      }
+    }
+  }
+}
 
 mutation SignInUser ($input: UserSignInInput!) {
     signInUser(input: $input) {

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -1621,7 +1621,7 @@ input GenGroupsInput {
   deletedAt: String
   deletedBy: ID
   count: Int! = 0
-  specificGroups: [GenSpecificGroupInput!]! = []
+  specificGroups: [GenSpecificGroupInput!]!
 }
 
 input GenSpecificGroupInput {

--- a/lib/widgets/atoms/invitation_tile.dart
+++ b/lib/widgets/atoms/invitation_tile.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-
-enum InvitationTileType {
-  requested,
-  accepted,
-}
 
 class InvitationTile extends StatelessWidget {
   final String userName;
   final String userJobTitle;
-  final InvitationTileType invitationTileType;
+  final Enum$ChannelInvitationStatus invitationStatus;
   final String? avatarUrl;
   final void Function() buttonOnPressed;
 
@@ -18,7 +14,7 @@ class InvitationTile extends StatelessWidget {
     Key? key,
     required this.userName,
     required this.userJobTitle,
-    required this.invitationTileType,
+    required this.invitationStatus,
     this.avatarUrl,
     required this.buttonOnPressed,
   }) : super(key: key);
@@ -79,11 +75,13 @@ class InvitationTile extends StatelessWidget {
   }
 
   String _invitationText(AppLocalizations l10n) {
-    switch (invitationTileType) {
-      case InvitationTileType.requested:
+    switch (invitationStatus) {
+      case Enum$ChannelInvitationStatus.created:
         return l10n.homeInvitationRequested;
-      case InvitationTileType.accepted:
+      case Enum$ChannelInvitationStatus.accepted:
         return l10n.homeInvitationAccepted;
+      default:
+        return 'UNDEFINED';
     }
   }
 }

--- a/lib/widgets/atoms/section_tile.dart
+++ b/lib/widgets/atoms/section_tile.dart
@@ -47,7 +47,8 @@ class _SectionTileState extends State<SectionTile> {
                 widget.title,
                 style: TextStyles.sectionHeader(context),
               ),
-              if (widget.seeAllOnPressed != null && !_isExpanded)
+              if (widget.seeAllOnPressed != null &&
+                  (!_isExpanded || widget.seeLessOnPressed == null))
                 _SectionExpandToggle(
                   onPressed: () => {
                     widget.seeAllOnPressed!(),
@@ -55,7 +56,8 @@ class _SectionTileState extends State<SectionTile> {
                   },
                   text: l10n.listSeeAll,
                 ),
-              if (widget.seeLessOnPressed != null && _isExpanded)
+              if (widget.seeLessOnPressed != null &&
+                  (_isExpanded || widget.seeAllOnPressed == null))
                 _SectionExpandToggle(
                   onPressed: () => {
                     widget.seeLessOnPressed!(),

--- a/lib/widgets/molecules/invitation_section.dart
+++ b/lib/widgets/molecules/invitation_section.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mm_flutter_app/__generated/schema/operations.graphql.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/data/models/channels/channels_provider.dart';
+import 'package:mm_flutter_app/data/models/user/user_provider.dart';
 import 'package:mm_flutter_app/widgets/atoms/invitation_tile.dart';
 import 'package:mm_flutter_app/widgets/atoms/section_tile.dart';
+import 'package:provider/provider.dart';
 
 class InvitationSection extends StatefulWidget {
   static const maxTilesToShow = 2;
@@ -13,111 +19,90 @@ class InvitationSection extends StatefulWidget {
 }
 
 class _InvitationSectionState extends State<InvitationSection> {
-  bool _isLongList = false;
-  bool _isExpanded = false;
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final ChannelsProvider channelsProvider =
+        Provider.of<ChannelsProvider>(context);
+    final UserProvider userProvider = Provider.of<UserProvider>(context);
+    return channelsProvider.getInboxInvitations(
+      onData: (data, {refetch, fetchMore}) {
+        if (data.response?.channels?.invitations == null ||
+            data.response!.channels!.invitations!.isEmpty) {
+          return const SizedBox(width: 0, height: 0);
+        }
+        final filteredInvitations = data.response!.channels!.invitations!
+            .where((element) =>
+                element.status == Enum$ChannelInvitationStatus.accepted ||
+                element.status == Enum$ChannelInvitationStatus.created)
+            .take(InvitationSection.maxTilesToShow)
+            .toList(growable: false);
+        List<String> userIds = filteredInvitations
+            .map((e) => e.createdBy)
+            .nonNulls
+            .toList(growable: false);
+        if (filteredInvitations.isEmpty ||
+            filteredInvitations.length != userIds.length) {
+          return const SizedBox(width: 0, height: 0);
+        }
+        return SectionTile(
+          title: l10n.homeInvitationSectionTitle,
+          addTopDivider: true,
+          removeBottomPadding: true,
+          seeAllOnPressed: () => context.push('/inbox'),
+          child: _createInvitationTiles(
+            l10n,
+            userProvider,
+            userIds,
+            filteredInvitations,
+          ),
+        );
+      },
+    );
+  }
 
-  List<Widget> _createInvitationTiles(AppLocalizations l10n) {
-    final List<_Invitation> invitations = _getInvitations();
-    if (invitations.length > InvitationSection.maxTilesToShow) {
-      _isLongList = true;
-    }
-    List<Widget> invitationsContent = [];
-    int tilesShown = 0;
-    while (tilesShown < invitations.length &&
-        (_isExpanded || tilesShown < InvitationSection.maxTilesToShow)) {
-      if (invitationsContent.length.isOdd) {
-        invitationsContent.add(Components.indentedSubDivider);
+  Widget _createInvitationTiles(
+      AppLocalizations l10n,
+      UserProvider userProvider,
+      List<String> userIds,
+      List<Query$GetInboxInvitations$myInbox$channels$invitations>
+          invitations) {
+    return userProvider.findUsersWithFilter(Input$UserListFilter(ids: userIds),
+        onData: (data, {refetch, fetchMore}) {
+      if (data.response == null) {
+        return const SizedBox(width: 0, height: 0);
       }
-      invitationsContent
-          .add(_createInvitationTile(l10n, invitations[tilesShown]));
-      tilesShown++;
-    }
-    return invitationsContent;
+      List<Widget> invitationWidgets = [];
+      for (int i = 0; i < invitations.length; i++) {
+        if (i > 0) {
+          invitationWidgets.add(Components.indentedSubDivider);
+        }
+        invitationWidgets.add(_createInvitationTile(
+          l10n,
+          data.response!
+              .firstWhere((element) => invitations[i].createdBy! == element.id),
+          invitations[i].status,
+        ));
+      }
+      return Column(
+        children: invitationWidgets,
+      );
+    });
   }
 
   InvitationTile _createInvitationTile(
     AppLocalizations l10n,
-    _Invitation invitation,
+    Query$FindUsersWithFilter$findUsers user,
+    Enum$ChannelInvitationStatus invitationStatus,
   ) {
     return InvitationTile(
-      userName: invitation.userName,
-      userJobTitle: invitation.userJobTitle,
-      invitationTileType: invitation.invitationType,
-      avatarUrl: invitation.avatarUrl,
+      userName: user.fullName ?? '',
+      userJobTitle: user.jobTitle ?? '',
+      invitationStatus: invitationStatus,
+      avatarUrl: user.avatarUrl,
       buttonOnPressed: () => {
         //TODO(m-rosario): Open profile when clicked.
       },
     );
   }
-
-  List<_Invitation> _getInvitations() {
-    //TODO(m-rosario): Call backend instead of using hardcoded mock data.
-    final List<_Invitation> invitations = [
-      _Invitation(
-        userName: 'Moshe Goldberg',
-        userJobTitle: 'Co-founder, CEO - Goldberg & Co.',
-        invitationType: InvitationTileType.requested,
-        avatarUrl:
-            'https://images.squarespace-cdn.com/content/v1/530ce8d1e4b067ea68a9f821/1612484390216-5NVBC0NJJTFP1OPNRU6F/corporate%2Bbusiness%2Bheadshots%2Blos%2Bangeles_Danielle%2BSpires.jpg',
-      ),
-      _Invitation(
-        userName: 'Mila Dovonik',
-        userJobTitle: 'Co-founder, CEO - Mila Networks',
-        invitationType: InvitationTileType.accepted,
-        avatarUrl:
-            'https://justeconomyinstitute.org/wp-content/uploads/2021/07/kenya.jpg',
-      ),
-      _Invitation(
-        userName: 'Brandon Smith',
-        userJobTitle: 'Founder, CEO - BS Inc.',
-        invitationType: InvitationTileType.requested,
-        avatarUrl:
-            'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRKFZ-wy3m90LUavZZIb5dpNDduYghKF-7pSg&usqp=CAU',
-      ),
-      _Invitation(
-        userName: 'Catalina Echevarria',
-        userJobTitle: 'COO - ACME Corporation',
-        invitationType: InvitationTileType.accepted,
-        avatarUrl:
-            'https://media.istockphoto.com/id/1437816897/photo/business-woman-manager-or-human-resources-portrait-for-career-success-company-we-are-hiring.jpg?b=1&s=170667a&w=0&k=20&c=YQ_j83pg9fB-HWOd1Qur3_kBmG_ot_hZty8pvoFkr6A=',
-      ),
-    ];
-    return invitations;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
-    final List<Widget> invitationTiles = _createInvitationTiles(l10n);
-    return invitationTiles.isEmpty
-        ? SizedBox.fromSize(
-            size: const Size(0, 0),
-          )
-        : SectionTile(
-            title: l10n.homeInvitationSectionTitle,
-            addTopDivider: true,
-            removeBottomPadding: true,
-            seeAllOnPressed:
-                _isLongList ? () => setState(() => _isExpanded = true) : null,
-            seeLessOnPressed:
-                _isLongList ? () => setState(() => _isExpanded = false) : null,
-            child: Column(
-              children: invitationTiles,
-            ),
-          );
-  }
-}
-
-class _Invitation {
-  final String userName;
-  final String userJobTitle;
-  final InvitationTileType invitationType;
-  final String? avatarUrl;
-
-  _Invitation({
-    required this.userName,
-    required this.userJobTitle,
-    required this.invitationType,
-    this.avatarUrl,
-  });
 }

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -42,10 +42,21 @@ export function mockQueries(serverState: MockServerState) {
         },
         myInbox: () => {
             var mockChannelId = faker.string.alphanumeric({length: 24});
+            var mockInvitations = [
+                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[0], true, false),
+                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[1], false, false),
+                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[2], false, true),
+                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[3], false, false),
+            ];
             return {
                 __typename: "UserInbox",
                 channels: {
                     __typename: "ChannelInbox",
+                    invitations: mockInvitations,
+                    pendingInvitations: [
+                        mockInvitations[0],
+                        mockInvitations[1],
+                    ],
                     unseenMessages: [
                         generators.generateChannelInboxItemMessage(mockChannelId, serverState.loggedInUser),
                         generators.generateChannelInboxItemMessage(mockChannelId, serverState.otherUsers[0]),

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -1,4 +1,4 @@
-import { Sex, faker } from "@faker-js/faker";
+import { faker } from "@faker-js/faker";
 
 export function generateUser() {
     var mockFirstName = faker.person.firstName();

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -1,4 +1,4 @@
-import { faker } from "@faker-js/faker";
+import { Sex, faker } from "@faker-js/faker";
 
 export function generateUser() {
     var mockFirstName = faker.person.firstName();
@@ -14,7 +14,8 @@ export function generateUser() {
         fullName: mockFullName,
         userHandle: mockUserHandle,
         email: mockEmail,
-        avatarUrl: null,
+        avatarUrl: faker.image.urlPicsumPhotos(),
+        jobTitle: faker.person.jobTitle(), //TODO(MM): Implement in backend.
     }
 }
 
@@ -81,11 +82,31 @@ export function generateChannelMessage(sender: any, seen: boolean) {
     }
 }
 
+export function generateChannelInboxItemInvitation(channelId: string, sender: any,  declined?: boolean, accepted?: boolean) {
+var status: string;
+    if (accepted)
+        status = "accepted";
+    else if (declined)
+        status = "declined";
+    else
+        status = "created";
+    return {
+        __typename: "ChannelInboxItemInvitation",
+        channelId: channelId,
+        createdAt: faker.date.recent(),
+        createdBy: sender.id,
+        id: faker.string.alphanumeric({length: 24}),
+        messageText: faker.lorem.sentence(),
+        status: status,
+    }
+}
+
 export function generateChannelInboxItemMessage(channelId: string, sender: any) {
+
     return {
         __typename: "ChannelInboxItemMessage",
         channelId: channelId,
-        id: sender.id,
+        id: faker.string.alphanumeric({length: 24}),
         messageText: faker.lorem.sentence(),
         senderFullName: sender.fullName,
         createdBy: sender.id,


### PR DESCRIPTION
- Updated mock server to generate inbox invitations. Also added the jobTitle field to the user generator, and made the avatarUrl field show a random image.
- Added UserProvider query for finding users by ID.
- Added ChannelsProvider query for getting inbox invitations.
- Updated Widgets to use backend data instead of hardcoded data.
- Pointed the 'See all' button to the Inbox page.