### PR TITLE
Improvements to CrashHandler

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 part 'components.dart';
 part 'dimensions.dart';
 part 'enums.dart';
+part 'identifiers.dart';
 part 'paths.dart';
 part 'schemes.dart';
 part 'styles.dart';

--- a/lib/constants/identifiers.dart
+++ b/lib/constants/identifiers.dart
@@ -1,0 +1,6 @@
+part of 'app_constants.dart';
+
+class Identifiers {
+  Identifiers._private();
+  static const String appName = 'MicroMentor';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -18,6 +19,7 @@ import 'package:mm_flutter_app/widgets/screens/sign_in/sign_in_screen.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_screen.dart';
 import 'package:provider/provider.dart';
 
+import 'firebase_options.dart';
 import 'providers/user_provider.dart';
 import 'widgets/screens/explore/explore.dart';
 
@@ -141,6 +143,10 @@ class LoadingScreen extends StatelessWidget {
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    name: Identifiers.appName,
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   //TODO(m-rosario): Make crash data collection opt-in.
   final CrashHandler crashHandler = CrashHandler(!kDebugMode, true);
   FlutterError.onError = crashHandler.handleUncaughtFlutterError;


### PR DESCRIPTION
- Moved Firebase initialization to the main method of the app, since Firebase will be used for more than Crashlytics.
- Ensured error logging in logCrashReport is wrapped in a try-catch to prevent logger issues caused by the logger itself.
- Ensured Firebase Crashlytics is enabled only on platforms that support it (iOS and Android).
- Centralized crash reporting into a separate sendCrashReport method for better maintainability.
- Adjusted error classification to treat Error instances as fatal but without causing app exit.
- Removed _exitApp method, leaving app exit handling to the Flutter framework.
- Added Identifiers to the app_constants library for storing identifiers like the appName.
- Conducted overall refactoring for cleaner and more efficient code.
