### PR TITLE
Update mock server to generate a conversation with other user

### DIFF
--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -26,8 +26,8 @@ export function mockMutations(serverState: MockServerState) {
             serverState.channelInvitations.push(invitation);
             return invitation;
         },
-        createChannelMessage: () => {
-            const message = generators.generateChannelMessage(serverState.loggedInUser, true)
+        createChannelMessage: (messageText: string) => {
+            const message = generators.generateChannelMessage(messageText ,serverState.channels[0].id, serverState.loggedInUser, new Date(), true)
             serverState.channelMessages.push(message);
             return message;
         },

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -26,20 +26,20 @@ export function mockMutations(serverState: MockServerState) {
             serverState.channelInvitations.push(invitation);
             return invitation;
         },
-        createChannelMessage: (messageText: string) => {
-            const message = generators.generateChannelMessage(messageText ,serverState.channels[0].id, serverState.loggedInUser, new Date(), true)
+        createChannelMessage: (_: any, args: { input: { messageText: string }}) => {
+            const message = generators.generateChannelMessage(args.input.messageText ,serverState.channels[0].id, serverState.loggedInUser, new Date(), true)
             serverState.channelMessages.push(message);
             return message;
         },
-        updateChannelInvitation: (status: any) => {
+        updateChannelInvitation: (_: any, args: { input: { status: string }}) => {
             const invitation = serverState.channelInvitations[0]
-            if (status) {
-                if (status === "accepted"){
+            if (args.input.status) {
+                if (args.input.status === "accepted"){
                     invitation.status = "accepted";
                     invitation.channel = generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[3]])
                     serverState.channels.push(invitation.channel);
                 }
-                else if (status === "declined")
+                else if (args.input.status === "declined")
                     invitation.status = "declined";
             }
             return invitation.id;

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -1,22 +1,16 @@
-import { faker } from "@faker-js/faker";
 import { MockServerState } from "./util/state";
 import * as generators from "./util/generators";
 
 export function mockQueries(serverState: MockServerState) {
     return {
         findChannelById: () => {
-            return generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]);
+            return serverState.channels[0];
         },
         findChannelMessages: () => {
-            return [
-                generators.generateChannelMessage(serverState.loggedInUser, true),
-                generators.generateChannelMessage(serverState.otherUsers[0], false),
-            ]
+            return serverState.channelMessages;
         },
         findChannelsForUser: () => {
-            return [
-                generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[0]]),
-            ]
+            return serverState.channels;
         },
         findUsers: () => {
             return serverState.otherUsers.concat([serverState.loggedInUser]);
@@ -28,25 +22,18 @@ export function mockQueries(serverState: MockServerState) {
             return serverState.loggedInUser;
         },
         myInbox: () => {
-            var mockChannelId = faker.string.alphanumeric({length: 24});
-            var mockInvitations = [
-                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[0], true, false),
-                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[1], false, false),
-                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[2], false, true),
-                generators.generateChannelInboxItemInvitation(faker.string.alphanumeric({length: 24}), serverState.otherUsers[3], false, false),
-            ];
             return {
                 __typename: "UserInbox",
                 channels: {
                     __typename: "ChannelInbox",
-                    invitations: mockInvitations,
+                    invitations: serverState.channelInboxItemInvitations,
                     pendingInvitations: [
-                        mockInvitations[0],
-                        mockInvitations[1],
+                        serverState.channelInboxItemInvitations[0],
+                        serverState.channelInboxItemInvitations[1],
                     ],
                     unseenMessages: [
-                        generators.generateChannelInboxItemMessage(mockChannelId, serverState.loggedInUser),
-                        generators.generateChannelInboxItemMessage(mockChannelId, serverState.otherUsers[0]),
+                        generators.generateChannelInboxItemMessage(serverState.channels[0].id, serverState.loggedInUser),
+                        generators.generateChannelInboxItemMessage(serverState.channels[0].id, serverState.otherUsers[0]),
                     ],
                 }
             }

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -57,9 +57,18 @@ export function generateChannel(channelParticipants: any[]) {
     }
 }
 
-export function generateChannelMessage(sender: any, seen: boolean) {
+export function generateChannelMessage(
+    text: string = faker.lorem.sentence(),
+    channelId: string,
+    senderUser: any,
+    createdAt: Date,
+    isSeen: boolean = false,
+    isEdited: boolean = false,
+    isDeleted: boolean = false,
+    replyToMessageId: string | null = null,
+) {
     var statuses: object[] | null;
-    if (seen) {
+    if (isSeen) {
         statuses = [
             {
                 __typename: "ChannelMessageStatus",
@@ -72,15 +81,15 @@ export function generateChannelMessage(sender: any, seen: boolean) {
     return {
         __typename: "ChannelMessage",
         id: faker.string.alphanumeric({length: 24}),
-        createdBy: sender.id,
-        channelId: faker.string.alphanumeric({length: 24}),
-        messageText: faker.lorem.sentence(),
-        createdAt: faker.date.past({years: 1}),
-        replyToMessageId: null,
-        deletedBy: null,
+        createdBy: senderUser.id,
+        channelId: channelId,
+        messageText: text,
+        createdAt: createdAt.toISOString(),
+        replyToMessageId: replyToMessageId,
+        deletedBy: isDeleted ? senderUser.id : null,
         updatedAt: faker.date.recent(),
-        deletedAt: null,
-        editedAt: null,
+        deletedAt: isDeleted ? faker.date.recent() : null,
+        editedAt: isEdited ? faker.date.recent() : null,
         statuses: statuses,
     }
 }

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -34,20 +34,21 @@ export class MockServerState {
         ];
         this.channelInboxItemInvitations = [
             generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[0], true, false),
-                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[1], false, false),
-                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[2], false, true),
-                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[3], false, false),
+            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[1], false, false),
+            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[2], false, true),
+            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[3], false, false),
         ];
         const message0 = generators.generateChannelMessage('Hello!', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
-        const message1 = generators.generateChannelMessage('👋', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
+        const message1 = generators.generateChannelMessage('👋', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true, false, false);
         const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?',this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:35:01-07:00'), true);
         const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true);
         const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, false, true, message2.id);
-        const message5 = generators.generateChannelMessage('Of course!', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
+        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
         const message6 = generators.generateChannelMessage('👍', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:24:01-07:00'), true);
-        const message7 = generators.generateChannelMessage('Great, I will set up some time 😊', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, false, message5.id);
-        const message8 = generators.generateChannelMessage('You got it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
-        const message9 = generators.generateChannelMessage('👍👍', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
+        const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, true);
+        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, true, false, message5.id);
+        const message9 = generators.generateChannelMessage('You got it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
+        const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:01:01-07:00'), false);
         this.channelMessages = [
             message0,
             message1,
@@ -59,6 +60,7 @@ export class MockServerState {
             message7,
             message8,
             message9,
+            message10,
         ];
     }
 }

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -6,6 +6,7 @@ export class MockServerState {
     otherUsers: any[];
     channels: any[];
     channelInvitations: any[];
+    channelInboxItemInvitations: any[];
     channelMessages: any[];
 
     constructor() {
@@ -17,10 +18,10 @@ export class MockServerState {
             generators.generateUser(),
             generators.generateUser(),
             generators.generateUser(),
-        ]
+        ];
         this.channels = [
             generators.generateChannel([this.loggedInUser, this.otherUsers[0]]),
-        ]
+        ];
         this.channelInvitations = [
             // accepted invitation, channel exists
             generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[0], false, true),
@@ -30,10 +31,34 @@ export class MockServerState {
             generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[2], true),
             // TODO: accepted invitation, message doesn't exist yet in channel (a.k.a "match")
             // generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]], false, true),
-        ]
+        ];
+        this.channelInboxItemInvitations = [
+            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[0], true, false),
+                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[1], false, false),
+                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[2], false, true),
+                generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[3], false, false),
+        ];
+        const message0 = generators.generateChannelMessage('Hello!', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
+        const message1 = generators.generateChannelMessage('👋', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
+        const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?',this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:35:01-07:00'), true);
+        const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true);
+        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, false, true, message2.id);
+        const message5 = generators.generateChannelMessage('Of course!', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
+        const message6 = generators.generateChannelMessage('👍', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:24:01-07:00'), true);
+        const message7 = generators.generateChannelMessage('Great, I will set up some time 😊', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, false, message5.id);
+        const message8 = generators.generateChannelMessage('You got it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
+        const message9 = generators.generateChannelMessage('👍👍', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
         this.channelMessages = [
-            generators.generateChannelMessage(this.loggedInUser, true),
-            generators.generateChannelMessage(this.otherUsers[0], false),
-        ]
+            message0,
+            message1,
+            message2,
+            message3,
+            message4,
+            message5,
+            message6,
+            message7,
+            message8,
+            message9,
+        ];
     }
 }


### PR DESCRIPTION
Add a mock conversation so that the Chat UI can be tested more easily. The mock conversation covers the following:

- Conversation spanning multiple days
- Messages with emoji only
- Messages with text and emoji
- Replies from both sides
- Deleted message on both sides
- Edited message
- 2 unseen messages
- Allow adding new messages that persist in memory while the mock server is running

Includes some light refactoring of existing code.