### PR TITLE
UI improvements on invite-to-connect page and profile-quick-view

### DIFF
--- a/lib/constants/dimensions.dart
+++ b/lib/constants/dimensions.dart
@@ -58,7 +58,8 @@ class Dimensions {
   static const double channelMessagesAppBarHeight = 96.0;
   static const double channelMessagesAppBarAvatarLength = 48.0;
   static const double exploreFilterSizedBoxHeight = 80.0;
-  static const double highlightBorderWidth = 1.0;
+  static const double highlightBorderWidth = 2.0;
+  static const double cardBorderWidth = 1.0;
   static const double exploreBottomSection = 64.0;
   static const Size bigButtonSize = Size(80.0, 48.0);
   static const double notificationBubbleHeight = 16.0;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -94,6 +94,9 @@
     "inviteMessageTips": "Message Tips:",
     "inviteMessageTipsContent": "\u2022 Make your message specific\n\u2022 Keep it concise and simple\n\u2022 Be polite and respectful",
     "inviteDefaultMessageToMentor": "Hi,\nI saw your profile and think you could be a great mentor for my business. Can we connect? I admire your experience and would love to learn from you.\nThanks!",
+    "inviteDefaultMessageToEntrepreneur": "Hi,\nI saw your profile and would love to chat about some of your challenges. Would you like to connect?",
+    "inviteSelectedNumberMentor": "You've inviting {num} mentors to connect:",
+    "inviteSelectedNumberEntrepreneur": "You've inviting {num} entrepeneurs to connect:",
     "inviteCustomizeMessagePrompt": "Customize your message (optional)",
     "inviteMessagePlaceholder": "Enter invite message"
 }

--- a/lib/widgets/molecules/closable_tile.dart
+++ b/lib/widgets/molecules/closable_tile.dart
@@ -18,11 +18,11 @@ class CloseableTile extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(Insets.widgetSmallestInset),
       child: Card(
-        elevation: 0,
+        elevation: Elevations.level0,
         color: theme.colorScheme.surface,
         shape: RoundedRectangleBorder(
           side: BorderSide(
-            color: Theme.of(context).colorScheme.onSurface,
+            color: Theme.of(context).colorScheme.surfaceVariant,
           ),
           borderRadius:
               const BorderRadius.all(Radius.circular(Radii.roundedRectRadius)),

--- a/lib/widgets/molecules/profile_quick_view_card.dart
+++ b/lib/widgets/molecules/profile_quick_view_card.dart
@@ -180,7 +180,7 @@ class ProfileQuickViewCard extends StatelessWidget {
     return Card(
       color: colorScheme.surface,
       surfaceTintColor: Colors.transparent,
-      elevation: Elevations.level2,
+      elevation: Elevations.level0,
       child: InkWell(
         child: Ink(
           decoration: isRecommended
@@ -191,7 +191,13 @@ class ProfileQuickViewCard extends StatelessWidget {
                   ),
                   borderRadius: BorderRadius.circular(Radii.roundedRectRadius),
                 )
-              : null,
+              : BoxDecoration(
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    width: Dimensions.cardBorderWidth,
+                  ),
+                  borderRadius: BorderRadius.circular(Radii.roundedRectRadius),
+                ),
           child: Stack(
             children: [
               Align(

--- a/lib/widgets/screens/explore/invite_to_connect.dart
+++ b/lib/widgets/screens/explore/invite_to_connect.dart
@@ -7,8 +7,10 @@ import 'package:mm_flutter_app/widgets/molecules/profile_quick_view_card.dart';
 import '../../../constants/app_constants.dart';
 
 class MessageBox extends StatefulWidget {
+  final UserType currentUserType;
   const MessageBox({
     super.key,
+    required this.currentUserType,
   });
 
   @override
@@ -23,6 +25,10 @@ class _MessageBoxState extends State<MessageBox> {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
     final ThemeData theme = Theme.of(context);
 
+    final String defaultText = widget.currentUserType == UserType.mentor
+        ? l10n.inviteDefaultMessageToEntrepreneur
+        : l10n.inviteDefaultMessageToMentor;
+
     return Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: Insets.widgetMediumInset,
@@ -32,19 +38,29 @@ class _MessageBoxState extends State<MessageBox> {
           children: [
             Align(
               alignment: Alignment.topLeft,
-              child: Text(l10n.inviteCustomizeMessagePrompt),
+              child: Text(
+                l10n.inviteCustomizeMessagePrompt,
+              ),
             ),
             Padding(
               padding:
                   const EdgeInsets.symmetric(vertical: Insets.widgetSmallInset),
               child: TextField(
-                controller: _textEditingController
-                  ..text = l10n.inviteDefaultMessageToMentor,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+                controller: _textEditingController..text = defaultText,
                 keyboardType: TextInputType.multiline,
                 minLines: 5,
                 maxLines: 5,
                 decoration: InputDecoration(
-                  border: const OutlineInputBorder(),
+                  enabledBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: theme.colorScheme.primary),
+                      borderRadius:
+                          BorderRadius.circular(Radii.roundedRectRadius)),
+                  border: OutlineInputBorder(
+                      borderRadius:
+                          BorderRadius.circular(Radii.roundedRectRadius)),
                   hintText: l10n.inviteMessagePlaceholder,
                 ),
               ),
@@ -137,7 +153,8 @@ class _InviteToConnectState extends State<InviteToConnect> {
         ));
   }
 
-  Widget _createSelectedProfilesSection(BuildContext context) {
+  Widget _createSelectedProfilesSection(
+      BuildContext context, UserType currentUserType) {
     if (selectedProfiles.length == 1) {
       return Padding(
           padding: const EdgeInsets.symmetric(
@@ -147,6 +164,7 @@ class _InviteToConnectState extends State<InviteToConnect> {
           child: createProfilCardFromInfoAndCheckbox(
               info: selectedProfiles[0], checkbox: null));
     }
+
     List<Widget> profileTiles = [];
     for (int i = 0; i < selectedProfiles.length; i++) {
       ProfileQuickViewInfo profileInfo = selectedProfiles[i];
@@ -163,21 +181,40 @@ class _InviteToConnectState extends State<InviteToConnect> {
             });
           }));
     }
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Padding(
-        padding:
-            const EdgeInsets.symmetric(horizontal: Insets.widgetSmallInset),
-        child: Row(
-          children: profileTiles,
+
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
+    final ThemeData theme = Theme.of(context);
+    final String selectedText = currentUserType == UserType.mentor
+        ? l10n.inviteSelectedNumberEntrepreneur(profileTiles.length)
+        : l10n.inviteSelectedNumberMentor(profileTiles.length);
+
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Padding(
+          padding:
+              const EdgeInsets.symmetric(horizontal: Insets.widgetMediumInset),
+          child: Text(
+            selectedText,
+            style: theme.textTheme.labelSmall,
+          )),
+      SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Padding(
+          padding:
+              const EdgeInsets.symmetric(horizontal: Insets.widgetSmallInset),
+          child: Row(
+            children: profileTiles,
+          ),
         ),
-      ),
-    );
+      )
+    ]);
   }
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
+
+    // TODO: Replace currentUserType with actual backend
+    const UserType currentUserType = UserType.entrepreneur;
 
     return Scaffold(
         appBar: AppBar(
@@ -195,8 +232,8 @@ class _InviteToConnectState extends State<InviteToConnect> {
         body: Column(children: [
           Expanded(
               child: ListView(children: [
-            _createSelectedProfilesSection(context),
-            const MessageBox(),
+            _createSelectedProfilesSection(context, currentUserType),
+            const MessageBox(currentUserType: currentUserType),
             _createMessageTips(context),
           ])),
         ]));


### PR DESCRIPTION
    1. made invite-to-connect page work for both mentor and mentee user types
    2. improved the invite-to-connect page UI to bring it closer to the wireframe
    3. updated the profile quick view UI outline color and thickness
<img width="495" alt="Screenshot 2023-07-27 at 4 10 16 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/100324646/6b75ec90-3327-4bdb-a074-584c6c90ec09">
<img width="499" alt="image" src="https://github.com/micromentor-team/mm-flutter-app/assets/100324646/42df8da6-55f5-4850-a029-7a563344d729">

