### PR TITLE
Make error logging and reporting optional for Queries and Mutations

### DIFF
--- a/lib/data/models/user/user_provider.dart
+++ b/lib/data/models/user/user_provider.dart
@@ -51,6 +51,7 @@ class UserProvider extends BaseProvider {
     }) onData,
     Widget Function()? onLoading,
     Widget Function(String error, {void Function()? refetch})? onError,
+    bool logFailures = true,
   }) {
     return runQuery(
       document: documentNodeQueryGetAuthenticatedUser,
@@ -73,6 +74,7 @@ class UserProvider extends BaseProvider {
       },
       onLoading: onLoading,
       onError: onError,
+      logFailures: logFailures,
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -125,6 +125,7 @@ class StartScreen extends StatelessWidget {
 
         return const LoadingScreen();
       },
+      logFailures: false, // Error is expected when user is not logged in.
     );
   }
 }


### PR DESCRIPTION
Logging/reporting can be disabled if the error is handled manually, as is the case of the StartScreen showing the Sign In page if it fails to get the authenticated user.