### PR TITLE
Add configuration for mock server to devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,3 @@
 source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
 
-export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
-
 use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 /assets/.env
+/assets/.env.bak
 
 # IntelliJ related
 *.iml

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1689101590,
-        "narHash": "sha256-PC8mc78AUFUxiqdOKUkNRVaG39ftvt/LO+L+lNMN7oI=",
+        "lastModified": 1689595120,
+        "narHash": "sha256-n9q2m9/ul18MnrHjDRWE7vlqc9SIgbCoM/cihvySTzQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "36a7bb53b31a7fd40c026559005e10d824c88b5c",
+        "rev": "892ddef1fba6a956c172e6c1bb7c830795c713a2",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689138773,
-        "narHash": "sha256-NEcJPQfwc1jNDI/ITvieJW2Y+IWdGIYCFHLJl5PGx3o=",
+        "lastModified": 1689569955,
+        "narHash": "sha256-RF7/33M4MAhHiuyfkq15zeOJGWSZiOH4woRqPo+Z+N0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf57c599729771cd23054a18c0f3a391ae85e193",
+        "rev": "7e212cc9752edacf28f3579440f9adf4c5e346ae",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1688596063,
-        "narHash": "sha256-9t7RxBiKWHygsqXtiNATTJt4lim/oSYZV3RG8OjDDng=",
+        "lastModified": 1689553106,
+        "narHash": "sha256-RFFf6BbpqQB0l1ehAbgri9g9MGZkAY9UdiNotD9fG8Y=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c8d18ba345730019c3faf412c96a045ade171895",
+        "rev": "87589fa438dd6d5b8c7c1c6ab2ad69e4663bb51f",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,7 +1,10 @@
 { pkgs, ... }:
 
 let
-  android-comp     = android-pkgs.androidenv.composeAndroidPackages {
+  androidenv       = android-pkgs.androidenv.override {
+    licenseAccepted = true;
+  };
+  android-comp     = androidenv.composeAndroidPackages {
     buildToolsVersions = [ "30.0.3" ];
     platformVersions   = [ "29" "30" "31" "33" ];
   };
@@ -18,13 +21,25 @@ in {
     ANDROID_SDK_ROOT = "${android-sdk-root}";
   };
 
-  languages.java = {
-    enable      = true;
-    jdk.package = pkgs.jdk11;
+  languages = {
+    java = {
+      enable      = true;
+      jdk.package = pkgs.jdk11;
+    };
+
+    javascript.enable = true;
   };
 
   name = "mm-flutter-app";
 
   packages = with pkgs;
     [ act android-sdk flutter nodePackages.firebase-tools pandoc ];
+
+  processes.mock-server.exec = ''
+    mv assets/.env assets/.env.bak 2>/dev/null || true
+    touch assets/.env
+    echo APP_GRAPHQL_URL="http://localhost:4000/mmdata/api/graphql" >> assets/.env
+    echo APP_SUBSCRIPTION_URL="ws://localhost:4000/mmdata/api/graphql" >> assets/.env
+    cd mm-mock-server && npm install && npm start
+  '';
 }


### PR DESCRIPTION
This allows the mock server to be started by running `devenv up` without worrying about installing node, npm, etc.