### PR TITLE
Clean up app Dimensions constants

### DIFF
--- a/lib/constants/dimensions.dart
+++ b/lib/constants/dimensions.dart
@@ -1,26 +1,43 @@
 part of 'app_constants.dart';
 
+class LayoutBreakpoints {
+  const LayoutBreakpoints._private();
+  // Window class by width
+  static const double compactWidthMax = 600.0;
+  static const double mediumWidthMin = compactWidthMax;
+  static const double mediumWidthMax = expandedWidthMin;
+  static const double expandedWidthMin = 840.0;
+  // Window class by height
+  static const double compactHeightMax = 480.0;
+  static const double mediumHeightMin = compactHeightMax;
+  static const double mediumHeightMax = expandedHeightMin;
+  static const double expandedHeightMin = 900.0;
+}
+
+class AppEdgeInsets {
+  const AppEdgeInsets._private();
+  static const double paddingCompact = 16.0;
+  static const double paddingMedium = 24.0;
+  static const double paddingExpanded = 24.0;
+}
+
 class Insets {
   const Insets._private();
-  static const double appEdgeInsetCompact = 16.0;
-  static const double appEdgeInsetMedium = 24.0;
-  static const double appEdgeInsetExpanded = 24.0;
-  static const double widgetSmallestInset = 4.0;
-  static const double widgetSmallInset = 8.0;
-  static const double widgetMediumInset = 16.0;
-  static const double widgetMediumLargeInset = 24.0;
-  static const double widgetLargeInset = 32.0;
+  static const double paddingExtraSmall = 4.0;
+  static const double paddingSmall = 8.0;
+  static const double paddingMedium = 16.0;
+  static const double paddingLarge = 24.0;
+  static const double paddingExtraLarge = 32.0;
 }
 
 class Radii {
   Radii._private();
-  static const double roundedRectRadiusSmall = 8.0;
-  static const double roundedRectRadiusMedium = 12.0;
-  static const double roundedRectRadiusLarge = 16.0;
-  static const double avatarRadiusSmallest = 14.0;
   static const double avatarRadiusSmall = 24.0;
   static const double avatarRadiusMedium = 40.0;
   static const double avatarRadiusLarge = 48.0;
+  static const double roundedRectRadiusSmall = 8.0;
+  static const double roundedRectRadiusMedium = 12.0;
+  static const double roundedRectRadiusLarge = 16.0;
 }
 
 class Elevations {
@@ -35,39 +52,10 @@ class Elevations {
 
 class Dimensions {
   Dimensions._private();
-  static const double avatarRoundedRectLength = 28.0;
   static const double drawerHeaderHeight = 64.0;
-  static const double minimumInteractionWidgetLength = 48.0;
+  static const double highlightBorderWidth = 2.0;
+
+  static const Size bigButtonSize = Size(80.0, 48.0);
   static const Size imageTile = Size(88.0, 168.0);
   static const Size imageTileRectangularImage = Size(88.0, 72.0);
-  static const double reminderBannerImageHeight = 80.0;
-  static const double mentorCardHeight = 170;
-  static const double mentorCardWidth = 260;
-  static const double chipVisualDensity = -4;
-  static const double chipMaxWidth = 100;
-  static const double loginBoxWidth = 360;
-  static const double loginButtonHorizontalPadding = 80;
-  static const double loginButtonVerticalPadding = 8;
-  static const double signInWithButtonLeftPadding = 64;
-  static const double signInWithButtonOtherPadding = 8;
-  static const double lineHeight = 1;
-  static const double textBoxWidth = 200;
-  static const double sizedBoxWidth = 360;
-  static const double iconSizeSmall = 12.0;
-  static const double iconSizeMedium = 24.0;
-  static const double iconWidth = 24;
-  static const double iconSpaceWidth = 8;
-  static const double quickViewProfileAvatarLength = 80.0;
-  static const double channelMessagesAppBarHeight = 80.0;
-  static const double channelMessagesAppBarAvatarLength = 48.0;
-  static const double exploreFilterSizedBoxHeight = 80.0;
-  static const double highlightBorderWidth = 2.0;
-  static const double cardBorderWidth = 1.0;
-  static const double exploreBottomSection = 64.0;
-  static const Size bigButtonSize = Size(80.0, 48.0);
-  static const double notificationBubbleHeight = 16.0;
-  static const double notificationBubbleSingleCharWidth = 16.0;
-  static const double notificationBubbleDoubleCharWidth = 20.0;
-  static const double notificationBubbleTripleCharWidth = 24.0;
-  static const double squareAvatar = 88.0;
 }

--- a/lib/constants/styles.dart
+++ b/lib/constants/styles.dart
@@ -6,7 +6,7 @@ class ButtonStyles {
   static ButtonStyle primaryRoundedRectangleButton(BuildContext context) {
     return TextButton.styleFrom(
       backgroundColor: Theme.of(context).colorScheme.primary,
-      padding: const EdgeInsets.all(Insets.widgetSmallInset),
+      padding: const EdgeInsets.all(Insets.paddingSmall),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(Radii.roundedRectRadiusSmall * 2),
       ),

--- a/lib/utilities/errors/error_widget.dart
+++ b/lib/utilities/errors/error_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class CustomErrorWidget extends StatelessWidget {
   const CustomErrorWidget({super.key});
@@ -10,7 +9,7 @@ class CustomErrorWidget extends StatelessWidget {
     return Center(
       child: Icon(
         Icons.error,
-        size: Dimensions.minimumInteractionWidgetLength,
+        size: 48.0,
         color: theme.colorScheme.error,
       ),
     );

--- a/lib/utilities/scaffold_utils/appbar_factory.dart
+++ b/lib/utilities/scaffold_utils/appbar_factory.dart
@@ -32,8 +32,8 @@ class AppBarFactory {
           if (totalNotifications > 0)
             Padding(
               padding: const EdgeInsetsDirectional.only(
-                top: Insets.widgetSmallInset,
-                start: Insets.widgetSmallInset,
+                top: Insets.paddingSmall,
+                start: Insets.paddingSmall,
               ),
               child: NotificationBubble(
                 notifications: totalNotifications,
@@ -51,7 +51,7 @@ class AppBarFactory {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       const Icon(Icons.mail_outline),
-                      const SizedBox(width: Insets.widgetSmallInset),
+                      const SizedBox(width: Insets.paddingSmall),
                       Text(l10n.inboxInvitesReceived),
                     ],
                   ),
@@ -61,7 +61,7 @@ class AppBarFactory {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       const Icon(Icons.send_outlined),
-                      const SizedBox(width: Insets.widgetSmallInset),
+                      const SizedBox(width: Insets.paddingSmall),
                       Text(l10n.inboxInvitesSent),
                     ],
                   ),
@@ -92,7 +92,7 @@ class AppBarFactory {
     final ThemeData theme = Theme.of(context);
     final GoRouter router = GoRouter.of(context);
     return AppBar(
-      toolbarHeight: Dimensions.channelMessagesAppBarHeight,
+      toolbarHeight: 80.0,
       leading: IconButton(
         icon: const Icon(Icons.keyboard_arrow_left),
         onPressed: () => router.pop(),
@@ -107,14 +107,13 @@ class AppBarFactory {
               image: avatarUrl != null
                   ? NetworkImage(avatarUrl) as ImageProvider<Object>
                   : const AssetImage(Assets.blankAvatar),
-              width: Dimensions.channelMessagesAppBarAvatarLength,
-              height: Dimensions
-                  .channelMessagesAppBarAvatarLength, // Height of the avatar
+              width: 48.0,
+              height: 48.0,
               fit: BoxFit.cover,
             ),
           ),
           const SizedBox(
-            width: Insets.widgetMediumInset,
+            width: Insets.paddingMedium,
           ),
           Text(
             channelName,

--- a/lib/widgets/atoms/dismissible_tile.dart
+++ b/lib/widgets/atoms/dismissible_tile.dart
@@ -29,7 +29,7 @@ class DismissibleTile extends StatelessWidget {
         child: icon != null
             ? Padding(
                 padding: const EdgeInsetsDirectional.only(
-                  end: Insets.widgetLargeInset,
+                  end: Insets.paddingExtraLarge,
                 ),
                 child: Icon(
                   icon,
@@ -40,8 +40,8 @@ class DismissibleTile extends StatelessWidget {
       ),
       child: Padding(
         padding: const EdgeInsetsDirectional.only(
-          start: Insets.widgetSmallInset,
-          end: Insets.widgetMediumInset,
+          start: Insets.paddingSmall,
+          end: Insets.paddingMedium,
         ),
         child: child,
       ),

--- a/lib/widgets/atoms/explore_filter.dart
+++ b/lib/widgets/atoms/explore_filter.dart
@@ -107,13 +107,10 @@ class ExploreFilter extends StatelessWidget {
     }
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(
-          (Insets.widgetSmallestInset),
-          Insets.widgetSmallInset,
-          Insets.widgetSmallestInset,
-          Insets.widgetSmallInset),
+      padding: const EdgeInsets.fromLTRB((Insets.paddingExtraSmall),
+          Insets.paddingSmall, Insets.paddingExtraSmall, Insets.paddingSmall),
       child: SizedBox(
-        height: Dimensions.exploreFilterSizedBoxHeight,
+        height: 80.0,
         child: DecoratedBox(
           decoration: BoxDecoration(
             border: Border.all(
@@ -130,9 +127,9 @@ class ExploreFilter extends StatelessWidget {
                 children: [
                   Padding(
                     padding: const EdgeInsets.fromLTRB(
-                        (Insets.widgetLargeInset),
+                        (Insets.paddingExtraLarge),
                         0,
-                        (Insets.widgetMediumInset),
+                        (Insets.paddingMedium),
                         0),
                     child: Icon(
                       Icons.search,
@@ -174,9 +171,9 @@ class ExploreFilter extends StatelessWidget {
                 children: [
                   Padding(
                     padding: const EdgeInsets.fromLTRB(
-                        (Insets.widgetLargeInset),
+                        (Insets.paddingExtraLarge),
                         0,
-                        (Insets.widgetMediumInset),
+                        (Insets.paddingMedium),
                         0),
                     child: Icon(
                       Icons.tune,

--- a/lib/widgets/atoms/invitation_tile.dart
+++ b/lib/widgets/atoms/invitation_tile.dart
@@ -24,7 +24,7 @@ class InvitationTile extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
     return ListTile(
-      minVerticalPadding: Insets.widgetMediumLargeInset,
+      minVerticalPadding: Insets.paddingLarge,
       leading: CircleAvatar(
         radius: Radii.avatarRadiusSmall,
         backgroundImage: avatarUrl != null ? NetworkImage(avatarUrl!) : null,
@@ -42,7 +42,7 @@ class InvitationTile extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.symmetric(
-              vertical: Insets.widgetSmallestInset,
+              vertical: Insets.paddingExtraSmall,
             ),
             child: Text(
               userJobTitle,

--- a/lib/widgets/atoms/mentor_card.dart
+++ b/lib/widgets/atoms/mentor_card.dart
@@ -8,6 +8,10 @@ class MentorCard extends StatelessWidget {
   final String mentorBio;
   final List<String> mentorSkill;
 
+  static const double _mentorCardHeight = 170;
+  static const double _mentorCardWidth = 260;
+  static const double _chipMaxWidth = 100;
+
   const MentorCard({
     Key? key,
     required this.avatarUrl,
@@ -21,7 +25,7 @@ class MentorCard extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Padding(
-          padding: const EdgeInsets.all(Insets.widgetSmallInset),
+          padding: const EdgeInsets.all(Insets.paddingSmall),
           child: CircleAvatar(
             radius: Radii.avatarRadiusLarge,
             child: CircleAvatar(
@@ -52,7 +56,7 @@ class MentorCard extends StatelessWidget {
           //using ConstrainedBox to prevent Text Overflow beyond the Card
           label: ConstrainedBox(
             constraints: const BoxConstraints(
-              maxWidth: Dimensions.chipMaxWidth,
+              maxWidth: _chipMaxWidth,
             ),
             child: Text(
               l10n.recommendedMentorCardScrollable,
@@ -62,17 +66,17 @@ class MentorCard extends StatelessWidget {
             ),
           ),
           visualDensity: const VisualDensity(
-            vertical: Dimensions.chipVisualDensity,
+            vertical: -4,
           ),
           backgroundColor: Theme.of(context).colorScheme.primary,
         ),
 
         // Text for Mentor's Name
         Padding(
-          padding: const EdgeInsets.all(Insets.widgetSmallInset),
+          padding: const EdgeInsets.all(Insets.paddingSmall),
           //using SizedBox to prevent Text Overflow beyond the Card
           child: SizedBox(
-            width: Dimensions.mentorCardWidth / 2,
+            width: _mentorCardWidth / 2,
             child: Text(
               mentorName,
               style: theme.textTheme.titleSmall?.copyWith(
@@ -87,10 +91,10 @@ class MentorCard extends StatelessWidget {
 
         // Text for Mentor's Skill
         Padding(
-          padding: const EdgeInsets.all(Insets.widgetSmallInset),
+          padding: const EdgeInsets.all(Insets.paddingSmall),
           //using SizedBox to prevent Text Overflow beyond the Card
           child: SizedBox(
-            width: Dimensions.mentorCardWidth / 2,
+            width: _mentorCardWidth / 2,
             child: Text(
               mentorBio,
               style: theme.textTheme.labelSmall?.copyWith(
@@ -136,7 +140,7 @@ class MentorCard extends StatelessWidget {
       //using ConstrainedBox to prevent Text Overflow beyond the Card
       label: ConstrainedBox(
         constraints: const BoxConstraints(
-          maxWidth: Dimensions.chipMaxWidth,
+          maxWidth: _chipMaxWidth,
         ),
         child: Text(
           skill,
@@ -146,7 +150,7 @@ class MentorCard extends StatelessWidget {
         ),
       ),
       visualDensity: const VisualDensity(
-        vertical: Dimensions.chipVisualDensity,
+        vertical: -4,
       ),
       backgroundColor: theme.colorScheme.tertiaryContainer,
       side: BorderSide.none,
@@ -159,8 +163,8 @@ class MentorCard extends StatelessWidget {
     Column mentorInfoColumn = _getMentorInfo(context);
     return Card(
       child: SizedBox(
-        width: Dimensions.mentorCardWidth,
-        height: Dimensions.mentorCardHeight,
+        width: _mentorCardWidth,
+        height: _mentorCardHeight,
         child: Row(
           children: [
             avatarColumn,

--- a/lib/widgets/atoms/notification_bubble.dart
+++ b/lib/widgets/atoms/notification_bubble.dart
@@ -5,6 +5,11 @@ import '../../constants/app_constants.dart';
 class NotificationBubble extends StatelessWidget {
   final int notifications;
 
+  static const double _notificationBubbleHeight = 16.0;
+  static const double _notificationBubbleSingleCharWidth = 16.0;
+  static const double _notificationBubbleDoubleCharWidth = 20.0;
+  static const double _notificationBubbleTripleCharWidth = 24.0;
+
   const NotificationBubble({
     super.key,
     required this.notifications,
@@ -16,23 +21,22 @@ class NotificationBubble extends StatelessWidget {
     double bubbleWidth;
     String notificationText;
     if (notifications > Limits.maxNotificationsDisplayed) {
-      bubbleWidth = Dimensions.notificationBubbleTripleCharWidth;
+      bubbleWidth = _notificationBubbleTripleCharWidth;
       notificationText = Identifiers.notificationOverflow;
     } else if (notifications > 9) {
-      bubbleWidth = Dimensions.notificationBubbleDoubleCharWidth;
+      bubbleWidth = _notificationBubbleDoubleCharWidth;
       notificationText = notifications.toString();
     } else {
-      bubbleWidth = Dimensions.notificationBubbleSingleCharWidth;
+      bubbleWidth = _notificationBubbleSingleCharWidth;
       notificationText = notifications.toString();
     }
     return Align(
       alignment: Alignment.topLeft,
       child: ClipRRect(
-        borderRadius:
-            BorderRadius.circular(Dimensions.notificationBubbleHeight),
+        borderRadius: BorderRadius.circular(_notificationBubbleHeight),
         child: Container(
           width: bubbleWidth,
-          height: Dimensions.notificationBubbleHeight,
+          height: _notificationBubbleHeight,
           color: theme.colorScheme.error,
           child: Center(
             child: Text(

--- a/lib/widgets/atoms/profile_chip.dart
+++ b/lib/widgets/atoms/profile_chip.dart
@@ -36,7 +36,7 @@ class ProfileChip extends StatelessWidget {
         vertical: VisualDensity.minimumDensity,
       ),
       labelPadding: icon != null
-          ? const EdgeInsetsDirectional.only(end: Insets.widgetSmallInset)
+          ? const EdgeInsetsDirectional.only(end: Insets.paddingSmall)
           : null,
       padding: EdgeInsets.zero,
     );

--- a/lib/widgets/atoms/profile_header.dart
+++ b/lib/widgets/atoms/profile_header.dart
@@ -17,14 +17,14 @@ class ProfileHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.all(Insets.widgetLargeInset),
+      padding: const EdgeInsets.all(Insets.paddingExtraLarge),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Flexible(
             child: Padding(
-              padding: const EdgeInsets.all(Insets.widgetSmallestInset),
+              padding: const EdgeInsets.all(Insets.paddingExtraSmall),
               child: Text(
                 profileMessage,
                 textAlign: TextAlign.start,

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -29,7 +29,7 @@ class ReminderBanner extends StatelessWidget {
                 style: theme.textTheme.titleSmall,
                 textAlign: TextAlign.start,
                 softWrap: true),
-            const SizedBox(height: Insets.widgetSmallestInset),
+            const SizedBox(height: Insets.paddingExtraSmall),
             Text(subtitleText,
                 style: theme.textTheme.bodySmall,
                 textAlign: TextAlign.start,
@@ -48,7 +48,7 @@ class ReminderBanner extends StatelessWidget {
           const SizedBox(
               child: Image(
             image: AssetImage(Assets.reminderBannerStockImage),
-            height: Dimensions.reminderBannerImageHeight,
+            height: 80.0,
           )),
           InkWell(
             onTap: () => {debugPrint("hi")},
@@ -72,13 +72,13 @@ class ReminderBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(
-        horizontal: Insets.widgetMediumInset,
-        vertical: Insets.widgetSmallestInset,
+        horizontal: Insets.paddingMedium,
+        vertical: Insets.paddingExtraSmall,
       ),
       child: Card(
         surfaceTintColor: Theme.of(context).colorScheme.inverseSurface,
         child: Padding(
-          padding: const EdgeInsets.all(Insets.widgetMediumInset),
+          padding: const EdgeInsets.all(Insets.paddingMedium),
           child: Row(
             children: <Widget>[
               _buildTextColumn(context),

--- a/lib/widgets/atoms/section_tile.dart
+++ b/lib/widgets/atoms/section_tile.dart
@@ -37,13 +37,13 @@ class _SectionTileState extends State<SectionTile> {
           const Divider(
             thickness: 1,
             height: 0,
-            indent: Insets.widgetSmallInset,
-            endIndent: Insets.widgetSmallInset,
+            indent: Insets.paddingSmall,
+            endIndent: Insets.paddingSmall,
           ),
         Padding(
           padding: const EdgeInsets.symmetric(
-            vertical: Insets.widgetMediumInset,
-            horizontal: Insets.appEdgeInsetCompact,
+            vertical: Insets.paddingMedium,
+            horizontal: AppEdgeInsets.paddingCompact,
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -79,7 +79,7 @@ class _SectionTileState extends State<SectionTile> {
         ),
         Padding(
           padding: EdgeInsets.only(
-            bottom: widget.removeBottomPadding ? 0 : Insets.widgetMediumInset,
+            bottom: widget.removeBottomPadding ? 0 : Insets.paddingMedium,
           ),
           child: Center(
             child: widget.child,
@@ -104,7 +104,7 @@ class _SectionExpandToggle extends StatelessWidget {
     return InkWell(
       onTap: onPressed,
       child: Padding(
-        padding: const EdgeInsets.all(Insets.widgetSmallestInset),
+        padding: const EdgeInsets.all(Insets.paddingExtraSmall),
         child: Text(
           text,
           style: theme.textTheme.labelSmall?.copyWith(

--- a/lib/widgets/atoms/skill_chip.dart
+++ b/lib/widgets/atoms/skill_chip.dart
@@ -31,7 +31,7 @@ class SkillChip extends StatelessWidget {
         vertical: VisualDensity.minimumDensity,
       ),
       labelPadding: icon != null
-          ? const EdgeInsetsDirectional.only(end: Insets.widgetSmallInset)
+          ? const EdgeInsetsDirectional.only(end: Insets.paddingSmall)
           : null,
       padding: EdgeInsets.zero,
     );

--- a/lib/widgets/atoms/text_divider.dart
+++ b/lib/widgets/atoms/text_divider.dart
@@ -17,14 +17,14 @@ class TextDivider extends StatelessWidget {
         const Expanded(
           child: Divider(),
         ),
-        const SizedBox(width: Insets.widgetSmallInset),
+        const SizedBox(width: Insets.paddingSmall),
         Text(
           text,
           style: theme.textTheme.labelSmall?.copyWith(
             color: theme.colorScheme.outline,
           ),
         ),
-        const SizedBox(width: Insets.widgetSmallInset),
+        const SizedBox(width: Insets.paddingSmall),
         const Expanded(
           child: Divider(),
         ),

--- a/lib/widgets/molecules/closable_tile.dart
+++ b/lib/widgets/molecules/closable_tile.dart
@@ -16,7 +16,7 @@ class CloseableTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.all(Insets.widgetSmallestInset),
+      padding: const EdgeInsets.all(Insets.paddingExtraSmall),
       child: Card(
         elevation: Elevations.level0,
         color: theme.colorScheme.surface,
@@ -29,8 +29,7 @@ class CloseableTile extends StatelessWidget {
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(
-              vertical: Insets.widgetSmallInset,
-              horizontal: Insets.widgetMediumInset),
+              vertical: Insets.paddingSmall, horizontal: Insets.paddingMedium),
           child: Align(
             alignment: Alignment.center,
             child: SizedBox(
@@ -41,8 +40,8 @@ class CloseableTile extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
                   Container(
-                      width: Dimensions.squareAvatar,
-                      height: Dimensions.squareAvatar,
+                      width: 88,
+                      height: 88,
                       decoration: BoxDecoration(
                         borderRadius: const BorderRadius.all(
                             Radius.circular(Radii.roundedRectRadiusMedium)),

--- a/lib/widgets/molecules/explore_bottom_buttons.dart
+++ b/lib/widgets/molecules/explore_bottom_buttons.dart
@@ -28,7 +28,7 @@ class ExploreBottomButtons extends StatelessWidget {
 
     return Container(
       color: bgColor,
-      height: Dimensions.exploreBottomSection,
+      height: 64.0,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
@@ -64,7 +64,7 @@ class ExploreBottomButtons extends StatelessWidget {
                           l10n.exploreSendInviteButton(selectedCount),
                         ),
                   const SizedBox(
-                    width: Dimensions.iconSpaceWidth,
+                    width: Insets.paddingSmall,
                   ),
                   const Icon(Icons.send),
                 ],

--- a/lib/widgets/molecules/image_tile.dart
+++ b/lib/widgets/molecules/image_tile.dart
@@ -18,7 +18,7 @@ class ImageTile extends StatelessWidget {
   Widget _makeImage() {
     if (isCircle) {
       return Padding(
-        padding: const EdgeInsets.all(Insets.widgetSmallInset),
+        padding: const EdgeInsets.all(Insets.paddingSmall),
         child: CircleAvatar(
           radius: Radii.avatarRadiusSmall,
           child: CircleAvatar(
@@ -30,7 +30,7 @@ class ImageTile extends StatelessWidget {
     } else {
       return Padding(
         padding: const EdgeInsets.only(
-            top: Insets.widgetSmallInset, bottom: Insets.widgetMediumInset),
+            top: Insets.paddingSmall, bottom: Insets.paddingMedium),
         child: Container(
           width: Dimensions.imageTileRectangularImage.width,
           height: Dimensions.imageTileRectangularImage.height,
@@ -52,12 +52,12 @@ class ImageTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.all(Insets.widgetSmallestInset),
+      padding: const EdgeInsets.all(Insets.paddingExtraSmall),
       child: Card(
         child: Padding(
           padding: const EdgeInsets.symmetric(
-            vertical: Insets.widgetSmallInset,
-            horizontal: Insets.widgetMediumInset,
+            vertical: Insets.paddingSmall,
+            horizontal: Insets.paddingMedium,
           ),
           child: Align(
             alignment: Alignment.center,
@@ -80,8 +80,8 @@ class ImageTile extends StatelessWidget {
                   const Spacer(),
                   Padding(
                     padding: const EdgeInsets.only(
-                        top: Insets.widgetSmallestInset,
-                        bottom: Insets.widgetSmallInset),
+                        top: Insets.paddingExtraSmall,
+                        bottom: Insets.paddingSmall),
                     child: Text(
                       subtitle,
                       style: theme.textTheme.bodySmall?.copyWith(

--- a/lib/widgets/molecules/inbox_list_tile.dart
+++ b/lib/widgets/molecules/inbox_list_tile.dart
@@ -52,7 +52,7 @@ class InboxListTile extends StatelessWidget {
       onTap: onPressed,
       child: Padding(
         padding: const EdgeInsets.symmetric(
-          vertical: Insets.widgetSmallInset,
+          vertical: Insets.paddingSmall,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -64,8 +64,8 @@ class InboxListTile extends StatelessWidget {
                   children: [
                     Padding(
                       padding: const EdgeInsetsDirectional.only(
-                        top: Insets.widgetSmallInset,
-                        start: Insets.widgetSmallInset,
+                        top: Insets.paddingSmall,
+                        start: Insets.paddingSmall,
                       ),
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(
@@ -76,9 +76,8 @@ class InboxListTile extends StatelessWidget {
                               ? NetworkImage(avatarUrl!)
                                   as ImageProvider<Object>
                               : const AssetImage(Assets.blankAvatar),
-                          width: Dimensions.avatarRoundedRectLength,
-                          height: Dimensions
-                              .avatarRoundedRectLength, // Height of the avatar
+                          width: 28.0,
+                          height: 28.0,
                           fit: BoxFit.cover,
                         ),
                       ),
@@ -90,12 +89,12 @@ class InboxListTile extends StatelessWidget {
                   ],
                 ),
                 const SizedBox(
-                  width: Insets.widgetSmallInset,
+                  width: Insets.paddingSmall,
                 ),
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.only(
-                      bottom: Insets.widgetSmallestInset,
+                      bottom: Insets.paddingExtraSmall,
                     ),
                     child: Text(
                       fullName,
@@ -108,11 +107,11 @@ class InboxListTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(
-                  width: Insets.widgetSmallInset,
+                  width: Insets.paddingSmall,
                 ),
                 Padding(
                   padding: const EdgeInsets.only(
-                    bottom: Insets.widgetSmallestInset,
+                    bottom: Insets.paddingExtraSmall,
                   ),
                   child: Text(
                     _getDate(context),
@@ -124,17 +123,17 @@ class InboxListTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(
-                  width: Insets.widgetSmallInset,
+                  width: Insets.paddingSmall,
                 )
               ],
             ),
             const SizedBox(
-              height: Insets.widgetSmallInset,
+              height: Insets.paddingSmall,
             ),
             if (message != null)
               Padding(
                 padding: const EdgeInsets.symmetric(
-                  horizontal: Insets.widgetSmallInset,
+                  horizontal: Insets.paddingSmall,
                 ),
                 child: Text(
                   message!,

--- a/lib/widgets/molecules/invitation_section.dart
+++ b/lib/widgets/molecules/invitation_section.dart
@@ -82,8 +82,8 @@ class _InvitationSectionState extends State<InvitationSection> {
               const Divider(
                 thickness: 1,
                 height: 0,
-                indent: Insets.widgetMediumInset,
-                endIndent: Insets.widgetMediumInset,
+                indent: Insets.paddingMedium,
+                endIndent: Insets.paddingMedium,
               ),
             );
           }

--- a/lib/widgets/molecules/profile_quick_view_card.dart
+++ b/lib/widgets/molecules/profile_quick_view_card.dart
@@ -195,7 +195,7 @@ class ProfileQuickViewCard extends StatelessWidget {
               : BoxDecoration(
                   border: Border.all(
                     color: Theme.of(context).colorScheme.surfaceVariant,
-                    width: Dimensions.cardBorderWidth,
+                    width: 1.0,
                   ),
                   borderRadius:
                       BorderRadius.circular(Radii.roundedRectRadiusMedium),
@@ -207,7 +207,7 @@ class ProfileQuickViewCard extends StatelessWidget {
                 child: checkbox,
               ),
               Padding(
-                padding: const EdgeInsets.all(Insets.widgetMediumInset),
+                padding: const EdgeInsets.all(Insets.paddingMedium),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -230,14 +230,14 @@ class ProfileQuickViewCard extends StatelessWidget {
   ) {
     final ThemeData theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.only(bottom: Insets.widgetSmallInset),
+      padding: const EdgeInsets.only(bottom: Insets.paddingSmall),
       child: Row(
         children: [
           Icon(
             Icons.star,
             color: Theme.of(context).colorScheme.primary,
           ),
-          const SizedBox(width: Insets.widgetSmallInset),
+          const SizedBox(width: Insets.paddingSmall),
           Text(
             l10n.exploreRecommended,
             style: theme.textTheme.titleMedium?.copyWith(
@@ -263,13 +263,12 @@ class ProfileQuickViewCard extends StatelessWidget {
             image: avatarUrl != null
                 ? NetworkImage(avatarUrl!) as ImageProvider<Object>
                 : const AssetImage(Assets.blankAvatar),
-            width: Dimensions.quickViewProfileAvatarLength,
-            height:
-                Dimensions.quickViewProfileAvatarLength, // Height of the avatar
+            width: 80.0,
+            height: 80.0, // Height of the avatar
             fit: BoxFit.cover,
           ),
         ),
-        const SizedBox(width: Insets.widgetMediumInset),
+        const SizedBox(width: Insets.paddingMedium),
         Expanded(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -292,7 +291,7 @@ class ProfileQuickViewCard extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(height: Insets.widgetSmallestInset),
+              const SizedBox(height: Insets.paddingExtraSmall),
               Text(
                 location,
                 style: theme.textTheme.labelSmall?.copyWith(
@@ -301,7 +300,7 @@ class ProfileQuickViewCard extends StatelessWidget {
                 ),
               ),
               const Divider(
-                endIndent: Insets.widgetLargeInset,
+                endIndent: Insets.paddingExtraLarge,
               ),
               Text(
                 _companyText(l10n),
@@ -309,7 +308,7 @@ class ProfileQuickViewCard extends StatelessWidget {
                   color: theme.colorScheme.secondary,
                 ),
               ),
-              const SizedBox(height: Insets.widgetSmallestInset),
+              const SizedBox(height: Insets.paddingExtraSmall),
               _createProfileChips(l10n),
             ],
           ),
@@ -325,8 +324,8 @@ class ProfileQuickViewCard extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.only(
-            top: Insets.widgetMediumInset,
-            bottom: Insets.widgetSmallestInset,
+            top: Insets.paddingMedium,
+            bottom: Insets.paddingExtraSmall,
           ),
           child: Text(
             _expertiseText(l10n)!,
@@ -347,7 +346,7 @@ class ProfileQuickViewCard extends StatelessWidget {
     for (int i = 1; i < topSkills.length; i++) {
       rowChildren.addAll(
         [
-          const SizedBox(width: Insets.widgetSmallestInset),
+          const SizedBox(width: Insets.paddingExtraSmall),
           topSkills[i],
         ],
       );

--- a/lib/widgets/molecules/recommended_mentors_scroll.dart
+++ b/lib/widgets/molecules/recommended_mentors_scroll.dart
@@ -42,13 +42,13 @@ class RecommendedMentorsScroll extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.all(Insets.widgetSmallInset),
+          padding: const EdgeInsets.all(Insets.paddingSmall),
           child: Center(
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: Padding(
                 padding: const EdgeInsets.symmetric(
-                  horizontal: Insets.widgetSmallInset,
+                  horizontal: Insets.paddingSmall,
                 ),
                 child: Row(
                   children: recommendedMentorCards,
@@ -73,7 +73,7 @@ class RecommendedSection extends StatelessWidget {
       children: [
         const RecommendedMentorsScroll(),
         Padding(
-          padding: const EdgeInsets.all(Insets.widgetMediumInset),
+          padding: const EdgeInsets.all(Insets.paddingMedium),
           child: Container(
             width: 200,
             alignment: Alignment.center,

--- a/lib/widgets/molecules/resources_section.dart
+++ b/lib/widgets/molecules/resources_section.dart
@@ -44,8 +44,7 @@ class ResourcesSection extends StatelessWidget {
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Padding(
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.widgetSmallInset),
+          padding: const EdgeInsets.symmetric(horizontal: Insets.paddingSmall),
           child: Row(
             children: resourceTiles,
           ),

--- a/lib/widgets/molecules/upcoming_section.dart
+++ b/lib/widgets/molecules/upcoming_section.dart
@@ -77,8 +77,7 @@ class UpcomingSection extends StatelessWidget {
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Padding(
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.widgetSmallInset),
+          padding: const EdgeInsets.symmetric(horizontal: Insets.paddingSmall),
           child: Row(
             children: upcomingSessionTiles,
           ),

--- a/lib/widgets/screens/channel_messages/channel_messages.dart
+++ b/lib/widgets/screens/channel_messages/channel_messages.dart
@@ -299,7 +299,7 @@ class BuildMessageBubbles extends StatelessWidget {
             order: GroupedListOrder.DESC,
             useStickyGroupSeparators: false,
             padding: const EdgeInsets.symmetric(
-              horizontal: Insets.widgetMediumInset,
+              horizontal: Insets.paddingMedium,
             ),
             groupBy: (message) =>
                 DateFormat('yyyy-MM-dd').format(message.createdAt).toString(),
@@ -319,7 +319,7 @@ class BuildMessageBubbles extends StatelessWidget {
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
             controller: listScrollController,
             groupHeaderBuilder: (ChannelMessage message) => Padding(
-              padding: const EdgeInsets.all(Insets.widgetSmallInset),
+              padding: const EdgeInsets.all(Insets.paddingSmall),
               child: TextDivider(
                 text: DateTime.now().day == message.createdAt.day
                     ? l10n.dateSimpleToday[0].toUpperCase() +

--- a/lib/widgets/screens/channel_messages/message_bubble/message_bubble.dart
+++ b/lib/widgets/screens/channel_messages/message_bubble/message_bubble.dart
@@ -66,7 +66,7 @@ class MessageBubble extends StatelessWidget {
     if (status != null) {
       return Padding(
         padding: const EdgeInsets.only(
-          bottom: Insets.widgetSmallInset,
+          bottom: Insets.paddingSmall,
         ),
         child: Text(
           status,
@@ -127,7 +127,7 @@ class MessageBubble extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: Insets.widgetSmallestInset),
+      padding: const EdgeInsets.symmetric(vertical: Insets.paddingExtraSmall),
       child: Container(
         constraints: BoxConstraints(
           minWidth: 80,
@@ -160,10 +160,10 @@ class MessageBubble extends StatelessWidget {
                   : theme.colorScheme.tertiaryContainer,
           child: Padding(
             padding: EdgeInsets.only(
-              left: Insets.widgetSmallInset,
-              top: Insets.widgetSmallInset,
-              right: Insets.widgetSmallInset,
-              bottom: isEmoji ? 0 : Insets.widgetSmallInset,
+              left: Insets.paddingSmall,
+              top: Insets.paddingSmall,
+              right: Insets.paddingSmall,
+              bottom: isEmoji ? 0 : Insets.paddingSmall,
             ),
             child: Stack(
               children: [
@@ -189,7 +189,7 @@ class MessageBubble extends StatelessWidget {
                     if (replyingTo != null && message.deletedAt == null)
                       Padding(
                         padding: const EdgeInsets.only(
-                          bottom: Insets.widgetSmallInset,
+                          bottom: Insets.paddingSmall,
                         ),
                         child: ReplyMessage(
                           replyMessage: replyingTo!,
@@ -199,7 +199,7 @@ class MessageBubble extends StatelessWidget {
                     _buildMessageText(l10n, theme, isUser),
                     if (message.deletedAt == null || isUser)
                       const SizedBox(
-                        height: Insets.widgetMediumLargeInset,
+                        height: Insets.paddingLarge,
                       ),
                   ],
                 ),

--- a/lib/widgets/screens/channel_messages/message_input.dart
+++ b/lib/widgets/screens/channel_messages/message_input.dart
@@ -79,10 +79,10 @@ class _MessageInputState extends State<MessageInput> {
       color: theme.colorScheme.surfaceVariant,
       child: Padding(
         padding: const EdgeInsetsDirectional.only(
-          start: Insets.widgetMediumInset,
-          top: Insets.widgetMediumInset,
-          bottom: Insets.widgetMediumInset,
-          end: Insets.widgetSmallestInset,
+          start: Insets.paddingMedium,
+          top: Insets.paddingMedium,
+          bottom: Insets.paddingMedium,
+          end: Insets.paddingExtraSmall,
         ),
         child: Row(
           children: [
@@ -98,7 +98,7 @@ class _MessageInputState extends State<MessageInput> {
                   children: [
                     if (_replyingTo != null)
                       Padding(
-                        padding: const EdgeInsets.all(Insets.widgetSmallInset),
+                        padding: const EdgeInsets.all(Insets.paddingSmall),
                         child: ReplyMessage(
                           replyMessage: _replyingTo!,
                           participants: widget.participants,
@@ -122,8 +122,8 @@ class _MessageInputState extends State<MessageInput> {
                       onSubmitted: _sendMessage,
                       decoration: InputDecoration(
                         contentPadding: const EdgeInsets.symmetric(
-                          vertical: Insets.widgetSmallestInset,
-                          horizontal: Insets.widgetMediumInset,
+                          vertical: Insets.paddingExtraSmall,
+                          horizontal: Insets.paddingMedium,
                         ),
                         hintText: l10n.messagesInputHint,
                         hintStyle: theme.textTheme.bodyMedium?.copyWith(
@@ -136,7 +136,7 @@ class _MessageInputState extends State<MessageInput> {
                 ),
               ),
             ),
-            const SizedBox(width: Insets.widgetSmallestInset),
+            const SizedBox(width: Insets.paddingExtraSmall),
             IconButton(
               icon: const Icon(
                 Icons.mic_outlined,

--- a/lib/widgets/screens/channel_messages/reply_message.dart
+++ b/lib/widgets/screens/channel_messages/reply_message.dart
@@ -64,19 +64,19 @@ class ReplyMessage extends StatelessWidget {
                   bottomStart: Radius.circular(Radii.roundedRectRadiusSmall),
                 ),
               ),
-              width: Insets.widgetSmallInset,
+              width: Insets.paddingSmall,
             ),
           ),
           Padding(
             padding: const EdgeInsetsDirectional.only(
-              start: Insets.widgetSmallInset,
+              start: Insets.paddingSmall,
             ),
             child: Row(
               mainAxisSize: MainAxisSize.max,
               children: [
                 Expanded(
                   child: Padding(
-                    padding: const EdgeInsets.all(Insets.widgetSmallInset),
+                    padding: const EdgeInsets.all(Insets.paddingSmall),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -115,7 +115,7 @@ class ReplyMessage extends StatelessWidget {
                     splashColor: Colors.transparent,
                     icon: const Icon(
                       Icons.close,
-                      size: Dimensions.iconSizeMedium,
+                      size: 24.0,
                     ),
                     onPressed: onClose,
                   ),

--- a/lib/widgets/screens/explore/invite_to_connect.dart
+++ b/lib/widgets/screens/explore/invite_to_connect.dart
@@ -31,8 +31,8 @@ class _MessageBoxState extends State<MessageBox> {
 
     return Padding(
         padding: const EdgeInsets.symmetric(
-          horizontal: Insets.widgetMediumInset,
-          vertical: Insets.widgetSmallestInset,
+          horizontal: Insets.paddingMedium,
+          vertical: Insets.paddingExtraSmall,
         ),
         child: Column(
           children: [
@@ -44,7 +44,7 @@ class _MessageBoxState extends State<MessageBox> {
             ),
             Padding(
               padding:
-                  const EdgeInsets.symmetric(vertical: Insets.widgetSmallInset),
+                  const EdgeInsets.symmetric(vertical: Insets.paddingSmall),
               child: TextField(
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.outline,
@@ -84,7 +84,7 @@ class _MessageBoxState extends State<MessageBox> {
                     ),
                   ),
                 ),
-                const SizedBox(width: Insets.widgetMediumInset),
+                const SizedBox(width: Insets.paddingMedium),
                 ElevatedButton(
                   style: ElevatedButton.styleFrom(
                     minimumSize: Dimensions.bigButtonSize,
@@ -132,20 +132,20 @@ class _InviteToConnectState extends State<InviteToConnect> {
     final ThemeData theme = Theme.of(context);
     return Padding(
         padding: const EdgeInsets.symmetric(
-          horizontal: Insets.widgetMediumInset,
-          vertical: Insets.widgetSmallestInset,
+          horizontal: Insets.paddingMedium,
+          vertical: Insets.paddingExtraSmall,
         ),
         child: Card(
           color: theme.colorScheme.tertiaryContainer,
           child: Padding(
-              padding: const EdgeInsets.all(Insets.widgetSmallInset),
+              padding: const EdgeInsets.all(Insets.paddingSmall),
               child: ListTile(
                   title: Text(
                     l10n.inviteMessageTips,
                     style: theme.textTheme.titleMedium,
                   ),
                   subtitle: Padding(
-                      padding: const EdgeInsets.all(Insets.widgetSmallInset),
+                      padding: const EdgeInsets.all(Insets.paddingSmall),
                       child: Text(
                         l10n.inviteMessageTipsContent,
                         style: theme.textTheme.bodyMedium,
@@ -158,8 +158,8 @@ class _InviteToConnectState extends State<InviteToConnect> {
     if (selectedProfiles.length == 1) {
       return Padding(
           padding: const EdgeInsets.symmetric(
-            horizontal: Insets.widgetMediumInset,
-            vertical: Insets.widgetSmallestInset,
+            horizontal: Insets.paddingMedium,
+            vertical: Insets.paddingExtraSmall,
           ),
           child: createProfilCardFromInfoAndCheckbox(
               info: selectedProfiles[0], checkbox: null));
@@ -190,8 +190,7 @@ class _InviteToConnectState extends State<InviteToConnect> {
 
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       Padding(
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.widgetMediumInset),
+          padding: const EdgeInsets.symmetric(horizontal: Insets.paddingMedium),
           child: Text(
             selectedText,
             style: theme.textTheme.labelSmall,
@@ -199,8 +198,7 @@ class _InviteToConnectState extends State<InviteToConnect> {
       SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Padding(
-          padding:
-              const EdgeInsets.symmetric(horizontal: Insets.widgetSmallInset),
+          padding: const EdgeInsets.symmetric(horizontal: Insets.paddingSmall),
           child: Row(
             children: profileTiles,
           ),

--- a/lib/widgets/screens/inbox/inbox_archived_chats.dart
+++ b/lib/widgets/screens/inbox/inbox_archived_chats.dart
@@ -68,8 +68,8 @@ class _InboxArchivedChatsScreenState extends State<InboxArchivedChatsScreen>
       contentList.addAll([
         const Divider(
           height: 0,
-          indent: Insets.widgetMediumInset,
-          endIndent: Insets.widgetMediumInset,
+          indent: Insets.paddingMedium,
+          endIndent: Insets.paddingMedium,
         ),
         tiles[i],
       ]);

--- a/lib/widgets/screens/inbox/inbox_chats.dart
+++ b/lib/widgets/screens/inbox/inbox_chats.dart
@@ -106,8 +106,8 @@ class _InboxChatsScreenState extends State<InboxChatsScreen>
       contentList.addAll([
         const Divider(
           height: 0,
-          indent: Insets.widgetMediumInset,
-          endIndent: Insets.widgetMediumInset,
+          indent: Insets.paddingMedium,
+          endIndent: Insets.paddingMedium,
         ),
         tiles[i],
       ]);

--- a/lib/widgets/screens/inbox/inbox_invites_received.dart
+++ b/lib/widgets/screens/inbox/inbox_invites_received.dart
@@ -61,7 +61,7 @@ class _InboxInvitesReceivedScreenState extends State<InboxInvitesReceivedScreen>
       contentList.addAll([
         const Divider(
           height: 0,
-          indent: Insets.widgetSmallInset,
+          indent: Insets.paddingSmall,
         ),
         tiles[i],
       ]);
@@ -104,8 +104,8 @@ class _InboxInvitesReceivedScreenState extends State<InboxInvitesReceivedScreen>
     return SafeArea(
       child: Padding(
         padding: const EdgeInsetsDirectional.only(
-          start: Insets.widgetSmallInset,
-          end: Insets.widgetMediumInset,
+          start: Insets.paddingSmall,
+          end: Insets.paddingMedium,
         ),
         child: ListView(
           children: _createContentList(

--- a/lib/widgets/screens/inbox/inbox_invites_sent.dart
+++ b/lib/widgets/screens/inbox/inbox_invites_sent.dart
@@ -60,7 +60,7 @@ class _InboxInvitesSentScreenState extends State<InboxInvitesSentScreen>
       contentList.addAll([
         const Divider(
           height: 0,
-          indent: Insets.widgetSmallInset,
+          indent: Insets.paddingSmall,
         ),
         tiles[i],
       ]);
@@ -103,8 +103,8 @@ class _InboxInvitesSentScreenState extends State<InboxInvitesSentScreen>
     return SafeArea(
       child: Padding(
         padding: const EdgeInsetsDirectional.only(
-          start: Insets.widgetSmallInset,
-          end: Insets.widgetMediumInset,
+          start: Insets.paddingSmall,
+          end: Insets.paddingMedium,
         ),
         child: ListView(
           children: _createContentList(

--- a/lib/widgets/screens/inbox/new_invite_detailed_profile.dart
+++ b/lib/widgets/screens/inbox/new_invite_detailed_profile.dart
@@ -27,7 +27,7 @@ class _NewInviteDetailedProfileState extends State<NewInviteDetailedProfile>
 
   Widget _createDateDivider(ThemeData theme) {
     return Padding(
-      padding: const EdgeInsets.all(Insets.widgetMediumInset),
+      padding: const EdgeInsets.all(Insets.paddingMedium),
       child: Row(
         children: [
           const Expanded(child: Divider()),
@@ -46,8 +46,8 @@ class _NewInviteDetailedProfileState extends State<NewInviteDetailedProfile>
 
   Widget _createMessagePopup(ThemeData theme) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(Insets.widgetLargeInset, 0,
-          Insets.widgetLargeInset, Insets.widgetLargeInset),
+      padding: const EdgeInsets.fromLTRB(Insets.paddingExtraLarge, 0,
+          Insets.paddingExtraLarge, Insets.paddingExtraLarge),
       child: SizedBox(
         child: DecoratedBox(
           decoration: BoxDecoration(
@@ -60,7 +60,7 @@ class _NewInviteDetailedProfileState extends State<NewInviteDetailedProfile>
           ),
           child: const Padding(
             padding: EdgeInsets.all(
-              Insets.widgetSmallInset,
+              Insets.paddingSmall,
             ),
             child: Column(
               children: [
@@ -111,7 +111,7 @@ class _NewInviteDetailedProfileState extends State<NewInviteDetailedProfile>
             ),
           ),
         ),
-        const SizedBox(width: Insets.widgetMediumInset),
+        const SizedBox(width: Insets.paddingMedium),
         ElevatedButton(
           style: ElevatedButton.styleFrom(
             minimumSize: Dimensions.bigButtonSize,

--- a/lib/widgets/screens/sign_in/sign_in_screen.dart
+++ b/lib/widgets/screens/sign_in/sign_in_screen.dart
@@ -23,6 +23,18 @@ class _SignInScreenState extends State<SignInScreen> {
   late final TextEditingController emailController;
   late final TextEditingController passwordController;
 
+  static const double _loginBoxWidth = 360;
+  static const double _textBoxWidth = 200;
+  static const double _sizedBoxWidth = 360;
+  static const double _iconWidth = 24;
+  static const EdgeInsetsDirectional _signInWithButtonPadding =
+      EdgeInsetsDirectional.fromSTEB(
+    64.0,
+    8.0,
+    8.0,
+    8.0,
+  );
+
   @override
   void initState() {
     super.initState();
@@ -68,11 +80,8 @@ class _SignInScreenState extends State<SignInScreen> {
           onTap: () => FocusScope.of(context).requestFocus(_unfocusNode),
           child: SingleChildScrollView(
             child: Padding(
-              padding: const EdgeInsetsDirectional.fromSTEB(
-                  Insets.widgetSmallInset,
-                  Insets.widgetLargeInset,
-                  Insets.widgetSmallInset,
-                  0),
+              padding: const EdgeInsetsDirectional.fromSTEB(Insets.paddingSmall,
+                  Insets.paddingExtraLarge, Insets.paddingSmall, 0),
               child: Form(
                 key: _formKey,
                 child: Column(
@@ -81,9 +90,9 @@ class _SignInScreenState extends State<SignInScreen> {
                   children: [
                     Padding(
                       padding: const EdgeInsetsDirectional.fromSTEB(
-                          0, Insets.widgetLargeInset, 0, 0),
+                          0, Insets.paddingExtraLarge, 0, 0),
                       child: SizedBox(
-                        width: Dimensions.sizedBoxWidth,
+                        width: _sizedBoxWidth,
                         child: Column(
                           mainAxisSize: MainAxisSize.max,
                           crossAxisAlignment: CrossAxisAlignment.start,
@@ -98,7 +107,7 @@ class _SignInScreenState extends State<SignInScreen> {
                             ),
                             const Padding(
                               padding: EdgeInsetsDirectional.fromSTEB(
-                                  0, 0, 0, Insets.widgetMediumInset),
+                                  0, 0, 0, Insets.paddingMedium),
                             ),
                             Center(
                               child: Text(
@@ -114,7 +123,7 @@ class _SignInScreenState extends State<SignInScreen> {
                     ),
                     Center(
                       child: SizedBox(
-                        width: Dimensions.loginBoxWidth,
+                        width: _loginBoxWidth,
                         child: Column(
                           mainAxisSize: MainAxisSize.max,
                           crossAxisAlignment: CrossAxisAlignment.center,
@@ -156,7 +165,7 @@ class _SignInScreenState extends State<SignInScreen> {
                                 obscureText: true),
                             Padding(
                               padding: const EdgeInsetsDirectional.fromSTEB(
-                                  0, Insets.widgetMediumInset, 0, 0),
+                                  0, Insets.paddingMedium, 0, 0),
                               child: ElevatedButton(
                                 style:
                                     ButtonStyles.primaryRoundedRectangleButton(
@@ -210,10 +219,8 @@ class _SignInScreenState extends State<SignInScreen> {
                                 },
                                 child: Padding(
                                   padding: const EdgeInsets.symmetric(
-                                    vertical:
-                                        Dimensions.loginButtonVerticalPadding,
-                                    horizontal:
-                                        Dimensions.loginButtonHorizontalPadding,
+                                    vertical: 8.0,
+                                    horizontal: 80.0,
                                   ),
                                   child: Text(
                                     l10n.logIn,
@@ -229,7 +236,7 @@ class _SignInScreenState extends State<SignInScreen> {
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.all(Insets.widgetSmallInset),
+                      padding: const EdgeInsets.all(Insets.paddingSmall),
                       child: TextButton(
                         key: const Key('registerButton'),
                         onPressed: () {
@@ -244,13 +251,13 @@ class _SignInScreenState extends State<SignInScreen> {
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.all(Insets.widgetSmallInset),
+                      padding: const EdgeInsets.all(Insets.paddingSmall),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           Container(
-                            width: Dimensions.loginBoxWidth / 2,
-                            height: Dimensions.lineHeight,
+                            width: _loginBoxWidth / 2,
+                            height: 1,
                             color: Theme.of(context).colorScheme.outline,
                           ),
                           Text(
@@ -260,8 +267,8 @@ class _SignInScreenState extends State<SignInScreen> {
                             ),
                           ),
                           Container(
-                            width: Dimensions.loginBoxWidth / 2,
-                            height: Dimensions.lineHeight,
+                            width: _loginBoxWidth / 2,
+                            height: 1,
                             color: Theme.of(context).colorScheme.outline,
                           ),
                         ],
@@ -271,11 +278,7 @@ class _SignInScreenState extends State<SignInScreen> {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
                         Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                              Dimensions.signInWithButtonLeftPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding),
+                          padding: _signInWithButtonPadding,
                           child: TextButton(
                             onPressed: () {
                               _openSignUpScreen(context);
@@ -284,16 +287,16 @@ class _SignInScreenState extends State<SignInScreen> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 const SizedBox(
-                                  width: Dimensions.iconWidth,
+                                  width: _iconWidth,
                                   child: Image(
                                     image: AssetImage(Assets.googleIcon),
                                   ),
                                 ),
                                 const SizedBox(
-                                  width: Dimensions.iconSpaceWidth,
+                                  width: Insets.paddingSmall,
                                 ),
                                 SizedBox(
-                                  width: Dimensions.textBoxWidth,
+                                  width: _textBoxWidth,
                                   child: Text(
                                     l10n.signInWithGoogle,
                                     style: theme.textTheme.labelLarge?.copyWith(
@@ -306,11 +309,7 @@ class _SignInScreenState extends State<SignInScreen> {
                           ),
                         ),
                         Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                              Dimensions.signInWithButtonLeftPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding),
+                          padding: _signInWithButtonPadding,
                           child: TextButton(
                             onPressed: () {
                               _openSignUpScreen(context);
@@ -319,16 +318,16 @@ class _SignInScreenState extends State<SignInScreen> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 const SizedBox(
-                                  width: Dimensions.iconWidth,
+                                  width: _iconWidth,
                                   child: Image(
                                     image: AssetImage(Assets.facebookIcon),
                                   ),
                                 ),
                                 const SizedBox(
-                                  width: Dimensions.iconSpaceWidth,
+                                  width: Insets.paddingSmall,
                                 ),
                                 SizedBox(
-                                  width: Dimensions.textBoxWidth,
+                                  width: _textBoxWidth,
                                   child: Text(
                                     l10n.signInWithFacebook,
                                     style: theme.textTheme.labelLarge?.copyWith(
@@ -341,11 +340,7 @@ class _SignInScreenState extends State<SignInScreen> {
                           ),
                         ),
                         Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                              Dimensions.signInWithButtonLeftPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding),
+                          padding: _signInWithButtonPadding,
                           child: TextButton(
                             onPressed: () {
                               _openSignUpScreen(context);
@@ -354,16 +349,16 @@ class _SignInScreenState extends State<SignInScreen> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 const SizedBox(
-                                  width: Dimensions.iconWidth,
+                                  width: _iconWidth,
                                   child: Image(
                                     image: AssetImage(Assets.linkedInIcon),
                                   ),
                                 ),
                                 const SizedBox(
-                                  width: Dimensions.iconSpaceWidth,
+                                  width: Insets.paddingSmall,
                                 ),
                                 SizedBox(
-                                  width: Dimensions.textBoxWidth,
+                                  width: _textBoxWidth,
                                   child: Text(
                                     l10n.signInWithLinkedIn,
                                     style: theme.textTheme.labelLarge?.copyWith(
@@ -376,11 +371,7 @@ class _SignInScreenState extends State<SignInScreen> {
                           ),
                         ),
                         Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                              Dimensions.signInWithButtonLeftPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding,
-                              Dimensions.signInWithButtonOtherPadding),
+                          padding: _signInWithButtonPadding,
                           child: TextButton(
                             onPressed: () {
                               _openSignUpScreen(context);
@@ -389,16 +380,16 @@ class _SignInScreenState extends State<SignInScreen> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 const SizedBox(
-                                  width: Dimensions.iconWidth,
+                                  width: _iconWidth,
                                   child: Image(
                                     image: AssetImage(Assets.whatsappIcon),
                                   ),
                                 ),
                                 const SizedBox(
-                                  width: Dimensions.iconSpaceWidth,
+                                  width: Insets.paddingSmall,
                                 ),
                                 SizedBox(
-                                  width: Dimensions.textBoxWidth,
+                                  width: _textBoxWidth,
                                   child: Text(
                                     l10n.signInWithWhatsapp,
                                     style: theme.textTheme.labelLarge?.copyWith(


### PR DESCRIPTION
Removed measurements constants that were specific to a single component, and therefore were not being reference elsewhere.

The following Insets were renamed to follow the common UI measurement naming convention of T-Shirt sizes:
widgetSmallestInset  -> paddingExtraSmall
widgetSmallInset -> paddingSmall
widgetMediumInset -> paddingMedium
widgetMediumLargeInset -> paddingLarge
widgetLargeInset -> paddingExtraLarge

Also added some constants for window classes, which will become useful as we move towards designing adaptive layouts.