### PR TITLE
Add name parameter to the routes

### DIFF
--- a/lib/constants/routes.dart
+++ b/lib/constants/routes.dart
@@ -1,24 +1,38 @@
 part of 'app_constants.dart';
 
+class Route {
+  final String name;
+  final String path;
+
+  Route({required this.name, required this.path});
+}
+
 class Routes {
   Routes._private();
-  static const String root = '/';
-  static const String signin = '/signin';
-  static const String signup = '/signup';
-  static const String loading = '/loading';
-  static const String home = '/home';
-  static const String explore = '/explore';
-  static const String exploreInviteToConnect = '$explore/connect';
-  static const String progress = '/progress';
-  static const String inbox = '/inbox';
-  static const String inboxChats = '$inbox/chats';
-  static const String inboxChats$ChannelId =
-      '$inboxChats/:${RouteParams.channelId}';
-  static const String inboxInvites = '$inbox/invites';
-  static const String inboxInvitesReceived = '$inboxInvites/received';
-  static const String inboxInvitesSent = '$inboxInvites/sent';
-  static const String inboxArchived = '$inbox/archived';
-  static const String profile = '/profile';
+  static Route root = Route(name: 'root', path: '/');
+  static Route signin = Route(name: 'signin', path: '/signin');
+  static Route signup = Route(name: 'signup', path: '/signup');
+  static Route loading = Route(name: 'loading', path: '/loading');
+  static Route home = Route(name: 'home', path: '/home');
+  static Route explore = Route(name: 'explore', path: '/explore');
+  static Route exploreInviteToConnect =
+      Route(name: 'exploreInviteToConnect', path: '${explore.path}/connect');
+  static Route progress = Route(name: 'progress', path: '/progress');
+  static Route inbox = Route(name: 'inbox', path: '/inbox');
+  static Route inboxChats =
+      Route(name: 'inboxChats', path: '${inbox.path}/chats');
+  static Route inboxChatsChannelId = Route(
+      name: 'inboxChatsChannelId',
+      path: '${inboxChats.path}/:${RouteParams.channelId}');
+  static Route inboxInvites =
+      Route(name: 'inboxInvites', path: '${inbox.path}/invites');
+  static Route inboxInvitesReceived = Route(
+      name: 'inboxInvitesReceived', path: '${inboxInvites.path}/received');
+  static Route inboxInvitesSent =
+      Route(name: 'inboxInvitesSent', path: '${inboxInvites.path}/sent');
+  static Route inboxArchived =
+      Route(name: 'inboxArchived', path: '${inbox.path}/archived');
+  static Route profile = Route(name: 'profile', path: '/profile');
 }
 
 class RouteParams {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,7 +56,7 @@ class StartScreen extends StatelessWidget {
       },
       onData: (data, {refetch, fetchMore}) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          context.go(Routes.home);
+          context.go(Routes.home.path);
         });
 
         return const LoadingScreen();

--- a/lib/utilities/router.dart
+++ b/lib/utilities/router.dart
@@ -24,10 +24,11 @@ class AppRouter {
 
   static GoRouter createRouter(BuildContext context) {
     return GoRouter(
-      initialLocation: Routes.root,
+      initialLocation: Routes.root.path,
       routes: [
         GoRoute(
-          path: Routes.root,
+          path: Routes.root.path,
+          name: Routes.root.name,
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
@@ -36,7 +37,8 @@ class AppRouter {
           },
         ),
         GoRoute(
-          path: Routes.signin,
+          path: Routes.signin.path,
+          name: Routes.signin.name,
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
@@ -45,7 +47,8 @@ class AppRouter {
           },
         ),
         GoRoute(
-            path: Routes.signup,
+            path: Routes.signup.path,
+            name: Routes.signup.name,
             pageBuilder: (BuildContext context, GoRouterState state) {
               return MaterialPage(
                 key: state.pageKey,
@@ -53,7 +56,8 @@ class AppRouter {
               );
             }),
         GoRoute(
-          path: Routes.loading,
+          path: Routes.loading.path,
+          name: Routes.loading.name,
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
@@ -71,7 +75,8 @@ class AppRouter {
           },
           routes: <RouteBase>[
             GoRoute(
-              path: Routes.home,
+              path: Routes.home.path,
+              name: Routes.home.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -80,7 +85,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.explore,
+              path: Routes.explore.path,
+              name: Routes.explore.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -89,7 +95,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-                path: Routes.exploreInviteToConnect,
+                path: Routes.exploreInviteToConnect.path,
+                name: Routes.exploreInviteToConnect.name,
                 builder: (BuildContext context, GoRouterState state) {
                   List<ProfileQuickViewInfo> selectedProfiles =
                       state.extra as List<ProfileQuickViewInfo>;
@@ -98,7 +105,8 @@ class AppRouter {
                   );
                 }),
             GoRoute(
-              path: Routes.progress,
+              path: Routes.progress.path,
+              name: Routes.progress.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -107,7 +115,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.inboxChats,
+              path: Routes.inboxChats.path,
+              name: Routes.inboxChats.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -116,7 +125,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.inboxChats$ChannelId,
+              path: Routes.inboxChatsChannelId.path,
+              name: Routes.inboxChatsChannelId.name,
               pageBuilder: (context, state) {
                 final String channelId =
                     state.pathParameters[RouteParams.channelId]!;
@@ -129,7 +139,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.inboxInvitesReceived,
+              path: Routes.inboxInvitesReceived.path,
+              name: Routes.inboxInvitesReceived.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -138,7 +149,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.inboxInvitesSent,
+              path: Routes.inboxInvitesSent.path,
+              name: Routes.inboxInvitesSent.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -147,7 +159,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.inboxArchived,
+              path: Routes.inboxArchived.path,
+              name: Routes.inboxArchived.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,
@@ -156,7 +169,8 @@ class AppRouter {
               },
             ),
             GoRoute(
-              path: Routes.profile,
+              path: Routes.profile.path,
+              name: Routes.profile.name,
               pageBuilder: (BuildContext context, GoRouterState state) {
                 return MaterialPage(
                   key: state.pageKey,

--- a/lib/utilities/scaffold_utils/appbar_factory.dart
+++ b/lib/utilities/scaffold_utils/appbar_factory.dart
@@ -42,7 +42,7 @@ class AppBarFactory {
       ),
       title: _getInboxAppBarTitle(theme, l10n, router.location),
       centerTitle: true,
-      bottom: router.location.startsWith(Routes.inboxInvites)
+      bottom: router.location.startsWith(Routes.inboxInvites.path)
           ? TabBar(
               tabs: [
                 Tab(
@@ -69,9 +69,9 @@ class AppBarFactory {
               onTap: (index) {
                 String newRoute;
                 if (index == 1) {
-                  newRoute = Routes.inboxInvitesSent;
+                  newRoute = Routes.inboxInvitesSent.path;
                 } else {
-                  newRoute = Routes.inboxInvitesReceived;
+                  newRoute = Routes.inboxInvitesReceived.path;
                 }
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   router.push(newRoute);
@@ -134,10 +134,10 @@ class AppBarFactory {
   static Text _getInboxAppBarTitle(
       ThemeData theme, AppLocalizations l10n, String targetRoute) {
     final String title;
-    if (targetRoute == Routes.inboxArchived) {
+    if (targetRoute == Routes.inboxArchived.path) {
       title = l10n.inboxTitleArchivedChats;
-    } else if (targetRoute == Routes.inboxInvitesReceived ||
-        targetRoute == Routes.inboxInvitesSent) {
+    } else if (targetRoute == Routes.inboxInvitesReceived.path ||
+        targetRoute == Routes.inboxInvitesSent.path) {
       title = l10n.inboxTitleInvites;
     } else {
       title = l10n.inboxTitleChats;

--- a/lib/utilities/scaffold_utils/drawer_factory.dart
+++ b/lib/utilities/scaffold_utils/drawer_factory.dart
@@ -36,7 +36,7 @@ class DrawerFactory {
               onTap: () {
                 // Close Drawer
                 Navigator.of(context).pop();
-                router.push(Routes.inboxChats);
+                router.push(Routes.inboxChats.path);
               },
             ),
             ListTile(
@@ -52,7 +52,7 @@ class DrawerFactory {
               onTap: () {
                 // Close Drawer
                 Navigator.of(context).pop();
-                router.push(Routes.inboxInvitesReceived);
+                router.push(Routes.inboxInvitesReceived.path);
               },
             ),
             ListTile(
@@ -61,7 +61,7 @@ class DrawerFactory {
               onTap: () {
                 // Close Drawer
                 Navigator.of(context).pop();
-                router.push(Routes.inboxArchived);
+                router.push(Routes.inboxArchived.path);
               },
             ),
           ],

--- a/lib/widgets/atoms/app_wrapper.dart
+++ b/lib/widgets/atoms/app_wrapper.dart
@@ -17,19 +17,19 @@ class AppWrapper extends StatelessWidget {
   int _calculateSelectedIndex(BuildContext context) {
     final GoRouter route = GoRouter.of(context);
     final String location = route.location;
-    if (location.startsWith(Routes.home)) {
+    if (location.startsWith(Routes.home.path)) {
       return 0;
     }
-    if (location.startsWith(Routes.explore)) {
+    if (location.startsWith(Routes.explore.path)) {
       return 1;
     }
-    if (location.startsWith(Routes.progress)) {
+    if (location.startsWith(Routes.progress.path)) {
       return 2;
     }
-    if (location.startsWith(Routes.inbox)) {
+    if (location.startsWith(Routes.inbox.path)) {
       return 3;
     }
-    if (location.startsWith(Routes.profile)) {
+    if (location.startsWith(Routes.profile.path)) {
       return 4;
     }
     return 0;
@@ -73,19 +73,19 @@ class AppWrapper extends StatelessWidget {
               onDestinationSelected: (int index) {
                 switch (index) {
                   case 0:
-                    context.push(Routes.home);
+                    context.push(Routes.home.path);
                     break;
                   case 1:
-                    context.push(Routes.explore);
+                    context.push(Routes.explore.path);
                     break;
                   case 2:
-                    context.push(Routes.progress);
+                    context.push(Routes.progress.path);
                     break;
                   case 3:
-                    context.push(Routes.inboxChats);
+                    context.push(Routes.inboxChats.path);
                     break;
                   case 4:
-                    context.push(Routes.profile);
+                    context.push(Routes.profile.path);
                     break;
                   default:
                     throw UnexpectedStateError(

--- a/lib/widgets/screens/explore/explore.dart
+++ b/lib/widgets/screens/explore/explore.dart
@@ -121,7 +121,8 @@ class _ExploreCardScrollState extends State<ExploreCardScroll> {
                 selectedInfo.add(cardInfo[i]);
               }
             }
-            context.push(Routes.exploreInviteToConnect, extra: selectedInfo);
+            context.push(Routes.exploreInviteToConnect.path,
+                extra: selectedInfo);
           },
           selectedCount: isSelected
               .map((e) => e ? 1 : 0)

--- a/lib/widgets/screens/inbox/inbox_chats.dart
+++ b/lib/widgets/screens/inbox/inbox_chats.dart
@@ -47,7 +47,8 @@ class _InboxChatsScreenState extends State<InboxChatsScreen>
         message:
             'Lorem ipsum dolor sit amet consectetur. Enim id interdum pulvinar eget dolor sed sit enim.',
         notifications: notifications,
-        onPressed: () => context.push('${Routes.inboxChats}/$mockChannelId'),
+        onPressed: () =>
+            context.push('${Routes.inboxChats.path}/$mockChannelId'),
       ),
     );
   }


### PR DESCRIPTION
To reduce the synchronisation effort between the backend and frontend, I suggest having names for all of our routes.  

That will separate the route/path definition inside the flutter application and the route name used externally (for push notifications for instance). 

The idea here is that we can modify the internal pathing freely as long as we do not change the name of the route. Of course, in case of new parameters added to the route we would also need to change it in the backend. 

Hence, I have changed all the routes to contain a name and updated the references to use the "Routes.<route>.path". 