### PR TITLE
Replace remaining hardcoded routes to use the defined constants instead

### DIFF
--- a/lib/widgets/molecules/invitation_section.dart
+++ b/lib/widgets/molecules/invitation_section.dart
@@ -51,7 +51,7 @@ class _InvitationSectionState extends State<InvitationSection> {
           title: l10n.homeInvitationSectionTitle,
           addTopDivider: true,
           removeBottomPadding: true,
-          seeAllOnPressed: () => context.push('/inbox'),
+          seeAllOnPressed: () => context.push(Routes.inboxInvitesReceived.path),
           child: _createInvitationTiles(
             l10n,
             userProvider,

--- a/lib/widgets/molecules/upcoming_section.dart
+++ b/lib/widgets/molecules/upcoming_section.dart
@@ -72,7 +72,7 @@ class UpcomingSection extends StatelessWidget {
       title: l10n.homeUpcomingSectionTitle,
       addTopDivider: true,
       seeAllOnPressed: () {
-        context.go('/progress');
+        context.go(Routes.progress.path);
       },
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,

--- a/lib/widgets/screens/sign_in/sign_in_screen.dart
+++ b/lib/widgets/screens/sign_in/sign_in_screen.dart
@@ -204,7 +204,7 @@ class _SignInScreenState extends State<SignInScreen> {
                                         passwordController.text = '';
                                       }
                                     } else {
-                                      router.push('/');
+                                      router.push(Routes.root.path);
                                     }
                                   }
                                 },

--- a/lib/widgets/screens/sign_up/sign_up_screen.dart
+++ b/lib/widgets/screens/sign_up/sign_up_screen.dart
@@ -3,6 +3,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/providers/user_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -48,7 +49,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
   }
 
   _openHomeScreen(BuildContext context) {
-    context.go('/home');
+    context.go(Routes.home.path);
   }
 
   @override

--- a/lib/widgets/screens/welcome/welcome_screen.dart
+++ b/lib/widgets/screens/welcome/welcome_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class WelcomeScreen extends StatelessWidget {
   const WelcomeScreen({Key? key}) : super(key: key);
@@ -18,11 +19,11 @@ class SignInSignUp extends StatelessWidget {
   const SignInSignUp({super.key});
 
   void _openSignUpScreen(context) {
-    context.go('/signup');
+    context.go(Routes.signup.path);
   }
 
   void _openSignInScreen(context) {
-    context.go('/signin');
+    context.go(Routes.signin.path);
   }
 
   @override


### PR DESCRIPTION
In case of the 'See all' button, the route didn't exist, and it now points to the corresponding page to show all received invites.