### PR TITLE
Implement storybook_flutter, to review UI components independent of the business logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,6 @@ In Android Studio, select a target platform (Chrome web browser, Android
 Simulator, etc.) and then click on the `Run main.dart` button to build and the
 run the app on that platform. Shortcut : `Control + R` (macOS).
 
-### Run Widgetbook
-
-In Android Studio, select `Edit Configurations` in the Run menu. Copy
-configurations of main.dart and edit name as `widgetbook`. Edit
-`Dart entrypoint` to the path of your Widgetbook's main.dart. For e.g.
-`mm_flutter_app/widgetbook/main.dart` at the place of
-`mm_flutter_app/lib/main.dart`.
-
-Or to run from terminal, execute `flutter run -t widgetbook/main.dart`.
 
 ### Run Tests
 

--- a/lib/data/models/channels/mock_channels_provider.dart
+++ b/lib/data/models/channels/mock_channels_provider.dart
@@ -1,34 +1,57 @@
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/data/models/channels/channels_provider.dart';
-import 'package:mocktail/mocktail.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations.graphql.dart';
+import 'package:mm_flutter_app/data/models/base/base_provider.dart';
+import '../base/operation_result.dart';
 
-import 'channel.dart';
-
-class MockChannelProviders extends Mock implements ChannelsProvider {
-  List<Channel> channels = [];
-
-  List<Channel> get channelsList {
-    return channels;
+class MockChannelsProvider extends BaseProvider {
+  MockChannelsProvider({required super.client}) {
+    debugPrint('MockChannelsProvider initialized');
   }
 
-  @override
-  Widget queryUserChannels(
-      {required userId, required onData, onLoading, onError}) {
-    return onData(jsonDecode(
-        """[{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "ujjwal kumar,raghav yadav", "userIds": ["640abd97587f51d992676942", "640ad02455942518a6cdca3e"], "createdBy": "640abd97587f51d992676942", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640ad02455942518a6cdca3e", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992676942", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}}]}]"""));
+  Widget queryUserChannels({
+    required String userId,
+    required Function(dynamic) onData,
+    Function? onLoading,
+    Function? onError,
+  }) {
+    return onData(
+      jsonDecode(
+        """[{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "James McCloud,Slippy Toad", "userIds": ["640abd97587f51d992jh44bb32", "640acf9055942518a6cdca38"], "createdBy": "640abd97587f51d992jh44bb32", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992jh44bb32", "fullName": "James McCloud", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "james"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640acf9055942518a6cdca38", "fullName": "Slippy Toad", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "slippy"}}]}]""",
+      ),
+    );
   }
 
-  @override
-  Widget findChannelByChannelId(
-      {required channelId, required onData, onLoading, onError}) {
-    return onData(jsonDecode(
-        """{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "ujjwal kumar,raghav yadav", "userIds": ["640abd97587f51d992676942", "640ad02455942518a6cdca3e"], "createdBy": "640abd97587f51d992676942", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640ad02455942518a6cdca3e", "fullName": "ujjwal saini", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "ujjwal"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992676942", "fullName": "raghav yadav", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "raghav"}}]}"""));
+  Widget findChannelByChannelId({
+    required String channelId,
+    required Function(dynamic) onData,
+    Function? onLoading,
+    Function? onError,
+  }) {
+    return onData(
+      jsonDecode(
+        """[{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "James McCloud,Slippy Toad", "userIds": ["640abd97587f51d992jh44bb32", "640acf9055942518a6cdca38"], "createdBy": "640abd97587f51d992jh44bb32", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992jh44bb32", "fullName": "James McCloud", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "james"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640acf9055942518a6cdca38", "fullName": "Slippy Toad", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "slippy"}}]}]""",
+      ),
+    );
   }
 
-  @override
-  Future<String> createChannel({required createdBy, required userIds}) async {
+  Widget getInboxInvitations({
+    required Widget Function(
+      OperationResult<Query$GetInboxInvitations$myInbox> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return const SizedBox.shrink();
+  }
+
+  Future<String> createChannel({
+    required String createdBy,
+    required List<String> userIds,
+  }) async {
     return '3';
   }
 }

--- a/lib/data/models/user/user_mock_provider.dart
+++ b/lib/data/models/user/user_mock_provider.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/data/models/base/base_provider.dart';
+// import 'package:mm_flutter_app/utilities/utility.dart';
+// import 'package:shared_preferences/shared_preferences.dart';
+import '../../../__generated/schema/operations.graphql.dart';
+import '../../../__generated/schema/schema.graphql.dart';
+import '../base/operation_result.dart';
+
+typedef AuthenticatedUser = Query$GetAuthenticatedUser$getAuthenticatedUser;
+
+class UserMockProvider extends BaseProvider {
+  AuthenticatedUser? _user;
+
+  UserMockProvider({required client}) : super(client: client);
+
+  void _setUser(AuthenticatedUser authenticatedUser) {
+    if (_user == null) {
+      _user = authenticatedUser;
+      debugPrint('Got this user from the server userId: ${_user!.id}');
+    }
+  }
+
+  // Future<void> _resetUser() async {
+  //   _user = null;
+
+  //   client.resetStore();
+  //   // remove tokens
+  //   final pref = await SharedPreferences.getInstance();
+  //   pref.remove('authToken');
+  //   pref.remove('deviceUuid');
+  // }
+
+  // Future<String> _setDeviceUuid() async {
+  //   final pref = await SharedPreferences.getInstance();
+  //   final deviceUuid = AppUtility.getUuid();
+  //   pref.setString('deviceUuid', deviceUuid);
+  //   return deviceUuid;
+  // }
+
+  AuthenticatedUser? get user {
+    return _user;
+  }
+
+  void setMockUser(AuthenticatedUser user) {
+    _setUser(user);
+  }
+
+  Widget queryUser({
+    required Widget Function(
+      OperationResult<Query$GetAuthenticatedUser$getAuthenticatedUser> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+    bool logFailures = true,
+  }) {
+    // Implement mock behavior for queryUser
+    final mockResult =
+        OperationResult<Query$GetAuthenticatedUser$getAuthenticatedUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryGetAuthenticatedUser),
+      ),
+      response: _user,
+    );
+    return onData(mockResult);
+  }
+
+  Widget queryAllUsers({
+    required Widget Function(
+      OperationResult<List<Query$FindAllUsers$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    final List<Query$FindAllUsers$findUsers> mockData = [
+      Query$FindAllUsers$findUsers(
+        id: '640abd97587f51d992676942',
+        email: 'foxmccloud@example.com',
+        fullName: 'Fox McCloud',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/18.jpg',
+        userHandle: 'fox',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640acf9055942518a6cdca38',
+        email: 'slippytoad@example.com',
+        fullName: 'Slippy Toad',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/78.jpg',
+        userHandle: 'slippy',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640acfd255942518a6cdca3b',
+        email: 'peppyhare@example.com',
+        fullName: 'Peppy Hare',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/75.jpg',
+        userHandle: 'peppy',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640ad02455942518a6cdca3e',
+        email: 'falcolombardi@example.com',
+        fullName: 'Falco Lombardi',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/68.jpg',
+        userHandle: 'falco',
+      ),
+    ];
+
+    final mockResult = OperationResult<List<Query$FindAllUsers$findUsers>>(
+      gqlQueryResult: QueryResult(
+        data: {'data': mockData},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryFindAllUsers),
+      ),
+      response: mockData,
+    );
+    return onData(mockResult);
+  }
+
+  Widget findUsersWithFilter(
+    Input$UserListFilter input, {
+    required Widget Function(
+      OperationResult<List<Query$FindUsersWithFilter$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    final mockResult =
+        OperationResult<List<Query$FindUsersWithFilter$findUsers>>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryFindUsersWithFilter),
+      ),
+      response: [],
+    );
+    return onData(mockResult);
+  }
+
+  Future<OperationResult<Mutation$SignUpUser$signUpUser>> signUpUser(
+      Input$UserSignUpInput input) async {
+    final mockResult = OperationResult<Mutation$SignUpUser$signUpUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignUpUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<Mutation$SignInUser$signInUser>> signInUser(
+    Input$UserSignInInput input,
+  ) async {
+    final mockResult = OperationResult<Mutation$SignInUser$signInUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignInUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> signOutUser() async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignOutUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> updateUserData(Input$UserInput input) async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationUpdateUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> deleteUser() async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationDeleteUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+}

--- a/lib/providers/mock_channels_provider.dart
+++ b/lib/providers/mock_channels_provider.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations_channel.graphql.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/providers/base/operation_result.dart';
+import 'package:mm_flutter_app/providers/channels_provider.dart';
+
+
+class ChannelsMockProvider extends ChannelsProvider {
+  ChannelsMockProvider({required client}) : super(client: client);
+
+  @override
+  Widget queryUserChannels({
+    required String userId,
+    required Widget Function(
+      OperationResult<List<Query$FindChannelsForUser$findChannelsForUser>>
+          data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return onData(
+      jsonDecode(
+        """[{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "James McCloud,Slippy Toad", "userIds": ["640abd97587f51d992jh44bb32", "640acf9055942518a6cdca38"], "createdBy": "640abd97587f51d992jh44bb32", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992jh44bb32", "fullName": "James McCloud", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "james"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640acf9055942518a6cdca38", "fullName": "Slippy Toad", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "slippy"}}]}]""",
+      ),
+    );
+  }
+
+  @override
+  Widget findChannelById({
+    required String channelId,
+    required Widget Function(
+      OperationResult<Query$FindChannelById$findChannelById> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return onData(
+      jsonDecode(
+        """[{"__typename": "Channel", "id": "642bec90b1235682c898803b", "name": "James McCloud,Slippy Toad", "userIds": ["640abd97587f51d992jh44bb32", "640acf9055942518a6cdca38"], "createdBy": "640abd97587f51d992jh44bb32", "createdAt": "2023-04-04T09:23:28.471Z", "participants": [{"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640abd97587f51d992jh44bb32", "fullName": "James McCloud", "avatarUrl": "https://randomuser.me/api/portraits/med/men/68.jpg", "userHandle": "james"}}, {"__typename": "ChannelParticipant", "user": {"__typename": "User", "id": "640acf9055942518a6cdca38", "fullName": "Slippy Toad", "avatarUrl": "https://randomuser.me/api/portraits/med/men/18.jpg", "userHandle": "slippy"}}]}]""",
+      ),
+    );
+  }
+
+  @override
+  Widget getInboxInvitations({
+    required Widget Function(
+      OperationResult<Query$GetInboxInvitations$myInbox> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return Container();
+  }
+
+  @override
+  Future<OperationResult<Mutation$CreateChannel$createChannel>> createChannel({
+    required Input$ChannelInput input,
+  }) async {
+    return OperationResult(
+      gqlQueryResult: QueryResult(
+          data: null,
+          source: QueryResultSource.network,
+          options: QueryOptions(document: gql(''))),
+      response: null,
+    );
+  }
+
+  @override
+  Future<OperationResult<String>> deleteChannel({
+    required bool deletePhysically,
+    required String channelId,
+  }) async {
+    return OperationResult(
+      gqlQueryResult: QueryResult(
+          data: null,
+          source: QueryResultSource.network,
+          options: QueryOptions(document: gql(''))),
+      response: null,
+    );
+  }
+}

--- a/lib/providers/user_mock_provider.dart
+++ b/lib/providers/user_mock_provider.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations_user.graphql.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/providers/base/base_provider.dart';
+import 'package:mm_flutter_app/providers/base/operation_result.dart';
+
+typedef AuthenticatedUser = Query$GetAuthenticatedUser$getAuthenticatedUser;
+
+class UserMockProvider extends BaseProvider {
+  AuthenticatedUser? _user;
+
+  UserMockProvider({required client}) : super(client: client);
+
+  void _setUser(AuthenticatedUser authenticatedUser) {
+    if (_user == null) {
+      _user = authenticatedUser;
+      debugPrint('Got this user from the server userId: ${_user!.id}');
+    }
+  }
+
+  // Future<void> _resetUser() async {
+  //   _user = null;
+
+  //   client.resetStore();
+  //   // remove tokens
+  //   final pref = await SharedPreferences.getInstance();
+  //   pref.remove('authToken');
+  //   pref.remove('deviceUuid');
+  // }
+
+  // Future<String> _setDeviceUuid() async {
+  //   final pref = await SharedPreferences.getInstance();
+  //   final deviceUuid = AppUtility.getUuid();
+  //   pref.setString('deviceUuid', deviceUuid);
+  //   return deviceUuid;
+  // }
+
+  AuthenticatedUser? get user {
+    return _user;
+  }
+
+  void setMockUser(AuthenticatedUser user) {
+    _setUser(user);
+  }
+
+  Widget queryUser({
+    required Widget Function(
+      OperationResult<Query$GetAuthenticatedUser$getAuthenticatedUser> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+    bool logFailures = true,
+  }) {
+    // Implement mock behavior for queryUser
+    final mockResult =
+        OperationResult<Query$GetAuthenticatedUser$getAuthenticatedUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryGetAuthenticatedUser),
+      ),
+      response: _user,
+    );
+    return onData(mockResult);
+  }
+
+  Widget queryAllUsers({
+    required Widget Function(
+      OperationResult<List<Query$FindAllUsers$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    final List<Query$FindAllUsers$findUsers> mockData = [
+      Query$FindAllUsers$findUsers(
+        id: '640abd97587f51d992676942',
+        email: 'foxmccloud@example.com',
+        fullName: 'Fox McCloud',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/18.jpg',
+        userHandle: 'fox',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640acf9055942518a6cdca38',
+        email: 'slippytoad@example.com',
+        fullName: 'Slippy Toad',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/78.jpg',
+        userHandle: 'slippy',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640acfd255942518a6cdca3b',
+        email: 'peppyhare@example.com',
+        fullName: 'Peppy Hare',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/75.jpg',
+        userHandle: 'peppy',
+      ),
+      Query$FindAllUsers$findUsers(
+        id: '640ad02455942518a6cdca3e',
+        email: 'falcolombardi@example.com',
+        fullName: 'Falco Lombardi',
+        avatarUrl: 'https://randomuser.me/api/portraits/med/men/68.jpg',
+        userHandle: 'falco',
+      ),
+    ];
+
+    final mockResult = OperationResult<List<Query$FindAllUsers$findUsers>>(
+      gqlQueryResult: QueryResult(
+        data: {'data': mockData},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryFindAllUsers),
+      ),
+      response: mockData,
+    );
+    return onData(mockResult);
+  }
+
+  Widget findUsersWithFilter(
+    Input$UserListFilter input, {
+    required Widget Function(
+      OperationResult<List<Query$FindUsersWithFilter$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    final mockResult =
+        OperationResult<List<Query$FindUsersWithFilter$findUsers>>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: QueryOptions(document: documentNodeQueryFindUsersWithFilter),
+      ),
+      response: [],
+    );
+    return onData(mockResult);
+  }
+
+  Future<OperationResult<Mutation$SignUpUser$signUpUser>> signUpUser(
+      Input$UserSignUpInput input) async {
+    final mockResult = OperationResult<Mutation$SignUpUser$signUpUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignUpUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<Mutation$SignInUser$signInUser>> signInUser(
+    Input$UserSignInInput input,
+  ) async {
+    final mockResult = OperationResult<Mutation$SignInUser$signInUser>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignInUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> signOutUser() async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationSignOutUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> updateUserData(Input$UserInput input) async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationUpdateUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+
+  Future<OperationResult<void>> deleteUser() async {
+    final mockResult = OperationResult<void>(
+      gqlQueryResult: QueryResult(
+        data: {'data': ''},
+        source: QueryResultSource.network,
+        options: MutationOptions(document: documentNodeMutationDeleteUser),
+      ),
+      response: null,
+    );
+    return mockResult;
+  }
+}

--- a/lib/storybook/stories/atom_stories.dart
+++ b/lib/storybook/stories/atom_stories.dart
@@ -87,15 +87,11 @@ List<Story> atomStories(UserMockProvider mockUserProvider) {
       name: 'widgets/atoms/mentor card',
       description: 'a Mentor profile card',
       builder: (context) => Center(
-        child: Column(
-          children: [
-            MentorCard(
-              mentorName: mockUserProvider.user!.fullName!,
-              avatarUrl: mockUserProvider.user!.avatarUrl!,
-              mentorBio: 'The ace pilot of the Star Fox team',
-              mentorSkill: const ['marketing', 'barrel rolls'],
-            ),
-          ],
+        child: MentorCard(
+          mentorName: mockUserProvider.user!.fullName!,
+          avatarUrl: mockUserProvider.user!.avatarUrl!,
+          mentorBio: 'The ace pilot of the Star Fox team',
+          mentorSkill: const ['marketing', 'barrel rolls'],
         ),
       ),
     ),

--- a/lib/storybook/stories/atom_stories.dart
+++ b/lib/storybook/stories/atom_stories.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/providers/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/atoms/app_wrapper.dart';
+import 'package:mm_flutter_app/widgets/atoms/invitation_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/loading.dart';
+import 'package:mm_flutter_app/widgets/atoms/mentor_card.dart';
+import 'package:mm_flutter_app/widgets/atoms/profile_chip.dart';
+import 'package:mm_flutter_app/widgets/atoms/profile_header.dart';
+import 'package:mm_flutter_app/widgets/atoms/reminder_banner.dart';
+import 'package:mm_flutter_app/widgets/atoms/section_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/server_error.dart';
+import 'package:mm_flutter_app/widgets/atoms/skill_chip.dart';
+import 'package:mm_flutter_app/widgets/atoms/text_form_field_widget.dart';
+import 'package:mm_flutter_app/widgets/atoms/tune_icon.dart';
+
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+const generatedAvatarUrl = 'https://thispersondoesnotexist.com/';
+
+String _getGreeting(AppLocalizations l10n, String? fullName) {
+  int hour = DateTime.now().hour;
+  String timeOfDayGreeting;
+  if (hour >= 5 && hour < 12) {
+    timeOfDayGreeting = l10n.homeGreetingMorning;
+  } else if (hour >= 12 && hour < 18) {
+    timeOfDayGreeting = l10n.homeGreetingAfternoon;
+  } else {
+    timeOfDayGreeting = l10n.homeGreetingEvening;
+  }
+  return fullName != null ? '$timeOfDayGreeting, $fullName' : timeOfDayGreeting;
+}
+
+List<Story> atomStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/atoms/app wrapper',
+      description: 'the frame',
+      builder: (context) => const Center(
+          child: AppWrapper(
+        child: Text('asd'),
+      )),
+    ),
+    Story(
+      name: 'widgets/atoms/loading',
+      description: 'the loading animation',
+      builder: (context) => const Center(child: Loading()),
+    ),
+    Story(
+      name: 'widgets/atoms/invitation tile',
+      description: 'a User connection tile',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            InvitationTile(
+              userName: mockUserProvider.user!.fullName!,
+              userJobTitle: 'Pilot',
+              invitationStatus: context.knobs.options(
+                  label: 'status',
+                  initial: Enum$ChannelInvitationStatus.created,
+                  options: [
+                    const Option(
+                        label: 'created',
+                        value: Enum$ChannelInvitationStatus.created),
+                    const Option(
+                        label: 'accepted',
+                        value: Enum$ChannelInvitationStatus.accepted),
+                    const Option(
+                        label: 'declined',
+                        value: Enum$ChannelInvitationStatus.declined),
+                    const Option(
+                        label: 'unset',
+                        value: Enum$ChannelInvitationStatus.unset),
+                    const Option(
+                        label: 'unknown',
+                        value: Enum$ChannelInvitationStatus.$unknown),
+                  ]),
+              avatarUrl: mockUserProvider.user?.avatarUrl,
+              buttonOnPressed: () => {},
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/mentor card',
+      description: 'a Mentor profile card',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            MentorCard(
+              mentorName: mockUserProvider.user!.fullName!,
+              avatarUrl: mockUserProvider.user!.avatarUrl!,
+              mentorBio: 'The ace pilot of the Star Fox team',
+              mentorSkill: const ['marketing', 'barrel rolls'],
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/profile chip',
+      description: 'a badge indicating type',
+      builder: (context) => Center(
+        child: ProfileChip(
+          text: context.knobs.text(label: 'text', initial: 'Idea'),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/profile header',
+      description: 'includes the salutation',
+      builder: (context) {
+        final AppLocalizations l10n = AppLocalizations.of(context)!;
+        return Center(
+            child: ProfileHeader(
+          avatarUrl: context.knobs.boolean(
+            label: 'include media',
+            initial: true,
+          )
+              ? 'https://thispersondoesnotexist.com/'
+              : null,
+          profileMessage: _getGreeting(l10n, mockUserProvider.user!.fullName),
+          profileCompletionPercentage: context.knobs.nullable.sliderInt(
+            label: 'profile completion',
+            initial: 1,
+          ),
+        ));
+      },
+    ),
+    Story(
+      name: 'widgets/atoms/reminder banner',
+      description: 'a call to action banner',
+      builder: (context) => Center(
+        child: ReminderBanner(
+          titleText: context.knobs.text(
+            label: 'title',
+            initial: "Complete your profile",
+          ),
+          subtitleText: context.knobs.text(
+              label: 'subtitle',
+              initial:
+                  "Did you know that profiles with an avatar image are 60% more likely to connect?"),
+          ctaText: context.knobs.text(
+            label: 'cta',
+            initial: "Complete",
+          ),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/section tile',
+      description: 'tile section header',
+      builder: (context) => Center(
+        child: SectionTile(
+          title: 'section title',
+          child: Column(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.grey,
+                    style: BorderStyle.solid,
+                  ),
+                ),
+                margin: const EdgeInsets.all(10.0),
+                height: 100,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/server error',
+      description: 'the default messaging',
+      builder: ((context) => Center(
+            child: ServerError(
+              error: context.knobs.text(
+                label: 'text',
+                initial: 'An unexpected error has occured!',
+              ),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/atoms/skill chip',
+      description: 'a skill badge',
+      builder: (context) => const Center(
+        child: SkillChip(
+          skill: 'Marketing',
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/text form field',
+      description: 'a generic text input',
+      builder: (context) => Center(
+        child: TextFormFieldWidget(
+          label: context.knobs.text(label: 'label', initial: 'First Name'),
+          obscureText:
+              context.knobs.boolean(label: 'obfuscate', initial: false),
+          onPressed: () {},
+          textController: null,
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/tune icon',
+      description: 'with filter overlay',
+      builder: (context) => const Center(
+        child: TuneIcon(),
+      ),
+    ),
+  ];
+}

--- a/lib/storybook/stories/atom_stories.dart
+++ b/lib/storybook/stories/atom_stories.dart
@@ -1,0 +1,312 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/data/models/user/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/atoms/app_wrapper.dart';
+import 'package:mm_flutter_app/widgets/atoms/invitation_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/loading.dart';
+import 'package:mm_flutter_app/widgets/atoms/mentor_card.dart';
+// import 'package:mm_flutter_app/widgets/atoms/match_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/mentor_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/profile_header.dart';
+import 'package:mm_flutter_app/widgets/atoms/rectangle_button.dart';
+import 'package:mm_flutter_app/widgets/atoms/reminder_banner.dart';
+import 'package:mm_flutter_app/widgets/atoms/resource_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/section_tile.dart';
+import 'package:mm_flutter_app/widgets/atoms/server_error.dart';
+import 'package:mm_flutter_app/widgets/atoms/text_form_field_widget.dart';
+import 'package:mm_flutter_app/widgets/atoms/tune_icon.dart';
+import 'package:mm_flutter_app/widgets/atoms/user_search_bar.dart';
+
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+const generatedAvatarUrl = 'https://thispersondoesnotexist.com/';
+
+String _getGreeting(AppLocalizations l10n, String? fullName) {
+  int hour = DateTime.now().hour;
+  String timeOfDayGreeting;
+  if (hour >= 5 && hour < 12) {
+    timeOfDayGreeting = l10n.homeGreetingMorning;
+  } else if (hour >= 12 && hour < 18) {
+    timeOfDayGreeting = l10n.homeGreetingAfternoon;
+  } else {
+    timeOfDayGreeting = l10n.homeGreetingEvening;
+  }
+  return fullName != null ? '$timeOfDayGreeting, $fullName' : timeOfDayGreeting;
+}
+
+List<Story> atomStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/atoms/app wrapper',
+      description: 'the frame',
+      builder: (context) => const Center(
+          child: AppWrapper(
+        child: Text('asd'),
+      )),
+    ),
+    Story(
+      name: 'widgets/atoms/loading',
+      description: 'the loading animation',
+      builder: (context) => const Center(child: Loading()),
+    ),
+    Story(
+      name: 'widgets/atoms/invitation tile',
+      description: 'a User connection tile',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            InvitationTile(
+              userName: mockUserProvider.user!.fullName!,
+              userJobTitle: 'Pilot',
+              invitationStatus: context.knobs.options(
+                  label: 'status',
+                  initial: Enum$ChannelInvitationStatus.created,
+                  options: [
+                    const Option(
+                        label: 'created',
+                        value: Enum$ChannelInvitationStatus.created),
+                    const Option(
+                        label: 'accepted',
+                        value: Enum$ChannelInvitationStatus.accepted),
+                    const Option(
+                        label: 'declined',
+                        value: Enum$ChannelInvitationStatus.declined),
+                    const Option(
+                        label: 'unset',
+                        value: Enum$ChannelInvitationStatus.unset),
+                    const Option(
+                        label: 'unknown',
+                        value: Enum$ChannelInvitationStatus.$unknown),
+                  ]),
+              // userLocation: 'Pallet Town, Kanto',
+              avatarUrl: mockUserProvider.user?.avatarUrl,
+              // buttonText:
+              //     context.knobs.text(label: 'button label', initial: 'Connect'),
+              buttonOnPressed: () => {},
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/mentor card',
+      description: 'a Mentor profile card',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            MentorCard(
+              mentorName: mockUserProvider.user!.fullName!,
+              avatarUrl: mockUserProvider.user!.avatarUrl!,
+              mentorBio: 'The ace pilot of the Star Fox team',
+              mentorSkill: const ['marketing', 'barrel rolls'],
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/mentor tile',
+      description: 'a Mentor tile',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            MentorTile(
+              avatarUrl: mockUserProvider.user!.avatarUrl!,
+              mentorName: mockUserProvider.user!.fullName!,
+              mentorLocation: 'Bend, OR',
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/profile header',
+      description: 'includes the salutation',
+      builder: (context) {
+        final AppLocalizations l10n = AppLocalizations.of(context)!;
+        return Center(
+            child: ProfileHeader(
+          avatarUrl: context.knobs.boolean(
+            label: 'include media',
+            initial: true,
+          )
+              ? 'https://thispersondoesnotexist.com/'
+              : null,
+          profileMessage: _getGreeting(l10n, mockUserProvider.user!.fullName),
+          profileCompletionPercentage: context.knobs.nullable.sliderInt(
+            label: 'profile completion',
+            initial: 1,
+          ),
+        ));
+      },
+    ),
+    Story(
+      name: 'widgets/atoms/rectangle button',
+      description: 'a generic button',
+      builder: (context) => Center(
+        child: RectangleButton(
+          text: context.knobs.text(label: 'text', initial: 'connect'),
+          onPressed: () {},
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/reminder banner',
+      description: 'a call to action banner',
+      builder: (context) => Center(
+        child: ReminderBanner(
+          titleText: context.knobs.text(
+            label: 'title',
+            initial: "Complete your profile",
+          ),
+          subtitleText: context.knobs.text(
+              label: 'subtitle',
+              initial:
+                  "Did you know that profiles with an avatar image are 60% more likely to connect?"),
+          ctaText: context.knobs.text(
+            label: 'cta',
+            initial: "Complete",
+          ),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/resource tile',
+      description: 'a content tile',
+      builder: (context) => Center(
+        child: Column(
+          children: [
+            ResourceTile(
+              icon: context.knobs.options(
+                  label: 'icon',
+                  initial: context.knobs.options(
+                      label: 'icon',
+                      initial: const Icon(Icons.school_outlined)),
+                  options: [
+                    const Option(
+                      label: 'none',
+                      value: Icon(
+                        Icons.school_outlined,
+                      ),
+                    ),
+                  ]),
+              text: context.knobs.text(
+                label: 'text',
+                initial: 'Mentoring 101',
+              ),
+              onPress: () {},
+            ),
+          ],
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/searchbar',
+      description: 'for general use',
+      builder: (context) => Center(
+        child: SearchBar(
+          hintText: context.knobs.text(
+            label: 'hint',
+            initial: 'what are you looking for?',
+          ),
+          // leading: const Icon(Icons.search),
+          leading: context.knobs.options(
+            label: 'leading icon',
+            initial: const Icon(Icons.search),
+            options: [
+              const Option(
+                label: 'none',
+                value: null,
+              ),
+              const Option(
+                label: 'magnifying glass',
+                value: Icon(Icons.search),
+              )
+            ],
+          ),
+          trailing: context.knobs.options(
+            label: 'trailing icon',
+            initial: [],
+            options: [
+              const Option(
+                label: 'none',
+                value: [],
+              ),
+              const Option(
+                label: 'mic',
+                value: [
+                  Icon(Icons.mic),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/section tile',
+      description: 'tile section header',
+      builder: (context) => Center(
+        child: SectionTile(
+          title: 'section title',
+          child: Column(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                    border: Border.all(
+                        color: Colors.grey, style: BorderStyle.solid)),
+                margin: const EdgeInsets.all(10.0),
+                height: 100,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/server error',
+      description: 'the default messaging',
+      builder: ((context) => Center(
+            child: ServerError(
+              error: context.knobs.text(
+                label: 'text',
+                initial: 'An unexpected error has occured!',
+              ),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/atoms/text form field',
+      description: 'a generic text input',
+      builder: (context) => Center(
+        child: TextFormFieldWidget(
+          label: context.knobs.text(label: 'label', initial: 'First Name'),
+          obscureText:
+              context.knobs.boolean(label: 'obfuscate', initial: false),
+          onPressed: () {},
+          textController: null,
+        ),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/tune icon',
+      description: 'with filter overlay',
+      builder: (context) => const Center(
+        child: TuneIcon(),
+      ),
+    ),
+    Story(
+      name: 'widgets/atoms/user search bar',
+      description: 'transitions to header',
+      builder: (context) => Center(
+        child: UserSearchBar(
+          hintText: context.knobs.text(
+            label: 'hint',
+            initial: 'Search',
+          ),
+        ),
+      ),
+    ),
+  ];
+}

--- a/lib/storybook/stories/molecule_stories.dart
+++ b/lib/storybook/stories/molecule_stories.dart
@@ -37,7 +37,10 @@ List<Story> moleculeStories(UserMockProvider mockUserProvider) {
       description: 'main navigation buttons',
       builder: ((context) => Center(
             child: ExploreBottomButtons(
-              selectedCount: 1,
+              selectedCount: context.knobs.sliderInt(
+                label: 'count',
+                initial: 0,
+              ),
               clearAction: () {},
               sendInvitesAction: () {},
             ),
@@ -72,20 +75,21 @@ List<Story> moleculeStories(UserMockProvider mockUserProvider) {
           )),
     ),
     Story(
-      name: 'widgets/molecules/profile quick view card',
-      description: '',
-      builder: (context) => Center(
-        child: ProfileQuickViewCard(
-            userType: UserType.entrepreneur,
-            fullName: mockUserProvider.user!.fullName!,
-            location: 'Lylat System',
-            company: 'Arwing',
-            checkbox: Checkbox(
-              value: false,
-              onChanged: (value) {},
-            )),
-      ),
-    ),
+        name: 'widgets/molecules/profile quick view card',
+        description: 'profile cards for connection selection',
+        builder: (context) {
+          return Center(
+            child: ProfileQuickViewCard(
+              userType: UserType.entrepreneur,
+              fullName: mockUserProvider.user!.fullName!,
+              location: 'Lylat System',
+              company: 'Arwing',
+              checkbox: Checkbox(
+                  value: context.knobs.boolean(label: 'selected', initial: false),
+                  onChanged: (value) {}),
+            ),
+          );
+        }),
     Story(
       name: 'widgets/molecules/rating',
       description: '5 star rating scale',

--- a/lib/storybook/stories/molecule_stories.dart
+++ b/lib/storybook/stories/molecule_stories.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/data/models/user/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/molecules/customized_button.dart';
+import 'package:mm_flutter_app/widgets/molecules/image_tile.dart';
+import 'package:mm_flutter_app/widgets/molecules/mentors_section.dart';
+import 'package:mm_flutter_app/widgets/molecules/profile_image.dart';
+import 'package:mm_flutter_app/widgets/molecules/rating.dart';
+import 'package:mm_flutter_app/widgets/molecules/recommended_mentors_scroll.dart';
+import 'package:mm_flutter_app/widgets/molecules/resources_section.dart';
+import 'package:mm_flutter_app/widgets/molecules/search_container.dart';
+import 'package:mm_flutter_app/widgets/molecules/upcoming_section.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> moleculeStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/molecules/customized button',
+      description: 'an action button',
+      builder: ((context) => Center(
+            child: CustomizedButton(
+              text: context.knobs
+                  .text(label: 'text', initial: 'Find More Mentors'),
+              icon: context.knobs
+                  .options(label: 'icon', initial: Icons.search, options: [
+                const Option(
+                  label: 'search',
+                  value: Icons.search,
+                ),
+              ]),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/image tile',
+      description: 'a tile with an image',
+      builder: ((context) => Center(
+            child: SizedBox(
+              width: double.parse(
+                  context.knobs.text(label: 'width', initial: '200')),
+              height: double.parse(
+                  context.knobs.text(label: 'height', initial: '200')),
+              child: ImageTile(
+                image: const AssetImage(Assets.resourceWebinarStockImage),
+                title: 'Webinar',
+                subtitle: 'Mentoring First Step',
+                isCircle: context.knobs.boolean(
+                  label: 'circular',
+                  initial: false,
+                ),
+              ),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/mentors section',
+      description: 'a panel with mentor tiles',
+      builder: ((context) => const Center(
+            child: MentorsSection(),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/profile image',
+      description: 'a default profile image',
+      builder: ((context) => const Center(
+            child: ProfileImage(),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/rating',
+      description: '5 star rating scale',
+      builder: ((context) => const Center(
+            child: Rating(),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/recommended mentors scroll',
+      description: 'horizontal scroll Mentor profiles',
+      builder: ((context) => const Column(
+            children: [
+              RecommendedMentorsScroll(),
+            ],
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/resources section',
+      description: 'a panel with match tiles',
+      builder: ((context) => const Column(
+            children: [
+              ResourcesSection(),
+            ],
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/search container',
+      description: 'a panel with match tiles',
+      builder: ((context) => Center(
+            child: Column(
+              children: [
+                SearchContainer(
+                  onChanged: (str) {},
+                ),
+              ],
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/upcoming section',
+      description: 'horizontal scroll mentoring sessions',
+      builder: ((context) => const Center(
+            child: UpcomingSection(),
+          )),
+    ),
+  ];
+}

--- a/lib/storybook/stories/molecule_stories.dart
+++ b/lib/storybook/stories/molecule_stories.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/providers/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/molecules/customized_button.dart';
+import 'package:mm_flutter_app/widgets/molecules/explore_bottom_buttons.dart';
+import 'package:mm_flutter_app/widgets/molecules/image_tile.dart';
+import 'package:mm_flutter_app/widgets/molecules/invitation_section.dart';
+import 'package:mm_flutter_app/widgets/molecules/profile_quick_view_card.dart';
+import 'package:mm_flutter_app/widgets/molecules/rating.dart';
+import 'package:mm_flutter_app/widgets/molecules/recommended_mentors_scroll.dart';
+import 'package:mm_flutter_app/widgets/molecules/resources_section.dart';
+import 'package:mm_flutter_app/widgets/molecules/search_container.dart';
+import 'package:mm_flutter_app/widgets/molecules/upcoming_section.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> moleculeStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/molecules/customized button',
+      description: 'an action button',
+      builder: ((context) => Center(
+            child: CustomizedButton(
+              text: context.knobs
+                  .text(label: 'text', initial: 'Find More Mentors'),
+              icon: context.knobs
+                  .options(label: 'icon', initial: Icons.search, options: [
+                const Option(
+                  label: 'search',
+                  value: Icons.search,
+                ),
+              ]),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/explore bottom buttons',
+      description: 'main navigation buttons',
+      builder: ((context) => Center(
+            child: ExploreBottomButtons(
+              selectedCount: 1,
+              clearAction: () {},
+              sendInvitesAction: () {},
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/image tile',
+      description: 'a tile with an image',
+      builder: ((context) => Center(
+            child: SizedBox(
+              width: double.parse(
+                  context.knobs.text(label: 'width', initial: '200')),
+              height: double.parse(
+                  context.knobs.text(label: 'height', initial: '200')),
+              child: ImageTile(
+                image: const AssetImage(Assets.resourceWebinarStockImage),
+                title: 'Webinar',
+                subtitle: 'Mentoring First Step',
+                isCircle: context.knobs.boolean(
+                  label: 'circular',
+                  initial: false,
+                ),
+              ),
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/invitations section',
+      description: '',
+      builder: ((context) => const Center(
+            child: InvitationSection(),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/profile quick view card',
+      description: '',
+      builder: (context) => Center(
+        child: ProfileQuickViewCard(
+            userType: UserType.entrepreneur,
+            fullName: mockUserProvider.user!.fullName!,
+            location: 'Lylat System',
+            company: 'Arwing',
+            checkbox: Checkbox(
+              value: false,
+              onChanged: (value) {},
+            )),
+      ),
+    ),
+    Story(
+      name: 'widgets/molecules/rating',
+      description: '5 star rating scale',
+      builder: ((context) => const Center(
+            child: Rating(),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/recommended mentors scroll',
+      description: 'horizontal scroll Mentor profiles',
+      builder: ((context) => const Column(
+            children: [
+              RecommendedMentorsScroll(),
+            ],
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/resources section',
+      description: 'a panel with match tiles',
+      builder: ((context) => const Column(
+            children: [
+              ResourcesSection(),
+            ],
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/search container',
+      description: 'a panel with match tiles',
+      builder: ((context) => Center(
+            child: Column(
+              children: [
+                SearchContainer(
+                  onChanged: (str) {},
+                ),
+              ],
+            ),
+          )),
+    ),
+    Story(
+      name: 'widgets/molecules/upcoming section',
+      description: 'horizontal scroll mentoring sessions',
+      builder: ((context) => const Center(
+            child: UpcomingSection(),
+          )),
+    ),
+  ];
+}

--- a/lib/storybook/stories/organism_stories.dart
+++ b/lib/storybook/stories/organism_stories.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/data/models/user/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/organisms/user_card.dart';
+import 'package:mm_flutter_app/widgets/organisms/user_expanded_card.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> organismStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/organisms/user card',
+      description: 'a User card',
+      builder: ((context) {
+        return mockUserProvider.queryAllUsers(
+          onLoading: () {
+            return const SizedBox.shrink();
+          },
+          onError: (error, {refetch}) {
+            return Text('Error: $error');
+          },
+          onData: (data, {refetch, fetchMore}) {
+            List users = data.response != null
+                ? data.response!.reversed
+                    .where((element) => element.id != mockUserProvider.user?.id)
+                    .toList()
+                : [];
+
+            return Column(
+              children: [
+                Center(
+                  child: userCard(
+                    users,
+                    context.knobs
+                        .sliderInt(label: 'list index', initial: 0, max: 3),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      }),
+    ),
+    Story(
+      name: 'widgets/organisms/expanded user card',
+      description: 'an expanded User card',
+      builder: ((context) {
+        return mockUserProvider.queryAllUsers(
+          onLoading: () {
+            return const SizedBox.shrink();
+          },
+          onError: (error, {refetch}) {
+            return Text('Error: $error');
+          },
+          onData: (data, {refetch, fetchMore}) {
+            List users = data.response != null
+                ? data.response!.reversed
+                    .where((element) => element.id != mockUserProvider.user?.id)
+                    .toList()
+                : [];
+
+            return Center(
+              child: userExpandedCard(
+                users: users,
+                context: context,
+                index: context.knobs
+                    .sliderInt(label: 'list index', initial: 0, max: 3),
+                onOpenMessage: () {},
+              ),
+            );
+          },
+        );
+      }),
+    ),
+  ];
+}

--- a/lib/storybook/stories/organism_stories.dart
+++ b/lib/storybook/stories/organism_stories.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/providers/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/organisms/user_card.dart';
+import 'package:mm_flutter_app/widgets/organisms/user_expanded_card.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> organismStories(UserMockProvider mockUserProvider) {
+  return [
+    Story(
+      name: 'widgets/organisms/user card',
+      description: 'a User card',
+      builder: ((context) {
+        return mockUserProvider.queryAllUsers(
+          onLoading: () {
+            return const SizedBox.shrink();
+          },
+          onError: (error, {refetch}) {
+            return Text('Error: $error');
+          },
+          onData: (data, {refetch, fetchMore}) {
+            List users = data.response != null
+                ? data.response!.reversed
+                    .where((element) => element.id != mockUserProvider.user?.id)
+                    .toList()
+                : [];
+
+            return Column(
+              children: [
+                Center(
+                  child: userCard(
+                    users,
+                    context.knobs
+                        .sliderInt(label: 'list index', initial: 0, max: 3),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      }),
+    ),
+    Story(
+      name: 'widgets/organisms/expanded user card',
+      description: 'an expanded User card',
+      builder: ((context) {
+        return mockUserProvider.queryAllUsers(
+          onLoading: () {
+            return const SizedBox.shrink();
+          },
+          onError: (error, {refetch}) {
+            return Text('Error: $error');
+          },
+          onData: (data, {refetch, fetchMore}) {
+            List users = data.response != null
+                ? data.response!.reversed
+                    .where((element) => element.id != mockUserProvider.user?.id)
+                    .toList()
+                : [];
+
+            return Center(
+              child: userExpandedCard(
+                users: users,
+                context: context,
+                index: context.knobs
+                    .sliderInt(label: 'list index', initial: 0, max: 3),
+                onOpenMessage: () {},
+              ),
+            );
+          },
+        );
+      }),
+    ),
+  ];
+}

--- a/lib/storybook/stories/screen_stories.dart
+++ b/lib/storybook/stories/screen_stories.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/providers/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/screens/dashboard/dashboard.dart';
+import 'package:mm_flutter_app/widgets/screens/explore/explore.dart';
+import 'package:mm_flutter_app/widgets/screens/home/dialog_and_rating.dart';
+import 'package:mm_flutter_app/widgets/screens/home/home.dart';
+import 'package:mm_flutter_app/widgets/screens/home/users_list.dart';
+import 'package:mm_flutter_app/widgets/screens/home_menu/home_menu.dart';
+import 'package:mm_flutter_app/widgets/screens/messages/messages_list.dart';
+import 'package:mm_flutter_app/widgets/screens/messages/messages_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/about.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/profile_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/your_email.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/your_name.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_in/sign_in_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/user_settings/user_settings.dart';
+import 'package:mm_flutter_app/widgets/screens/welcome/welcome_screen.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> screenStories(UserMockProvider mockUserProvider) {
+  return [
+    // ========== channel messages ==========
+    // Story(
+    //   name: 'screens/channel messages/message bubble',
+    //   description: '',
+    //   builder: (context) {
+    //     return MessageBubble(
+    //       message: Message(
+    //         id: '101',
+    //         createdBy: mockUserProvider.user!.id,
+    //         channelId: '101',
+    //         messageText: context.knobs.text(
+    //           label: 'message text',
+    //           initial: 'This is an example message text. 👍🏻',
+    //         ),
+    //         createdAt: DateTime.now().toString(),
+    //       ),
+    //       participants: const [],
+    //     );
+    //   },
+    // ),
+    // ========== dashboard ==========
+    Story(
+      name: 'screens/dashboard',
+      description: 'the dashboard view',
+      builder: (context) {
+        return const DashboardScreen();
+      },
+    ),
+    // ========== explore ==========
+    Story(
+      name: 'screens/explore/explore',
+      description: 'the explore view',
+      builder: (context) {
+        return const ExploreCardScroll();
+      },
+    ),
+    // ========== home ==========
+    Story(
+      name: 'screens/home/dialog and rating',
+      description: 'the user rating',
+      builder: (context) {
+        return Center(child: rating(4));
+      },
+    ),
+    Story(
+      name: 'screens/home/home',
+      description: 'the home view',
+      builder: (context) {
+        return const HomeScreen();
+      },
+    ),
+    Story(
+      name: 'screens/home/users list',
+      description: 'a list of Users',
+      builder: (context) {
+        return const UsersList(
+          channels: [],
+          search: '',
+        );
+      },
+    ),
+    // ========== home menu ==========
+    Story(
+      name: 'screens/home menu',
+      description: 'the home menu',
+      builder: (context) {
+        return const HomeMenu();
+      },
+    ),
+    // ========== messages ==========
+    Story(
+      name: 'screens/messages/messages list',
+      description: '',
+      builder: (context) {
+        return MessagesList(
+          user: mockUserProvider.user!,
+          channels: const [],
+        );
+      },
+    ),
+    Story(
+      name: 'screens/messages/messages screen',
+      description: '',
+      builder: (context) {
+        return const ChannelsScreen();
+      },
+    ),
+    // ========== profile ==========
+    Story(
+      name: 'screens/profile/about',
+      description: '',
+      builder: (context) {
+        return const About();
+      },
+    ),
+    Story(
+      name: 'screens/profile/profile',
+      description: '',
+      builder: (context) {
+        return const ProfileScreen();
+      },
+    ),
+    Story(
+      name: 'screens/profile/your email',
+      description: '',
+      builder: (context) {
+        return const YourEmail();
+      },
+    ),
+    Story(
+      name: 'screens/profile/your name',
+      description: '',
+      builder: (context) {
+        return YourName();
+      },
+    ),
+    // ========== sign in ==========
+    Story(
+      name: 'screens/sign in',
+      description: '',
+      builder: (context) {
+        return const SignInScreen();
+      },
+    ),
+    // ========== sign up ==========
+    Story(
+      name: 'screens/sign up',
+      description: '',
+      builder: (context) {
+        return const SignUpScreen();
+      },
+    ),
+    // ========== tabs ==========
+    Story(
+      name: 'screens/tab',
+      description: '',
+      builder: (context) {
+        return Tab();
+      },
+    ),
+    // ========== user settings ==========
+    Story(
+      name: 'screens/user settings',
+      description: '',
+      builder: (context) {
+        return const UserSettings();
+      },
+    ),
+    // ========== welcome ==========
+    Story(
+      name: 'screens/welcome',
+      description: '',
+      builder: (context) {
+        return const WelcomeScreen();
+      },
+    ),
+  ];
+}

--- a/lib/storybook/stories/screen_stories.dart
+++ b/lib/storybook/stories/screen_stories.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/data/models/messages/message.dart';
+import 'package:mm_flutter_app/data/models/user/user_mock_provider.dart';
+import 'package:mm_flutter_app/widgets/screens/channel_messages/message_bubble/message_bubble.dart';
+import 'package:mm_flutter_app/widgets/screens/dashboard/dashboard.dart';
+import 'package:mm_flutter_app/widgets/screens/explore/entrepreneurs.dart';
+import 'package:mm_flutter_app/widgets/screens/explore/explore.dart';
+import 'package:mm_flutter_app/widgets/screens/explore/mentors.dart';
+import 'package:mm_flutter_app/widgets/screens/home/dialog_and_rating.dart';
+import 'package:mm_flutter_app/widgets/screens/home/home.dart';
+import 'package:mm_flutter_app/widgets/screens/home/users_list.dart';
+import 'package:mm_flutter_app/widgets/screens/home_menu/home_menu.dart';
+import 'package:mm_flutter_app/widgets/screens/messages/messages_list.dart';
+import 'package:mm_flutter_app/widgets/screens/messages/messages_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/about.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/profile_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/your_email.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/your_name.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_in/sign_in_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_screen.dart';
+import 'package:mm_flutter_app/widgets/screens/user_settings/user_settings.dart';
+import 'package:mm_flutter_app/widgets/screens/welcome/welcome_screen.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+List<Story> screenStories(UserMockProvider mockUserProvider) {
+  return [
+    // ========== channel messages ==========
+    Story(
+      name: 'screens/channel messages/message bubble',
+      description: '',
+      builder: (context) {
+        return MessageBubble(
+          message: Message(
+            id: '101',
+            createdBy: mockUserProvider.user!.id,
+            channelId: '101',
+            messageText: context.knobs.text(
+              label: 'message text',
+              initial: 'This is an example message text. 👍🏻',
+            ),
+            createdAt: DateTime.now().toString(),
+          ),
+          participants: const [],
+        );
+      },
+    ),
+    // ========== dashboard ==========
+    Story(
+      name: 'screens/dashboard',
+      description: 'the dashboard view',
+      builder: (context) {
+        return const DashboardScreen();
+      },
+    ),
+    // ========== explore ==========
+    Story(
+      name: 'screens/explore/explore',
+      description: 'the explore view',
+      builder: (context) {
+        return const Explore();
+      },
+    ),
+    Story(
+      name: 'screens/explore/entrepreneurs',
+      description: 'the entrepreneurs pane of explore',
+      builder: (context) {
+        return const Entrepreneurs();
+      },
+    ),
+    Story(
+      name: 'screens/explore/mentors',
+      description: 'the mentors pane of explore',
+      builder: (context) {
+        return const Mentors();
+      },
+    ),
+    // ========== home ==========
+    Story(
+      name: 'screens/home/dialog and rating',
+      description: 'the user rating',
+      builder: (context) {
+        return Center(child: rating(4));
+      },
+    ),
+    Story(
+      name: 'screens/home/home',
+      description: 'the home view',
+      builder: (context) {
+        return const HomeScreen();
+      },
+    ),
+    Story(
+      name: 'screens/home/users list',
+      description: 'a list of Users',
+      builder: (context) {
+        return const UsersList(
+          channels: [],
+          search: '',
+        );
+        // TODO add channels mock provider
+      },
+    ),
+    // ========== home menu ==========
+    Story(
+      name: 'screens/home menu',
+      description: 'the home menu',
+      builder: (context) {
+        return const HomeMenu();
+      },
+    ),
+    // ========== messages ==========
+    Story(
+      name: 'screens/messages/messages list',
+      description: '',
+      builder: (context) {
+        return MessagesList(
+          user: mockUserProvider.user!,
+          channels: const [],
+        );
+      },
+    ),
+    Story(
+      name: 'screens/messages/messages screen',
+      description: '',
+      builder: (context) {
+        return const ChannelsScreen();
+      },
+    ),
+    // ========== profile ==========
+    Story(
+      name: 'screens/profile/about',
+      description: '',
+      builder: (context) {
+        return const About();
+      },
+    ),
+    Story(
+      name: 'screens/profile/profile',
+      description: '',
+      builder: (context) {
+        return const ProfileScreen();
+      },
+    ),
+    Story(
+      name: 'screens/profile/your email',
+      description: '',
+      builder: (context) {
+        return const YourEmail();
+      },
+    ),
+    Story(
+      name: 'screens/profile/your name',
+      description: '',
+      builder: (context) {
+        return YourName();
+      },
+    ),
+    // ========== sign in ==========
+    Story(
+      name: 'screens/sign in',
+      description: '',
+      builder: (context) {
+        return const SignInScreen();
+      },
+    ),
+    // ========== sign up ==========
+    Story(
+      name: 'screens/sign up',
+      description: '',
+      builder: (context) {
+        return const SignUpScreen();
+      },
+    ),
+    // ========== tabs ==========
+    Story(
+      name: 'screens/tab',
+      description: '',
+      builder: (context) {
+        return Tab();
+      },
+    ),
+    // ========== user settings ==========
+    Story(
+      name: 'screens/user settings',
+      description: '',
+      builder: (context) {
+        return const UserSettings();
+      },
+    ),
+    // ========== welcome ==========
+    Story(
+      name: 'screens/welcome',
+      description: '',
+      builder: (context) {
+        return const WelcomeScreen();
+      },
+    ),
+  ];
+}

--- a/lib/storybook/storybook.dart
+++ b/lib/storybook/storybook.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/data/models/channels/mock_channels_provider.dart';
+import 'package:mm_flutter_app/data/models/user/user_mock_provider.dart';
+import 'package:mm_flutter_app/storybook/stories/atom_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/molecule_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/organism_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/screen_stories.dart';
+
+import 'package:provider/provider.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+void main() => runApp(StorybookApp());
+
+DeviceFrameData defaultDeviceFrameData = DeviceFrameData(
+  isFrameVisible: true,
+  device: Devices.android.bigPhone,
+  orientation: Orientation.portrait,
+);
+
+final _plugins = initializePlugins(
+  contentsSidePanel: true,
+  knobsSidePanel: true,
+  initialDeviceFrameData: defaultDeviceFrameData,
+);
+
+final HttpLink httpLink = HttpLink(
+  'https://mock-storybook-url.com/graphql',
+);
+
+final AuthLink authLink = AuthLink(
+  getToken: () async {
+    return 'abcdefghij';
+  },
+);
+
+final Link link = authLink.concat(httpLink);
+
+class StorybookApp extends StatelessWidget {
+  StorybookApp({Key? key}) : super(key: key);
+  final UserMockProvider mockUserProvider = UserMockProvider(
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+  );
+  final MockChannelsProvider mockChannelProvider = MockChannelsProvider(
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+  );
+
+  Widget sbWrapper(BuildContext _, Widget? child) {
+    final defaultMockedUser = AuthenticatedUser(
+      id: '640abd97587f51d992jh44bb32',
+      userHandle: 'james',
+      fullName: 'James McCloud',
+      avatarUrl: 'https://thispersondoesnotexist.com/',
+      email: 'james@example.com',
+      profileCompletionPercentage: 65,
+    );
+    mockUserProvider.setMockUser(defaultMockedUser);
+
+    // TODO: The App Frame requires Go Router in the context
+    // final GoRouter router = GoRouter(initialLocation: '/', routes: [
+    //   GoRoute(
+    //     path: '/',
+    //     builder: (BuildContext context, GoRouterState state) {
+    //       return const StartScreen();
+    //     },
+    //   ),
+    // ]);
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<UserMockProvider>.value(
+          value: mockUserProvider,
+        ),
+        ChangeNotifierProvider<MockChannelsProvider>.value(
+          value: mockChannelProvider,
+        ),
+      ],
+      child: MaterialApp(
+        // routerConfig: router,
+        title: "MicroMentor",
+        debugShowCheckedModeBanner: false,
+        theme: AppThemes.light(),
+        darkTheme: AppThemes.dark(),
+        home: Scaffold(
+          body: child,
+        ),
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Storybook(
+        initialStory: 'widgets/atoms/profile header',
+        showPanel: true,
+        plugins: _plugins,
+        wrapperBuilder: sbWrapper,
+        stories: [
+          ...atomStories(mockUserProvider),
+          ...moleculeStories(mockUserProvider),
+          ...organismStories(mockUserProvider),
+          ...screenStories(mockUserProvider),
+        ],
+      );
+}

--- a/lib/storybook/storybook.dart
+++ b/lib/storybook/storybook.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/providers/mock_channels_provider.dart';
+import 'package:mm_flutter_app/providers/user_mock_provider.dart';
+import 'package:mm_flutter_app/storybook/stories/atom_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/molecule_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/organism_stories.dart';
+import 'package:mm_flutter_app/storybook/stories/screen_stories.dart';
+
+import 'package:provider/provider.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+void main() => runApp(StorybookApp());
+
+DeviceFrameData defaultDeviceFrameData = DeviceFrameData(
+  isFrameVisible: true,
+  device: Devices.android.bigPhone,
+  orientation: Orientation.portrait,
+);
+
+final _plugins = initializePlugins(
+  contentsSidePanel: true,
+  knobsSidePanel: true,
+  initialDeviceFrameData: defaultDeviceFrameData,
+);
+
+final HttpLink httpLink = HttpLink(
+  'https://mock-storybook-url.com/graphql',
+);
+
+final AuthLink authLink = AuthLink(
+  getToken: () async {
+    return 'abcdefghij';
+  },
+);
+
+final Link link = authLink.concat(httpLink);
+
+class StorybookApp extends StatelessWidget {
+  StorybookApp({Key? key}) : super(key: key);
+  final UserMockProvider mockUserProvider = UserMockProvider(
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+  );
+  final ChannelsMockProvider mockChannelProvider = ChannelsMockProvider(
+    client: GraphQLClient(
+      link: link,
+      cache: GraphQLCache(store: InMemoryStore()),
+    ),
+  );
+
+  Widget sbWrapper(BuildContext _, Widget? child) {
+    final defaultMockedUser = AuthenticatedUser(
+      id: '640abd97587f51d992jh44bb32',
+      userHandle: 'james',
+      fullName: 'James McCloud',
+      avatarUrl: 'https://thispersondoesnotexist.com/',
+      email: 'james@example.com',
+      profileCompletionPercentage: 65,
+    );
+    mockUserProvider.setMockUser(defaultMockedUser);
+
+    // TODO: The App Frame requires Go Router in the context
+    // final GoRouter router = GoRouter(initialLocation: '/', routes: [
+    //   GoRoute(
+    //     path: '/',
+    //     builder: (BuildContext context, GoRouterState state) {
+    //       return const StartScreen();
+    //     },
+    //   ),
+    // ]);
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<UserMockProvider>.value(
+          value: mockUserProvider,
+        ),
+        ChangeNotifierProvider<ChannelsMockProvider>.value(
+          value: mockChannelProvider,
+        ),
+      ],
+      child: MaterialApp(
+        // routerConfig: router,
+        title: "MicroMentor",
+        debugShowCheckedModeBanner: false,
+        theme: AppThemes.light(),
+        darkTheme: AppThemes.dark(),
+        home: Scaffold(
+          body: child,
+        ),
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Storybook(
+        initialStory: 'widgets/atoms/profile header',
+        showPanel: true,
+        plugins: _plugins,
+        wrapperBuilder: sbWrapper,
+        stories: [
+          ...atomStories(mockUserProvider),
+          ...moleculeStories(mockUserProvider),
+          ...organismStories(mockUserProvider),
+          ...screenStories(mockUserProvider),
+        ],
+      );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.8"
+  device_frame:
+    dependency: transitive
+    description:
+      name: device_frame
+      sha256: afe76182aec178d171953d9b4a50a43c57c7cf3c77d8b09a48bf30c8fa04dd9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   dio:
     dependency: "direct main"
     description:
@@ -434,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.4.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -884,6 +900,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  pointer_interceptor:
+    dependency: transitive
+    description:
+      name: pointer_interceptor
+      sha256: "6aa680b30d96dccef496933d00208ad25f07e047f644dc98ce03ec6141633a9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   pointycastle:
     dependency: transitive
     description:
@@ -1081,6 +1105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  storybook_flutter:
+    dependency: "direct main"
+    description:
+      name: storybook_flutter
+      sha256: "0ef97a82741e12734af3c104ef6c913af1ed808756214d23bff2bd115e547887"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   retry: ^3.1.2
   flutter_localizations:
     sdk: flutter
+  storybook_flutter: ^0.12.0
 
 
 dev_dependencies:
@@ -78,9 +79,6 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   analyzer: ^5.0.0
-  # widgetbook: ^2.4.1
-  # widgetbook_annotation: ^2.1.0
-  # widgetbook_generator: ^2.4.1
   build_runner: ^2.3.3
   flutter_launcher_icons: ^0.13.0
 


### PR DESCRIPTION
Stands up [storybook_flutter](https://pub.dev/packages/storybook_flutter) and two refactored MockProviders to support this. In `storybook.dart`, the `main` function can be run to spin up the UI showcase. Here, the large majority of widgets are covered and available to be interacted with. This was a great exercise to get back up to speed with the Flutter side of things, but there are a few bridges left to cross that will see updates as I work in other places in the source.

Some challenges:
- RTL is not officially supported. There's some documentation on extending the functionality to support "global" knobs, but this will be a phase 2 exercise when I've got some more time to work on this.
- Global knobs: There are a few already (dark/light, device and orientation) but there should be a few more like `theme` and `localization`
- Passing the providers to permeate each level of the widget. I'm having trouble with partially rendering most screen widgets, in that the frame is there but the content is not able to access the provider and throws an error.

To do in next phase:
- [ ] Solve the provider issues for the screen stories
- [ ] Mock Messages provider
- [ ] Implement routing
- [ ] Implement more global knobs
- [ ] Host this independently so it's accessible to the _rest_ of the Team (?)