### PR TITLE
GraphQL Schema updates with options/content

### DIFF
--- a/lib/__generated/schema/operations_content.graphql.dart
+++ b/lib/__generated/schema/operations_content.graphql.dart
@@ -1,0 +1,3567 @@
+// GENERATED WITH GRAPHQL_CODEGEN
+// DO NOT MODIFY
+// ignore_for_file: type=lint
+
+import 'package:gql/ast.dart';
+import 'schema.graphql.dart';
+
+class Query$FindCompanyStages {
+  Query$FindCompanyStages({
+    required this.findCompanyTypes,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindCompanyStages.fromJson(Map<String, dynamic> json) {
+    final l$findCompanyTypes = json['findCompanyTypes'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCompanyStages(
+      findCompanyTypes: (l$findCompanyTypes as List<dynamic>)
+          .map((e) => Query$FindCompanyStages$findCompanyTypes.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindCompanyStages$findCompanyTypes> findCompanyTypes;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findCompanyTypes = findCompanyTypes;
+    _resultData['findCompanyTypes'] =
+        l$findCompanyTypes.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findCompanyTypes = findCompanyTypes;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findCompanyTypes.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCompanyStages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findCompanyTypes = findCompanyTypes;
+    final lOther$findCompanyTypes = other.findCompanyTypes;
+    if (l$findCompanyTypes.length != lOther$findCompanyTypes.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCompanyTypes.length; i++) {
+      final l$findCompanyTypes$entry = l$findCompanyTypes[i];
+      final lOther$findCompanyTypes$entry = lOther$findCompanyTypes[i];
+      if (l$findCompanyTypes$entry != lOther$findCompanyTypes$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCompanyStages on Query$FindCompanyStages {
+  CopyWith$Query$FindCompanyStages<Query$FindCompanyStages> get copyWith =>
+      CopyWith$Query$FindCompanyStages(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindCompanyStages<TRes> {
+  factory CopyWith$Query$FindCompanyStages(
+    Query$FindCompanyStages instance,
+    TRes Function(Query$FindCompanyStages) then,
+  ) = _CopyWithImpl$Query$FindCompanyStages;
+
+  factory CopyWith$Query$FindCompanyStages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCompanyStages;
+
+  TRes call({
+    List<Query$FindCompanyStages$findCompanyTypes>? findCompanyTypes,
+    String? $__typename,
+  });
+  TRes findCompanyTypes(
+      Iterable<Query$FindCompanyStages$findCompanyTypes> Function(
+              Iterable<
+                  CopyWith$Query$FindCompanyStages$findCompanyTypes<
+                      Query$FindCompanyStages$findCompanyTypes>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindCompanyStages<TRes>
+    implements CopyWith$Query$FindCompanyStages<TRes> {
+  _CopyWithImpl$Query$FindCompanyStages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCompanyStages _instance;
+
+  final TRes Function(Query$FindCompanyStages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findCompanyTypes = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCompanyStages(
+        findCompanyTypes:
+            findCompanyTypes == _undefined || findCompanyTypes == null
+                ? _instance.findCompanyTypes
+                : (findCompanyTypes
+                    as List<Query$FindCompanyStages$findCompanyTypes>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findCompanyTypes(
+          Iterable<Query$FindCompanyStages$findCompanyTypes> Function(
+                  Iterable<
+                      CopyWith$Query$FindCompanyStages$findCompanyTypes<
+                          Query$FindCompanyStages$findCompanyTypes>>)
+              _fn) =>
+      call(
+          findCompanyTypes: _fn(_instance.findCompanyTypes
+              .map((e) => CopyWith$Query$FindCompanyStages$findCompanyTypes(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindCompanyStages<TRes>
+    implements CopyWith$Query$FindCompanyStages<TRes> {
+  _CopyWithStubImpl$Query$FindCompanyStages(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindCompanyStages$findCompanyTypes>? findCompanyTypes,
+    String? $__typename,
+  }) =>
+      _res;
+  findCompanyTypes(_fn) => _res;
+}
+
+const documentNodeQueryFindCompanyStages = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindCompanyStages'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findCompanyTypes'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindCompanyStages$findCompanyStages {
+  Query$FindCompanyStages$findCompanyStages({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$FindCompanyStages$findCompanyStages.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCompanyStages$findCompanyStages(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCompanyStages$findCompanyStages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCompanyStages$findCompanyStages
+    on Query$FindCompanyStages$findCompanyStages {
+  CopyWith$Query$FindCompanyStages$findCompanyStages<
+          Query$FindCompanyStages$findCompanyStages>
+      get copyWith => CopyWith$Query$FindCompanyStages$findCompanyStages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindCompanyStages$findCompanyStages<TRes> {
+  factory CopyWith$Query$FindCompanyStages$findCompanyStages(
+    Query$FindCompanyStages$findCompanyStages instance,
+    TRes Function(Query$FindCompanyStages$findCompanyStages) then,
+  ) = _CopyWithImpl$Query$FindCompanyStages$findCompanyStages;
+
+  factory CopyWith$Query$FindCompanyStages$findCompanyStages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCompanyStages$findCompanyStages;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindCompanyStages$findCompanyStages<TRes>
+    implements CopyWith$Query$FindCompanyStages$findCompanyStages<TRes> {
+  _CopyWithImpl$Query$FindCompanyStages$findCompanyStages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCompanyStages$findCompanyStages _instance;
+
+  final TRes Function(Query$FindCompanyStages$findCompanyStages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCompanyStages$findCompanyStages(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindCompanyStages$findCompanyStages<TRes>
+    implements CopyWith$Query$FindCompanyStages$findCompanyStages<TRes> {
+  _CopyWithStubImpl$Query$FindCompanyStages$findCompanyStages(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindCompanyStages$findCompanyTypes {
+  Query$FindCompanyStages$findCompanyTypes({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'CompanyType',
+  });
+
+  factory Query$FindCompanyStages$findCompanyTypes.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCompanyStages$findCompanyTypes(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCompanyStages$findCompanyTypes) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCompanyStages$findCompanyTypes
+    on Query$FindCompanyStages$findCompanyTypes {
+  CopyWith$Query$FindCompanyStages$findCompanyTypes<
+          Query$FindCompanyStages$findCompanyTypes>
+      get copyWith => CopyWith$Query$FindCompanyStages$findCompanyTypes(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
+  factory CopyWith$Query$FindCompanyStages$findCompanyTypes(
+    Query$FindCompanyStages$findCompanyTypes instance,
+    TRes Function(Query$FindCompanyStages$findCompanyTypes) then,
+  ) = _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes;
+
+  factory CopyWith$Query$FindCompanyStages$findCompanyTypes.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
+  _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCompanyStages$findCompanyTypes _instance;
+
+  final TRes Function(Query$FindCompanyStages$findCompanyTypes) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCompanyStages$findCompanyTypes(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
+  _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindCountries {
+  Query$FindCountries({
+    required this.findCountries,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindCountries.fromJson(Map<String, dynamic> json) {
+    final l$findCountries = json['findCountries'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCountries(
+      findCountries: (l$findCountries as List<dynamic>)
+          .map((e) => Query$FindCountries$findCountries.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindCountries$findCountries> findCountries;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findCountries = findCountries;
+    _resultData['findCountries'] =
+        l$findCountries.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findCountries = findCountries;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findCountries.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCountries) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findCountries = findCountries;
+    final lOther$findCountries = other.findCountries;
+    if (l$findCountries.length != lOther$findCountries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCountries.length; i++) {
+      final l$findCountries$entry = l$findCountries[i];
+      final lOther$findCountries$entry = lOther$findCountries[i];
+      if (l$findCountries$entry != lOther$findCountries$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCountries on Query$FindCountries {
+  CopyWith$Query$FindCountries<Query$FindCountries> get copyWith =>
+      CopyWith$Query$FindCountries(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindCountries<TRes> {
+  factory CopyWith$Query$FindCountries(
+    Query$FindCountries instance,
+    TRes Function(Query$FindCountries) then,
+  ) = _CopyWithImpl$Query$FindCountries;
+
+  factory CopyWith$Query$FindCountries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCountries;
+
+  TRes call({
+    List<Query$FindCountries$findCountries>? findCountries,
+    String? $__typename,
+  });
+  TRes findCountries(
+      Iterable<Query$FindCountries$findCountries> Function(
+              Iterable<
+                  CopyWith$Query$FindCountries$findCountries<
+                      Query$FindCountries$findCountries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindCountries<TRes>
+    implements CopyWith$Query$FindCountries<TRes> {
+  _CopyWithImpl$Query$FindCountries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCountries _instance;
+
+  final TRes Function(Query$FindCountries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findCountries = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCountries(
+        findCountries: findCountries == _undefined || findCountries == null
+            ? _instance.findCountries
+            : (findCountries as List<Query$FindCountries$findCountries>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findCountries(
+          Iterable<Query$FindCountries$findCountries> Function(
+                  Iterable<
+                      CopyWith$Query$FindCountries$findCountries<
+                          Query$FindCountries$findCountries>>)
+              _fn) =>
+      call(
+          findCountries: _fn(_instance.findCountries
+              .map((e) => CopyWith$Query$FindCountries$findCountries(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindCountries<TRes>
+    implements CopyWith$Query$FindCountries<TRes> {
+  _CopyWithStubImpl$Query$FindCountries(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindCountries$findCountries>? findCountries,
+    String? $__typename,
+  }) =>
+      _res;
+  findCountries(_fn) => _res;
+}
+
+const documentNodeQueryFindCountries = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindCountries'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findCountries'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'alpha2Key'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindCountries$findCountries {
+  Query$FindCountries$findCountries({
+    required this.alpha2Key,
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindCountries$findCountries.fromJson(
+      Map<String, dynamic> json) {
+    final l$alpha2Key = json['alpha2Key'];
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCountries$findCountries(
+      alpha2Key: (l$alpha2Key as String),
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String alpha2Key;
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$alpha2Key = alpha2Key;
+    _resultData['alpha2Key'] = l$alpha2Key;
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$alpha2Key = alpha2Key;
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$alpha2Key,
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCountries$findCountries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$alpha2Key = alpha2Key;
+    final lOther$alpha2Key = other.alpha2Key;
+    if (l$alpha2Key != lOther$alpha2Key) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCountries$findCountries
+    on Query$FindCountries$findCountries {
+  CopyWith$Query$FindCountries$findCountries<Query$FindCountries$findCountries>
+      get copyWith => CopyWith$Query$FindCountries$findCountries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindCountries$findCountries<TRes> {
+  factory CopyWith$Query$FindCountries$findCountries(
+    Query$FindCountries$findCountries instance,
+    TRes Function(Query$FindCountries$findCountries) then,
+  ) = _CopyWithImpl$Query$FindCountries$findCountries;
+
+  factory CopyWith$Query$FindCountries$findCountries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCountries$findCountries;
+
+  TRes call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindCountries$findCountries<TRes>
+    implements CopyWith$Query$FindCountries$findCountries<TRes> {
+  _CopyWithImpl$Query$FindCountries$findCountries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCountries$findCountries _instance;
+
+  final TRes Function(Query$FindCountries$findCountries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? alpha2Key = _undefined,
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCountries$findCountries(
+        alpha2Key: alpha2Key == _undefined || alpha2Key == null
+            ? _instance.alpha2Key
+            : (alpha2Key as String),
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindCountries$findCountries<TRes>
+    implements CopyWith$Query$FindCountries$findCountries<TRes> {
+  _CopyWithStubImpl$Query$FindCountries$findCountries(this._res);
+
+  TRes _res;
+
+  call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindCountriesInLanguage {
+  factory Variables$Query$FindCountriesInLanguage(
+          {Enum$UiLanguage? uiLanguage}) =>
+      Variables$Query$FindCountriesInLanguage._({
+        if (uiLanguage != null) r'uiLanguage': uiLanguage,
+      });
+
+  Variables$Query$FindCountriesInLanguage._(this._$data);
+
+  factory Variables$Query$FindCountriesInLanguage.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('uiLanguage')) {
+      final l$uiLanguage = data['uiLanguage'];
+      result$data['uiLanguage'] = l$uiLanguage == null
+          ? null
+          : fromJson$Enum$UiLanguage((l$uiLanguage as String));
+    }
+    return Variables$Query$FindCountriesInLanguage._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Enum$UiLanguage? get uiLanguage => (_$data['uiLanguage'] as Enum$UiLanguage?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('uiLanguage')) {
+      final l$uiLanguage = uiLanguage;
+      result$data['uiLanguage'] =
+          l$uiLanguage == null ? null : toJson$Enum$UiLanguage(l$uiLanguage);
+    }
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindCountriesInLanguage<
+          Variables$Query$FindCountriesInLanguage>
+      get copyWith => CopyWith$Variables$Query$FindCountriesInLanguage(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindCountriesInLanguage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$uiLanguage = uiLanguage;
+    final lOther$uiLanguage = other.uiLanguage;
+    if (_$data.containsKey('uiLanguage') !=
+        other._$data.containsKey('uiLanguage')) {
+      return false;
+    }
+    if (l$uiLanguage != lOther$uiLanguage) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$uiLanguage = uiLanguage;
+    return Object.hashAll(
+        [_$data.containsKey('uiLanguage') ? l$uiLanguage : const {}]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindCountriesInLanguage<TRes> {
+  factory CopyWith$Variables$Query$FindCountriesInLanguage(
+    Variables$Query$FindCountriesInLanguage instance,
+    TRes Function(Variables$Query$FindCountriesInLanguage) then,
+  ) = _CopyWithImpl$Variables$Query$FindCountriesInLanguage;
+
+  factory CopyWith$Variables$Query$FindCountriesInLanguage.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindCountriesInLanguage;
+
+  TRes call({Enum$UiLanguage? uiLanguage});
+}
+
+class _CopyWithImpl$Variables$Query$FindCountriesInLanguage<TRes>
+    implements CopyWith$Variables$Query$FindCountriesInLanguage<TRes> {
+  _CopyWithImpl$Variables$Query$FindCountriesInLanguage(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindCountriesInLanguage _instance;
+
+  final TRes Function(Variables$Query$FindCountriesInLanguage) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? uiLanguage = _undefined}) =>
+      _then(Variables$Query$FindCountriesInLanguage._({
+        ..._instance._$data,
+        if (uiLanguage != _undefined)
+          'uiLanguage': (uiLanguage as Enum$UiLanguage?),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindCountriesInLanguage<TRes>
+    implements CopyWith$Variables$Query$FindCountriesInLanguage<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindCountriesInLanguage(this._res);
+
+  TRes _res;
+
+  call({Enum$UiLanguage? uiLanguage}) => _res;
+}
+
+class Query$FindCountriesInLanguage {
+  Query$FindCountriesInLanguage({
+    required this.findCountries,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindCountriesInLanguage.fromJson(Map<String, dynamic> json) {
+    final l$findCountries = json['findCountries'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCountriesInLanguage(
+      findCountries: (l$findCountries as List<dynamic>)
+          .map((e) => Query$FindCountriesInLanguage$findCountries.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindCountriesInLanguage$findCountries> findCountries;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findCountries = findCountries;
+    _resultData['findCountries'] =
+        l$findCountries.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findCountries = findCountries;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findCountries.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCountriesInLanguage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findCountries = findCountries;
+    final lOther$findCountries = other.findCountries;
+    if (l$findCountries.length != lOther$findCountries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCountries.length; i++) {
+      final l$findCountries$entry = l$findCountries[i];
+      final lOther$findCountries$entry = lOther$findCountries[i];
+      if (l$findCountries$entry != lOther$findCountries$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCountriesInLanguage
+    on Query$FindCountriesInLanguage {
+  CopyWith$Query$FindCountriesInLanguage<Query$FindCountriesInLanguage>
+      get copyWith => CopyWith$Query$FindCountriesInLanguage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindCountriesInLanguage<TRes> {
+  factory CopyWith$Query$FindCountriesInLanguage(
+    Query$FindCountriesInLanguage instance,
+    TRes Function(Query$FindCountriesInLanguage) then,
+  ) = _CopyWithImpl$Query$FindCountriesInLanguage;
+
+  factory CopyWith$Query$FindCountriesInLanguage.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCountriesInLanguage;
+
+  TRes call({
+    List<Query$FindCountriesInLanguage$findCountries>? findCountries,
+    String? $__typename,
+  });
+  TRes findCountries(
+      Iterable<Query$FindCountriesInLanguage$findCountries> Function(
+              Iterable<
+                  CopyWith$Query$FindCountriesInLanguage$findCountries<
+                      Query$FindCountriesInLanguage$findCountries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindCountriesInLanguage<TRes>
+    implements CopyWith$Query$FindCountriesInLanguage<TRes> {
+  _CopyWithImpl$Query$FindCountriesInLanguage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCountriesInLanguage _instance;
+
+  final TRes Function(Query$FindCountriesInLanguage) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findCountries = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCountriesInLanguage(
+        findCountries: findCountries == _undefined || findCountries == null
+            ? _instance.findCountries
+            : (findCountries
+                as List<Query$FindCountriesInLanguage$findCountries>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findCountries(
+          Iterable<Query$FindCountriesInLanguage$findCountries> Function(
+                  Iterable<
+                      CopyWith$Query$FindCountriesInLanguage$findCountries<
+                          Query$FindCountriesInLanguage$findCountries>>)
+              _fn) =>
+      call(
+          findCountries: _fn(_instance.findCountries
+              .map((e) => CopyWith$Query$FindCountriesInLanguage$findCountries(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindCountriesInLanguage<TRes>
+    implements CopyWith$Query$FindCountriesInLanguage<TRes> {
+  _CopyWithStubImpl$Query$FindCountriesInLanguage(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindCountriesInLanguage$findCountries>? findCountries,
+    String? $__typename,
+  }) =>
+      _res;
+  findCountries(_fn) => _res;
+}
+
+const documentNodeQueryFindCountriesInLanguage = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindCountriesInLanguage'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'uiLanguage')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UiLanguage'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findCountries'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'uiLanguage'),
+            value: VariableNode(name: NameNode(value: 'uiLanguage')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'alpha2Key'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindCountriesInLanguage$findCountries {
+  Query$FindCountriesInLanguage$findCountries({
+    required this.alpha2Key,
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindCountriesInLanguage$findCountries.fromJson(
+      Map<String, dynamic> json) {
+    final l$alpha2Key = json['alpha2Key'];
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCountriesInLanguage$findCountries(
+      alpha2Key: (l$alpha2Key as String),
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String alpha2Key;
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$alpha2Key = alpha2Key;
+    _resultData['alpha2Key'] = l$alpha2Key;
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$alpha2Key = alpha2Key;
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$alpha2Key,
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCountriesInLanguage$findCountries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$alpha2Key = alpha2Key;
+    final lOther$alpha2Key = other.alpha2Key;
+    if (l$alpha2Key != lOther$alpha2Key) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCountriesInLanguage$findCountries
+    on Query$FindCountriesInLanguage$findCountries {
+  CopyWith$Query$FindCountriesInLanguage$findCountries<
+          Query$FindCountriesInLanguage$findCountries>
+      get copyWith => CopyWith$Query$FindCountriesInLanguage$findCountries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindCountriesInLanguage$findCountries<TRes> {
+  factory CopyWith$Query$FindCountriesInLanguage$findCountries(
+    Query$FindCountriesInLanguage$findCountries instance,
+    TRes Function(Query$FindCountriesInLanguage$findCountries) then,
+  ) = _CopyWithImpl$Query$FindCountriesInLanguage$findCountries;
+
+  factory CopyWith$Query$FindCountriesInLanguage$findCountries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCountriesInLanguage$findCountries;
+
+  TRes call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindCountriesInLanguage$findCountries<TRes>
+    implements CopyWith$Query$FindCountriesInLanguage$findCountries<TRes> {
+  _CopyWithImpl$Query$FindCountriesInLanguage$findCountries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCountriesInLanguage$findCountries _instance;
+
+  final TRes Function(Query$FindCountriesInLanguage$findCountries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? alpha2Key = _undefined,
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCountriesInLanguage$findCountries(
+        alpha2Key: alpha2Key == _undefined || alpha2Key == null
+            ? _instance.alpha2Key
+            : (alpha2Key as String),
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindCountriesInLanguage$findCountries<TRes>
+    implements CopyWith$Query$FindCountriesInLanguage$findCountries<TRes> {
+  _CopyWithStubImpl$Query$FindCountriesInLanguage$findCountries(this._res);
+
+  TRes _res;
+
+  call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindEducationLevels {
+  Query$FindEducationLevels({
+    required this.findEducationLevels,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindEducationLevels.fromJson(Map<String, dynamic> json) {
+    final l$findEducationLevels = json['findEducationLevels'];
+    final l$$__typename = json['__typename'];
+    return Query$FindEducationLevels(
+      findEducationLevels: (l$findEducationLevels as List<dynamic>)
+          .map((e) => Query$FindEducationLevels$findEducationLevels.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindEducationLevels$findEducationLevels> findEducationLevels;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findEducationLevels = findEducationLevels;
+    _resultData['findEducationLevels'] =
+        l$findEducationLevels.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findEducationLevels = findEducationLevels;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findEducationLevels.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindEducationLevels) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findEducationLevels = findEducationLevels;
+    final lOther$findEducationLevels = other.findEducationLevels;
+    if (l$findEducationLevels.length != lOther$findEducationLevels.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findEducationLevels.length; i++) {
+      final l$findEducationLevels$entry = l$findEducationLevels[i];
+      final lOther$findEducationLevels$entry = lOther$findEducationLevels[i];
+      if (l$findEducationLevels$entry != lOther$findEducationLevels$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindEducationLevels
+    on Query$FindEducationLevels {
+  CopyWith$Query$FindEducationLevels<Query$FindEducationLevels> get copyWith =>
+      CopyWith$Query$FindEducationLevels(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindEducationLevels<TRes> {
+  factory CopyWith$Query$FindEducationLevels(
+    Query$FindEducationLevels instance,
+    TRes Function(Query$FindEducationLevels) then,
+  ) = _CopyWithImpl$Query$FindEducationLevels;
+
+  factory CopyWith$Query$FindEducationLevels.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindEducationLevels;
+
+  TRes call({
+    List<Query$FindEducationLevels$findEducationLevels>? findEducationLevels,
+    String? $__typename,
+  });
+  TRes findEducationLevels(
+      Iterable<Query$FindEducationLevels$findEducationLevels> Function(
+              Iterable<
+                  CopyWith$Query$FindEducationLevels$findEducationLevels<
+                      Query$FindEducationLevels$findEducationLevels>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindEducationLevels<TRes>
+    implements CopyWith$Query$FindEducationLevels<TRes> {
+  _CopyWithImpl$Query$FindEducationLevels(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindEducationLevels _instance;
+
+  final TRes Function(Query$FindEducationLevels) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findEducationLevels = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindEducationLevels(
+        findEducationLevels:
+            findEducationLevels == _undefined || findEducationLevels == null
+                ? _instance.findEducationLevels
+                : (findEducationLevels
+                    as List<Query$FindEducationLevels$findEducationLevels>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findEducationLevels(
+          Iterable<Query$FindEducationLevels$findEducationLevels> Function(
+                  Iterable<
+                      CopyWith$Query$FindEducationLevels$findEducationLevels<
+                          Query$FindEducationLevels$findEducationLevels>>)
+              _fn) =>
+      call(
+          findEducationLevels: _fn(_instance.findEducationLevels.map(
+              (e) => CopyWith$Query$FindEducationLevels$findEducationLevels(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindEducationLevels<TRes>
+    implements CopyWith$Query$FindEducationLevels<TRes> {
+  _CopyWithStubImpl$Query$FindEducationLevels(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindEducationLevels$findEducationLevels>? findEducationLevels,
+    String? $__typename,
+  }) =>
+      _res;
+  findEducationLevels(_fn) => _res;
+}
+
+const documentNodeQueryFindEducationLevels = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindEducationLevels'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findEducationLevels'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindEducationLevels$findEducationLevels {
+  Query$FindEducationLevels$findEducationLevels({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'EducationLevel',
+  });
+
+  factory Query$FindEducationLevels$findEducationLevels.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindEducationLevels$findEducationLevels(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindEducationLevels$findEducationLevels) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindEducationLevels$findEducationLevels
+    on Query$FindEducationLevels$findEducationLevels {
+  CopyWith$Query$FindEducationLevels$findEducationLevels<
+          Query$FindEducationLevels$findEducationLevels>
+      get copyWith => CopyWith$Query$FindEducationLevels$findEducationLevels(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindEducationLevels$findEducationLevels<TRes> {
+  factory CopyWith$Query$FindEducationLevels$findEducationLevels(
+    Query$FindEducationLevels$findEducationLevels instance,
+    TRes Function(Query$FindEducationLevels$findEducationLevels) then,
+  ) = _CopyWithImpl$Query$FindEducationLevels$findEducationLevels;
+
+  factory CopyWith$Query$FindEducationLevels$findEducationLevels.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindEducationLevels$findEducationLevels;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindEducationLevels$findEducationLevels<TRes>
+    implements CopyWith$Query$FindEducationLevels$findEducationLevels<TRes> {
+  _CopyWithImpl$Query$FindEducationLevels$findEducationLevels(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindEducationLevels$findEducationLevels _instance;
+
+  final TRes Function(Query$FindEducationLevels$findEducationLevels) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindEducationLevels$findEducationLevels(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindEducationLevels$findEducationLevels<TRes>
+    implements CopyWith$Query$FindEducationLevels$findEducationLevels<TRes> {
+  _CopyWithStubImpl$Query$FindEducationLevels$findEducationLevels(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindExpertises {
+  Query$FindExpertises({
+    required this.findExpertises,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindExpertises.fromJson(Map<String, dynamic> json) {
+    final l$findExpertises = json['findExpertises'];
+    final l$$__typename = json['__typename'];
+    return Query$FindExpertises(
+      findExpertises: (l$findExpertises as List<dynamic>)
+          .map((e) => Query$FindExpertises$findExpertises.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindExpertises$findExpertises> findExpertises;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findExpertises = findExpertises;
+    _resultData['findExpertises'] =
+        l$findExpertises.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findExpertises = findExpertises;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findExpertises.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindExpertises) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findExpertises = findExpertises;
+    final lOther$findExpertises = other.findExpertises;
+    if (l$findExpertises.length != lOther$findExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findExpertises.length; i++) {
+      final l$findExpertises$entry = l$findExpertises[i];
+      final lOther$findExpertises$entry = lOther$findExpertises[i];
+      if (l$findExpertises$entry != lOther$findExpertises$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindExpertises on Query$FindExpertises {
+  CopyWith$Query$FindExpertises<Query$FindExpertises> get copyWith =>
+      CopyWith$Query$FindExpertises(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindExpertises<TRes> {
+  factory CopyWith$Query$FindExpertises(
+    Query$FindExpertises instance,
+    TRes Function(Query$FindExpertises) then,
+  ) = _CopyWithImpl$Query$FindExpertises;
+
+  factory CopyWith$Query$FindExpertises.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindExpertises;
+
+  TRes call({
+    List<Query$FindExpertises$findExpertises>? findExpertises,
+    String? $__typename,
+  });
+  TRes findExpertises(
+      Iterable<Query$FindExpertises$findExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindExpertises$findExpertises<
+                      Query$FindExpertises$findExpertises>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindExpertises<TRes>
+    implements CopyWith$Query$FindExpertises<TRes> {
+  _CopyWithImpl$Query$FindExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindExpertises _instance;
+
+  final TRes Function(Query$FindExpertises) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findExpertises = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindExpertises(
+        findExpertises: findExpertises == _undefined || findExpertises == null
+            ? _instance.findExpertises
+            : (findExpertises as List<Query$FindExpertises$findExpertises>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findExpertises(
+          Iterable<Query$FindExpertises$findExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindExpertises$findExpertises<
+                          Query$FindExpertises$findExpertises>>)
+              _fn) =>
+      call(
+          findExpertises: _fn(_instance.findExpertises
+              .map((e) => CopyWith$Query$FindExpertises$findExpertises(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindExpertises<TRes>
+    implements CopyWith$Query$FindExpertises<TRes> {
+  _CopyWithStubImpl$Query$FindExpertises(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindExpertises$findExpertises>? findExpertises,
+    String? $__typename,
+  }) =>
+      _res;
+  findExpertises(_fn) => _res;
+}
+
+const documentNodeQueryFindExpertises = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindExpertises'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findExpertises'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindExpertises$findExpertises {
+  Query$FindExpertises$findExpertises({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindExpertises$findExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindExpertises$findExpertises(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindExpertises$findExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindExpertises$findExpertises
+    on Query$FindExpertises$findExpertises {
+  CopyWith$Query$FindExpertises$findExpertises<
+          Query$FindExpertises$findExpertises>
+      get copyWith => CopyWith$Query$FindExpertises$findExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindExpertises$findExpertises<TRes> {
+  factory CopyWith$Query$FindExpertises$findExpertises(
+    Query$FindExpertises$findExpertises instance,
+    TRes Function(Query$FindExpertises$findExpertises) then,
+  ) = _CopyWithImpl$Query$FindExpertises$findExpertises;
+
+  factory CopyWith$Query$FindExpertises$findExpertises.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindExpertises$findExpertises;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindExpertises$findExpertises<TRes>
+    implements CopyWith$Query$FindExpertises$findExpertises<TRes> {
+  _CopyWithImpl$Query$FindExpertises$findExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindExpertises$findExpertises _instance;
+
+  final TRes Function(Query$FindExpertises$findExpertises) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindExpertises$findExpertises(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindExpertises$findExpertises<TRes>
+    implements CopyWith$Query$FindExpertises$findExpertises<TRes> {
+  _CopyWithStubImpl$Query$FindExpertises$findExpertises(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindIndustries {
+  Query$FindIndustries({
+    required this.findIndustries,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindIndustries.fromJson(Map<String, dynamic> json) {
+    final l$findIndustries = json['findIndustries'];
+    final l$$__typename = json['__typename'];
+    return Query$FindIndustries(
+      findIndustries: (l$findIndustries as List<dynamic>)
+          .map((e) => Query$FindIndustries$findIndustries.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindIndustries$findIndustries> findIndustries;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findIndustries = findIndustries;
+    _resultData['findIndustries'] =
+        l$findIndustries.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findIndustries = findIndustries;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findIndustries.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindIndustries) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findIndustries = findIndustries;
+    final lOther$findIndustries = other.findIndustries;
+    if (l$findIndustries.length != lOther$findIndustries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findIndustries.length; i++) {
+      final l$findIndustries$entry = l$findIndustries[i];
+      final lOther$findIndustries$entry = lOther$findIndustries[i];
+      if (l$findIndustries$entry != lOther$findIndustries$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindIndustries on Query$FindIndustries {
+  CopyWith$Query$FindIndustries<Query$FindIndustries> get copyWith =>
+      CopyWith$Query$FindIndustries(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindIndustries<TRes> {
+  factory CopyWith$Query$FindIndustries(
+    Query$FindIndustries instance,
+    TRes Function(Query$FindIndustries) then,
+  ) = _CopyWithImpl$Query$FindIndustries;
+
+  factory CopyWith$Query$FindIndustries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindIndustries;
+
+  TRes call({
+    List<Query$FindIndustries$findIndustries>? findIndustries,
+    String? $__typename,
+  });
+  TRes findIndustries(
+      Iterable<Query$FindIndustries$findIndustries> Function(
+              Iterable<
+                  CopyWith$Query$FindIndustries$findIndustries<
+                      Query$FindIndustries$findIndustries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindIndustries<TRes>
+    implements CopyWith$Query$FindIndustries<TRes> {
+  _CopyWithImpl$Query$FindIndustries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindIndustries _instance;
+
+  final TRes Function(Query$FindIndustries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findIndustries = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindIndustries(
+        findIndustries: findIndustries == _undefined || findIndustries == null
+            ? _instance.findIndustries
+            : (findIndustries as List<Query$FindIndustries$findIndustries>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findIndustries(
+          Iterable<Query$FindIndustries$findIndustries> Function(
+                  Iterable<
+                      CopyWith$Query$FindIndustries$findIndustries<
+                          Query$FindIndustries$findIndustries>>)
+              _fn) =>
+      call(
+          findIndustries: _fn(_instance.findIndustries
+              .map((e) => CopyWith$Query$FindIndustries$findIndustries(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindIndustries<TRes>
+    implements CopyWith$Query$FindIndustries<TRes> {
+  _CopyWithStubImpl$Query$FindIndustries(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindIndustries$findIndustries>? findIndustries,
+    String? $__typename,
+  }) =>
+      _res;
+  findIndustries(_fn) => _res;
+}
+
+const documentNodeQueryFindIndustries = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindIndustries'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findIndustries'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindIndustries$findIndustries {
+  Query$FindIndustries$findIndustries({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindIndustries$findIndustries.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindIndustries$findIndustries(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindIndustries$findIndustries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindIndustries$findIndustries
+    on Query$FindIndustries$findIndustries {
+  CopyWith$Query$FindIndustries$findIndustries<
+          Query$FindIndustries$findIndustries>
+      get copyWith => CopyWith$Query$FindIndustries$findIndustries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindIndustries$findIndustries<TRes> {
+  factory CopyWith$Query$FindIndustries$findIndustries(
+    Query$FindIndustries$findIndustries instance,
+    TRes Function(Query$FindIndustries$findIndustries) then,
+  ) = _CopyWithImpl$Query$FindIndustries$findIndustries;
+
+  factory CopyWith$Query$FindIndustries$findIndustries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindIndustries$findIndustries;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindIndustries$findIndustries<TRes>
+    implements CopyWith$Query$FindIndustries$findIndustries<TRes> {
+  _CopyWithImpl$Query$FindIndustries$findIndustries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindIndustries$findIndustries _instance;
+
+  final TRes Function(Query$FindIndustries$findIndustries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindIndustries$findIndustries(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindIndustries$findIndustries<TRes>
+    implements CopyWith$Query$FindIndustries$findIndustries<TRes> {
+  _CopyWithStubImpl$Query$FindIndustries$findIndustries(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindGenders {
+  Query$FindGenders({
+    required this.findGenders,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindGenders.fromJson(Map<String, dynamic> json) {
+    final l$findGenders = json['findGenders'];
+    final l$$__typename = json['__typename'];
+    return Query$FindGenders(
+      findGenders: (l$findGenders as List<dynamic>)
+          .map((e) => Query$FindGenders$findGenders.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindGenders$findGenders> findGenders;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findGenders = findGenders;
+    _resultData['findGenders'] = l$findGenders.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findGenders = findGenders;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findGenders.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindGenders) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findGenders = findGenders;
+    final lOther$findGenders = other.findGenders;
+    if (l$findGenders.length != lOther$findGenders.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findGenders.length; i++) {
+      final l$findGenders$entry = l$findGenders[i];
+      final lOther$findGenders$entry = lOther$findGenders[i];
+      if (l$findGenders$entry != lOther$findGenders$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindGenders on Query$FindGenders {
+  CopyWith$Query$FindGenders<Query$FindGenders> get copyWith =>
+      CopyWith$Query$FindGenders(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindGenders<TRes> {
+  factory CopyWith$Query$FindGenders(
+    Query$FindGenders instance,
+    TRes Function(Query$FindGenders) then,
+  ) = _CopyWithImpl$Query$FindGenders;
+
+  factory CopyWith$Query$FindGenders.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindGenders;
+
+  TRes call({
+    List<Query$FindGenders$findGenders>? findGenders,
+    String? $__typename,
+  });
+  TRes findGenders(
+      Iterable<Query$FindGenders$findGenders> Function(
+              Iterable<
+                  CopyWith$Query$FindGenders$findGenders<
+                      Query$FindGenders$findGenders>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindGenders<TRes>
+    implements CopyWith$Query$FindGenders<TRes> {
+  _CopyWithImpl$Query$FindGenders(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindGenders _instance;
+
+  final TRes Function(Query$FindGenders) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findGenders = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindGenders(
+        findGenders: findGenders == _undefined || findGenders == null
+            ? _instance.findGenders
+            : (findGenders as List<Query$FindGenders$findGenders>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findGenders(
+          Iterable<Query$FindGenders$findGenders> Function(
+                  Iterable<
+                      CopyWith$Query$FindGenders$findGenders<
+                          Query$FindGenders$findGenders>>)
+              _fn) =>
+      call(
+          findGenders: _fn(_instance.findGenders
+              .map((e) => CopyWith$Query$FindGenders$findGenders(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindGenders<TRes>
+    implements CopyWith$Query$FindGenders<TRes> {
+  _CopyWithStubImpl$Query$FindGenders(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindGenders$findGenders>? findGenders,
+    String? $__typename,
+  }) =>
+      _res;
+  findGenders(_fn) => _res;
+}
+
+const documentNodeQueryFindGenders = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindGenders'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findGenders'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindGenders$findGenders {
+  Query$FindGenders$findGenders({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Gender',
+  });
+
+  factory Query$FindGenders$findGenders.fromJson(Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindGenders$findGenders(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindGenders$findGenders) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindGenders$findGenders
+    on Query$FindGenders$findGenders {
+  CopyWith$Query$FindGenders$findGenders<Query$FindGenders$findGenders>
+      get copyWith => CopyWith$Query$FindGenders$findGenders(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindGenders$findGenders<TRes> {
+  factory CopyWith$Query$FindGenders$findGenders(
+    Query$FindGenders$findGenders instance,
+    TRes Function(Query$FindGenders$findGenders) then,
+  ) = _CopyWithImpl$Query$FindGenders$findGenders;
+
+  factory CopyWith$Query$FindGenders$findGenders.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindGenders$findGenders;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindGenders$findGenders<TRes>
+    implements CopyWith$Query$FindGenders$findGenders<TRes> {
+  _CopyWithImpl$Query$FindGenders$findGenders(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindGenders$findGenders _instance;
+
+  final TRes Function(Query$FindGenders$findGenders) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindGenders$findGenders(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindGenders$findGenders<TRes>
+    implements CopyWith$Query$FindGenders$findGenders<TRes> {
+  _CopyWithStubImpl$Query$FindGenders$findGenders(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindLanguages {
+  Query$FindLanguages({
+    required this.findLanguages,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindLanguages.fromJson(Map<String, dynamic> json) {
+    final l$findLanguages = json['findLanguages'];
+    final l$$__typename = json['__typename'];
+    return Query$FindLanguages(
+      findLanguages: (l$findLanguages as List<dynamic>)
+          .map((e) => Query$FindLanguages$findLanguages.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindLanguages$findLanguages> findLanguages;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findLanguages = findLanguages;
+    _resultData['findLanguages'] =
+        l$findLanguages.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findLanguages = findLanguages;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findLanguages.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindLanguages) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findLanguages = findLanguages;
+    final lOther$findLanguages = other.findLanguages;
+    if (l$findLanguages.length != lOther$findLanguages.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findLanguages.length; i++) {
+      final l$findLanguages$entry = l$findLanguages[i];
+      final lOther$findLanguages$entry = lOther$findLanguages[i];
+      if (l$findLanguages$entry != lOther$findLanguages$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindLanguages on Query$FindLanguages {
+  CopyWith$Query$FindLanguages<Query$FindLanguages> get copyWith =>
+      CopyWith$Query$FindLanguages(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindLanguages<TRes> {
+  factory CopyWith$Query$FindLanguages(
+    Query$FindLanguages instance,
+    TRes Function(Query$FindLanguages) then,
+  ) = _CopyWithImpl$Query$FindLanguages;
+
+  factory CopyWith$Query$FindLanguages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindLanguages;
+
+  TRes call({
+    List<Query$FindLanguages$findLanguages>? findLanguages,
+    String? $__typename,
+  });
+  TRes findLanguages(
+      Iterable<Query$FindLanguages$findLanguages> Function(
+              Iterable<
+                  CopyWith$Query$FindLanguages$findLanguages<
+                      Query$FindLanguages$findLanguages>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindLanguages<TRes>
+    implements CopyWith$Query$FindLanguages<TRes> {
+  _CopyWithImpl$Query$FindLanguages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindLanguages _instance;
+
+  final TRes Function(Query$FindLanguages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findLanguages = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindLanguages(
+        findLanguages: findLanguages == _undefined || findLanguages == null
+            ? _instance.findLanguages
+            : (findLanguages as List<Query$FindLanguages$findLanguages>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findLanguages(
+          Iterable<Query$FindLanguages$findLanguages> Function(
+                  Iterable<
+                      CopyWith$Query$FindLanguages$findLanguages<
+                          Query$FindLanguages$findLanguages>>)
+              _fn) =>
+      call(
+          findLanguages: _fn(_instance.findLanguages
+              .map((e) => CopyWith$Query$FindLanguages$findLanguages(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindLanguages<TRes>
+    implements CopyWith$Query$FindLanguages<TRes> {
+  _CopyWithStubImpl$Query$FindLanguages(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindLanguages$findLanguages>? findLanguages,
+    String? $__typename,
+  }) =>
+      _res;
+  findLanguages(_fn) => _res;
+}
+
+const documentNodeQueryFindLanguages = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindLanguages'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findLanguages'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'isUiLanguage'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'shortLangCode'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'longLangCode'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindLanguages$findLanguages {
+  Query$FindLanguages$findLanguages({
+    required this.textId,
+    this.translatedValue,
+    required this.isUiLanguage,
+    this.shortLangCode,
+    this.longLangCode,
+    this.$__typename = 'Language',
+  });
+
+  factory Query$FindLanguages$findLanguages.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$isUiLanguage = json['isUiLanguage'];
+    final l$shortLangCode = json['shortLangCode'];
+    final l$longLangCode = json['longLangCode'];
+    final l$$__typename = json['__typename'];
+    return Query$FindLanguages$findLanguages(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      isUiLanguage: (l$isUiLanguage as bool),
+      shortLangCode: (l$shortLangCode as String?),
+      longLangCode: (l$longLangCode as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final bool isUiLanguage;
+
+  final String? shortLangCode;
+
+  final String? longLangCode;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$isUiLanguage = isUiLanguage;
+    _resultData['isUiLanguage'] = l$isUiLanguage;
+    final l$shortLangCode = shortLangCode;
+    _resultData['shortLangCode'] = l$shortLangCode;
+    final l$longLangCode = longLangCode;
+    _resultData['longLangCode'] = l$longLangCode;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$isUiLanguage = isUiLanguage;
+    final l$shortLangCode = shortLangCode;
+    final l$longLangCode = longLangCode;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$isUiLanguage,
+      l$shortLangCode,
+      l$longLangCode,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindLanguages$findLanguages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$isUiLanguage = isUiLanguage;
+    final lOther$isUiLanguage = other.isUiLanguage;
+    if (l$isUiLanguage != lOther$isUiLanguage) {
+      return false;
+    }
+    final l$shortLangCode = shortLangCode;
+    final lOther$shortLangCode = other.shortLangCode;
+    if (l$shortLangCode != lOther$shortLangCode) {
+      return false;
+    }
+    final l$longLangCode = longLangCode;
+    final lOther$longLangCode = other.longLangCode;
+    if (l$longLangCode != lOther$longLangCode) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindLanguages$findLanguages
+    on Query$FindLanguages$findLanguages {
+  CopyWith$Query$FindLanguages$findLanguages<Query$FindLanguages$findLanguages>
+      get copyWith => CopyWith$Query$FindLanguages$findLanguages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindLanguages$findLanguages<TRes> {
+  factory CopyWith$Query$FindLanguages$findLanguages(
+    Query$FindLanguages$findLanguages instance,
+    TRes Function(Query$FindLanguages$findLanguages) then,
+  ) = _CopyWithImpl$Query$FindLanguages$findLanguages;
+
+  factory CopyWith$Query$FindLanguages$findLanguages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindLanguages$findLanguages;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    bool? isUiLanguage,
+    String? shortLangCode,
+    String? longLangCode,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindLanguages$findLanguages<TRes>
+    implements CopyWith$Query$FindLanguages$findLanguages<TRes> {
+  _CopyWithImpl$Query$FindLanguages$findLanguages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindLanguages$findLanguages _instance;
+
+  final TRes Function(Query$FindLanguages$findLanguages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? isUiLanguage = _undefined,
+    Object? shortLangCode = _undefined,
+    Object? longLangCode = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindLanguages$findLanguages(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        isUiLanguage: isUiLanguage == _undefined || isUiLanguage == null
+            ? _instance.isUiLanguage
+            : (isUiLanguage as bool),
+        shortLangCode: shortLangCode == _undefined
+            ? _instance.shortLangCode
+            : (shortLangCode as String?),
+        longLangCode: longLangCode == _undefined
+            ? _instance.longLangCode
+            : (longLangCode as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindLanguages$findLanguages<TRes>
+    implements CopyWith$Query$FindLanguages$findLanguages<TRes> {
+  _CopyWithStubImpl$Query$FindLanguages$findLanguages(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    bool? isUiLanguage,
+    String? shortLangCode,
+    String? longLangCode,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptions {
+  Query$FindAllOptions({
+    required this.findOptions,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindAllOptions.fromJson(Map<String, dynamic> json) {
+    final l$findOptions = json['findOptions'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptions(
+      findOptions: (l$findOptions as List<dynamic>)
+          .map((e) => Query$FindAllOptions$findOptions.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindAllOptions$findOptions> findOptions;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findOptions = findOptions;
+    _resultData['findOptions'] = l$findOptions.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findOptions = findOptions;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findOptions.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptions) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findOptions = findOptions;
+    final lOther$findOptions = other.findOptions;
+    if (l$findOptions.length != lOther$findOptions.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findOptions.length; i++) {
+      final l$findOptions$entry = l$findOptions[i];
+      final lOther$findOptions$entry = lOther$findOptions[i];
+      if (l$findOptions$entry != lOther$findOptions$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptions on Query$FindAllOptions {
+  CopyWith$Query$FindAllOptions<Query$FindAllOptions> get copyWith =>
+      CopyWith$Query$FindAllOptions(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindAllOptions<TRes> {
+  factory CopyWith$Query$FindAllOptions(
+    Query$FindAllOptions instance,
+    TRes Function(Query$FindAllOptions) then,
+  ) = _CopyWithImpl$Query$FindAllOptions;
+
+  factory CopyWith$Query$FindAllOptions.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptions;
+
+  TRes call({
+    List<Query$FindAllOptions$findOptions>? findOptions,
+    String? $__typename,
+  });
+  TRes findOptions(
+      Iterable<Query$FindAllOptions$findOptions> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptions$findOptions<
+                      Query$FindAllOptions$findOptions>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindAllOptions<TRes>
+    implements CopyWith$Query$FindAllOptions<TRes> {
+  _CopyWithImpl$Query$FindAllOptions(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptions _instance;
+
+  final TRes Function(Query$FindAllOptions) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findOptions = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptions(
+        findOptions: findOptions == _undefined || findOptions == null
+            ? _instance.findOptions
+            : (findOptions as List<Query$FindAllOptions$findOptions>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findOptions(
+          Iterable<Query$FindAllOptions$findOptions> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptions$findOptions<
+                          Query$FindAllOptions$findOptions>>)
+              _fn) =>
+      call(
+          findOptions: _fn(_instance.findOptions
+              .map((e) => CopyWith$Query$FindAllOptions$findOptions(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindAllOptions<TRes>
+    implements CopyWith$Query$FindAllOptions<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptions(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindAllOptions$findOptions>? findOptions,
+    String? $__typename,
+  }) =>
+      _res;
+  findOptions(_fn) => _res;
+}
+
+const documentNodeQueryFindAllOptions = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindAllOptions'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findOptions'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'optionType'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindAllOptions$findOptions {
+  Query$FindAllOptions$findOptions({
+    required this.textId,
+    this.translatedValue,
+    required this.optionType,
+    this.$__typename = 'Option',
+  });
+
+  factory Query$FindAllOptions$findOptions.fromJson(Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$optionType = json['optionType'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptions$findOptions(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      optionType: fromJson$Enum$OptionType((l$optionType as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final Enum$OptionType optionType;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$optionType = optionType;
+    _resultData['optionType'] = toJson$Enum$OptionType(l$optionType);
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$optionType = optionType;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$optionType,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptions$findOptions) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$optionType = optionType;
+    final lOther$optionType = other.optionType;
+    if (l$optionType != lOther$optionType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptions$findOptions
+    on Query$FindAllOptions$findOptions {
+  CopyWith$Query$FindAllOptions$findOptions<Query$FindAllOptions$findOptions>
+      get copyWith => CopyWith$Query$FindAllOptions$findOptions(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptions$findOptions<TRes> {
+  factory CopyWith$Query$FindAllOptions$findOptions(
+    Query$FindAllOptions$findOptions instance,
+    TRes Function(Query$FindAllOptions$findOptions) then,
+  ) = _CopyWithImpl$Query$FindAllOptions$findOptions;
+
+  factory CopyWith$Query$FindAllOptions$findOptions.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptions$findOptions;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    Enum$OptionType? optionType,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptions$findOptions<TRes>
+    implements CopyWith$Query$FindAllOptions$findOptions<TRes> {
+  _CopyWithImpl$Query$FindAllOptions$findOptions(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptions$findOptions _instance;
+
+  final TRes Function(Query$FindAllOptions$findOptions) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? optionType = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptions$findOptions(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        optionType: optionType == _undefined || optionType == null
+            ? _instance.optionType
+            : (optionType as Enum$OptionType),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptions$findOptions<TRes>
+    implements CopyWith$Query$FindAllOptions$findOptions<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptions$findOptions(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    Enum$OptionType? optionType,
+    String? $__typename,
+  }) =>
+      _res;
+}

--- a/lib/__generated/schema/operations_content.graphql.dart
+++ b/lib/__generated/schema/operations_content.graphql.dart
@@ -7,31 +7,31 @@ import 'schema.graphql.dart';
 
 class Query$FindCompanyStages {
   Query$FindCompanyStages({
-    required this.findCompanyTypes,
+    required this.findCompanyStages,
     this.$__typename = 'Query',
   });
 
   factory Query$FindCompanyStages.fromJson(Map<String, dynamic> json) {
-    final l$findCompanyTypes = json['findCompanyTypes'];
+    final l$findCompanyStages = json['findCompanyStages'];
     final l$$__typename = json['__typename'];
     return Query$FindCompanyStages(
-      findCompanyTypes: (l$findCompanyTypes as List<dynamic>)
-          .map((e) => Query$FindCompanyStages$findCompanyTypes.fromJson(
+      findCompanyStages: (l$findCompanyStages as List<dynamic>)
+          .map((e) => Query$FindCompanyStages$findCompanyStages.fromJson(
               (e as Map<String, dynamic>)))
           .toList(),
       $__typename: (l$$__typename as String),
     );
   }
 
-  final List<Query$FindCompanyStages$findCompanyTypes> findCompanyTypes;
+  final List<Query$FindCompanyStages$findCompanyStages> findCompanyStages;
 
   final String $__typename;
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
-    final l$findCompanyTypes = findCompanyTypes;
-    _resultData['findCompanyTypes'] =
-        l$findCompanyTypes.map((e) => e.toJson()).toList();
+    final l$findCompanyStages = findCompanyStages;
+    _resultData['findCompanyStages'] =
+        l$findCompanyStages.map((e) => e.toJson()).toList();
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -39,10 +39,10 @@ class Query$FindCompanyStages {
 
   @override
   int get hashCode {
-    final l$findCompanyTypes = findCompanyTypes;
+    final l$findCompanyStages = findCompanyStages;
     final l$$__typename = $__typename;
     return Object.hashAll([
-      Object.hashAll(l$findCompanyTypes.map((v) => v)),
+      Object.hashAll(l$findCompanyStages.map((v) => v)),
       l$$__typename,
     ]);
   }
@@ -56,15 +56,15 @@ class Query$FindCompanyStages {
         runtimeType != other.runtimeType) {
       return false;
     }
-    final l$findCompanyTypes = findCompanyTypes;
-    final lOther$findCompanyTypes = other.findCompanyTypes;
-    if (l$findCompanyTypes.length != lOther$findCompanyTypes.length) {
+    final l$findCompanyStages = findCompanyStages;
+    final lOther$findCompanyStages = other.findCompanyStages;
+    if (l$findCompanyStages.length != lOther$findCompanyStages.length) {
       return false;
     }
-    for (int i = 0; i < l$findCompanyTypes.length; i++) {
-      final l$findCompanyTypes$entry = l$findCompanyTypes[i];
-      final lOther$findCompanyTypes$entry = lOther$findCompanyTypes[i];
-      if (l$findCompanyTypes$entry != lOther$findCompanyTypes$entry) {
+    for (int i = 0; i < l$findCompanyStages.length; i++) {
+      final l$findCompanyStages$entry = l$findCompanyStages[i];
+      final lOther$findCompanyStages$entry = lOther$findCompanyStages[i];
+      if (l$findCompanyStages$entry != lOther$findCompanyStages$entry) {
         return false;
       }
     }
@@ -95,14 +95,14 @@ abstract class CopyWith$Query$FindCompanyStages<TRes> {
       _CopyWithStubImpl$Query$FindCompanyStages;
 
   TRes call({
-    List<Query$FindCompanyStages$findCompanyTypes>? findCompanyTypes,
+    List<Query$FindCompanyStages$findCompanyStages>? findCompanyStages,
     String? $__typename,
   });
-  TRes findCompanyTypes(
-      Iterable<Query$FindCompanyStages$findCompanyTypes> Function(
+  TRes findCompanyStages(
+      Iterable<Query$FindCompanyStages$findCompanyStages> Function(
               Iterable<
-                  CopyWith$Query$FindCompanyStages$findCompanyTypes<
-                      Query$FindCompanyStages$findCompanyTypes>>)
+                  CopyWith$Query$FindCompanyStages$findCompanyStages<
+                      Query$FindCompanyStages$findCompanyStages>>)
           _fn);
 }
 
@@ -120,28 +120,28 @@ class _CopyWithImpl$Query$FindCompanyStages<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
-    Object? findCompanyTypes = _undefined,
+    Object? findCompanyStages = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindCompanyStages(
-        findCompanyTypes:
-            findCompanyTypes == _undefined || findCompanyTypes == null
-                ? _instance.findCompanyTypes
-                : (findCompanyTypes
-                    as List<Query$FindCompanyStages$findCompanyTypes>),
+        findCompanyStages:
+            findCompanyStages == _undefined || findCompanyStages == null
+                ? _instance.findCompanyStages
+                : (findCompanyStages
+                    as List<Query$FindCompanyStages$findCompanyStages>),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
       ));
-  TRes findCompanyTypes(
-          Iterable<Query$FindCompanyStages$findCompanyTypes> Function(
+  TRes findCompanyStages(
+          Iterable<Query$FindCompanyStages$findCompanyStages> Function(
                   Iterable<
-                      CopyWith$Query$FindCompanyStages$findCompanyTypes<
-                          Query$FindCompanyStages$findCompanyTypes>>)
+                      CopyWith$Query$FindCompanyStages$findCompanyStages<
+                          Query$FindCompanyStages$findCompanyStages>>)
               _fn) =>
       call(
-          findCompanyTypes: _fn(_instance.findCompanyTypes
-              .map((e) => CopyWith$Query$FindCompanyStages$findCompanyTypes(
+          findCompanyStages: _fn(_instance.findCompanyStages
+              .map((e) => CopyWith$Query$FindCompanyStages$findCompanyStages(
                     e,
                     (i) => i,
                   ))).toList());
@@ -154,11 +154,11 @@ class _CopyWithStubImpl$Query$FindCompanyStages<TRes>
   TRes _res;
 
   call({
-    List<Query$FindCompanyStages$findCompanyTypes>? findCompanyTypes,
+    List<Query$FindCompanyStages$findCompanyStages>? findCompanyStages,
     String? $__typename,
   }) =>
       _res;
-  findCompanyTypes(_fn) => _res;
+  findCompanyStages(_fn) => _res;
 }
 
 const documentNodeQueryFindCompanyStages = DocumentNode(definitions: [
@@ -169,7 +169,7 @@ const documentNodeQueryFindCompanyStages = DocumentNode(definitions: [
     directives: [],
     selectionSet: SelectionSetNode(selections: [
       FieldNode(
-        name: NameNode(value: 'findCompanyTypes'),
+        name: NameNode(value: 'findCompanyStages'),
         alias: null,
         arguments: [],
         directives: [],
@@ -355,19 +355,222 @@ class _CopyWithStubImpl$Query$FindCompanyStages$findCompanyStages<TRes>
       _res;
 }
 
-class Query$FindCompanyStages$findCompanyTypes {
-  Query$FindCompanyStages$findCompanyTypes({
+class Query$FindCompanyTypes {
+  Query$FindCompanyTypes({
+    required this.findCompanyTypes,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindCompanyTypes.fromJson(Map<String, dynamic> json) {
+    final l$findCompanyTypes = json['findCompanyTypes'];
+    final l$$__typename = json['__typename'];
+    return Query$FindCompanyTypes(
+      findCompanyTypes: (l$findCompanyTypes as List<dynamic>)
+          .map((e) => Query$FindCompanyTypes$findCompanyTypes.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindCompanyTypes$findCompanyTypes> findCompanyTypes;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findCompanyTypes = findCompanyTypes;
+    _resultData['findCompanyTypes'] =
+        l$findCompanyTypes.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findCompanyTypes = findCompanyTypes;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findCompanyTypes.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindCompanyTypes) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findCompanyTypes = findCompanyTypes;
+    final lOther$findCompanyTypes = other.findCompanyTypes;
+    if (l$findCompanyTypes.length != lOther$findCompanyTypes.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCompanyTypes.length; i++) {
+      final l$findCompanyTypes$entry = l$findCompanyTypes[i];
+      final lOther$findCompanyTypes$entry = lOther$findCompanyTypes[i];
+      if (l$findCompanyTypes$entry != lOther$findCompanyTypes$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindCompanyTypes on Query$FindCompanyTypes {
+  CopyWith$Query$FindCompanyTypes<Query$FindCompanyTypes> get copyWith =>
+      CopyWith$Query$FindCompanyTypes(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindCompanyTypes<TRes> {
+  factory CopyWith$Query$FindCompanyTypes(
+    Query$FindCompanyTypes instance,
+    TRes Function(Query$FindCompanyTypes) then,
+  ) = _CopyWithImpl$Query$FindCompanyTypes;
+
+  factory CopyWith$Query$FindCompanyTypes.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCompanyTypes;
+
+  TRes call({
+    List<Query$FindCompanyTypes$findCompanyTypes>? findCompanyTypes,
+    String? $__typename,
+  });
+  TRes findCompanyTypes(
+      Iterable<Query$FindCompanyTypes$findCompanyTypes> Function(
+              Iterable<
+                  CopyWith$Query$FindCompanyTypes$findCompanyTypes<
+                      Query$FindCompanyTypes$findCompanyTypes>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyTypes<TRes> {
+  _CopyWithImpl$Query$FindCompanyTypes(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindCompanyTypes _instance;
+
+  final TRes Function(Query$FindCompanyTypes) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findCompanyTypes = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindCompanyTypes(
+        findCompanyTypes:
+            findCompanyTypes == _undefined || findCompanyTypes == null
+                ? _instance.findCompanyTypes
+                : (findCompanyTypes
+                    as List<Query$FindCompanyTypes$findCompanyTypes>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findCompanyTypes(
+          Iterable<Query$FindCompanyTypes$findCompanyTypes> Function(
+                  Iterable<
+                      CopyWith$Query$FindCompanyTypes$findCompanyTypes<
+                          Query$FindCompanyTypes$findCompanyTypes>>)
+              _fn) =>
+      call(
+          findCompanyTypes: _fn(_instance.findCompanyTypes
+              .map((e) => CopyWith$Query$FindCompanyTypes$findCompanyTypes(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyTypes<TRes> {
+  _CopyWithStubImpl$Query$FindCompanyTypes(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindCompanyTypes$findCompanyTypes>? findCompanyTypes,
+    String? $__typename,
+  }) =>
+      _res;
+  findCompanyTypes(_fn) => _res;
+}
+
+const documentNodeQueryFindCompanyTypes = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindCompanyTypes'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findCompanyTypes'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindCompanyTypes$findCompanyTypes {
+  Query$FindCompanyTypes$findCompanyTypes({
     required this.textId,
     this.translatedValue,
     this.$__typename = 'CompanyType',
   });
 
-  factory Query$FindCompanyStages$findCompanyTypes.fromJson(
+  factory Query$FindCompanyTypes$findCompanyTypes.fromJson(
       Map<String, dynamic> json) {
     final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
-    return Query$FindCompanyStages$findCompanyTypes(
+    return Query$FindCompanyTypes$findCompanyTypes(
       textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
@@ -408,7 +611,7 @@ class Query$FindCompanyStages$findCompanyTypes {
     if (identical(this, other)) {
       return true;
     }
-    if (!(other is Query$FindCompanyStages$findCompanyTypes) ||
+    if (!(other is Query$FindCompanyTypes$findCompanyTypes) ||
         runtimeType != other.runtimeType) {
       return false;
     }
@@ -431,24 +634,24 @@ class Query$FindCompanyStages$findCompanyTypes {
   }
 }
 
-extension UtilityExtension$Query$FindCompanyStages$findCompanyTypes
-    on Query$FindCompanyStages$findCompanyTypes {
-  CopyWith$Query$FindCompanyStages$findCompanyTypes<
-          Query$FindCompanyStages$findCompanyTypes>
-      get copyWith => CopyWith$Query$FindCompanyStages$findCompanyTypes(
+extension UtilityExtension$Query$FindCompanyTypes$findCompanyTypes
+    on Query$FindCompanyTypes$findCompanyTypes {
+  CopyWith$Query$FindCompanyTypes$findCompanyTypes<
+          Query$FindCompanyTypes$findCompanyTypes>
+      get copyWith => CopyWith$Query$FindCompanyTypes$findCompanyTypes(
             this,
             (i) => i,
           );
 }
 
-abstract class CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
-  factory CopyWith$Query$FindCompanyStages$findCompanyTypes(
-    Query$FindCompanyStages$findCompanyTypes instance,
-    TRes Function(Query$FindCompanyStages$findCompanyTypes) then,
-  ) = _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes;
+abstract class CopyWith$Query$FindCompanyTypes$findCompanyTypes<TRes> {
+  factory CopyWith$Query$FindCompanyTypes$findCompanyTypes(
+    Query$FindCompanyTypes$findCompanyTypes instance,
+    TRes Function(Query$FindCompanyTypes$findCompanyTypes) then,
+  ) = _CopyWithImpl$Query$FindCompanyTypes$findCompanyTypes;
 
-  factory CopyWith$Query$FindCompanyStages$findCompanyTypes.stub(TRes res) =
-      _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes;
+  factory CopyWith$Query$FindCompanyTypes$findCompanyTypes.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindCompanyTypes$findCompanyTypes;
 
   TRes call({
     String? textId,
@@ -457,16 +660,16 @@ abstract class CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
   });
 }
 
-class _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
-    implements CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
-  _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes(
+class _CopyWithImpl$Query$FindCompanyTypes$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyTypes$findCompanyTypes<TRes> {
+  _CopyWithImpl$Query$FindCompanyTypes$findCompanyTypes(
     this._instance,
     this._then,
   );
 
-  final Query$FindCompanyStages$findCompanyTypes _instance;
+  final Query$FindCompanyTypes$findCompanyTypes _instance;
 
-  final TRes Function(Query$FindCompanyStages$findCompanyTypes) _then;
+  final TRes Function(Query$FindCompanyTypes$findCompanyTypes) _then;
 
   static const _undefined = <dynamic, dynamic>{};
 
@@ -475,7 +678,7 @@ class _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
-      _then(Query$FindCompanyStages$findCompanyTypes(
+      _then(Query$FindCompanyTypes$findCompanyTypes(
         textId: textId == _undefined || textId == null
             ? _instance.textId
             : (textId as String),
@@ -488,9 +691,9 @@ class _CopyWithImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
       ));
 }
 
-class _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes<TRes>
-    implements CopyWith$Query$FindCompanyStages$findCompanyTypes<TRes> {
-  _CopyWithStubImpl$Query$FindCompanyStages$findCompanyTypes(this._res);
+class _CopyWithStubImpl$Query$FindCompanyTypes$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindCompanyTypes$findCompanyTypes<TRes> {
+  _CopyWithStubImpl$Query$FindCompanyTypes$findCompanyTypes(this._res);
 
   TRes _res;
 

--- a/lib/__generated/schema/operations_content.graphql.dart
+++ b/lib/__generated/schema/operations_content.graphql.dart
@@ -5,6 +5,2054 @@
 import 'package:gql/ast.dart';
 import 'schema.graphql.dart';
 
+class Query$FindAllOptionsByType {
+  Query$FindAllOptionsByType({
+    required this.findCompanyStages,
+    required this.findCompanyTypes,
+    required this.findCountries,
+    required this.findEducationLevels,
+    required this.findExpertises,
+    required this.findIndustries,
+    required this.findGenders,
+    required this.findLanguages,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindAllOptionsByType.fromJson(Map<String, dynamic> json) {
+    final l$findCompanyStages = json['findCompanyStages'];
+    final l$findCompanyTypes = json['findCompanyTypes'];
+    final l$findCountries = json['findCountries'];
+    final l$findEducationLevels = json['findEducationLevels'];
+    final l$findExpertises = json['findExpertises'];
+    final l$findIndustries = json['findIndustries'];
+    final l$findGenders = json['findGenders'];
+    final l$findLanguages = json['findLanguages'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType(
+      findCompanyStages: (l$findCompanyStages as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findCompanyStages.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findCompanyTypes: (l$findCompanyTypes as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findCompanyTypes.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findCountries: (l$findCountries as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findCountries.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findEducationLevels: (l$findEducationLevels as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findEducationLevels.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findExpertises: (l$findExpertises as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findExpertises.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findIndustries: (l$findIndustries as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findIndustries.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findGenders: (l$findGenders as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findGenders.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      findLanguages: (l$findLanguages as List<dynamic>)
+          .map((e) => Query$FindAllOptionsByType$findLanguages.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindAllOptionsByType$findCompanyStages> findCompanyStages;
+
+  final List<Query$FindAllOptionsByType$findCompanyTypes> findCompanyTypes;
+
+  final List<Query$FindAllOptionsByType$findCountries> findCountries;
+
+  final List<Query$FindAllOptionsByType$findEducationLevels>
+      findEducationLevels;
+
+  final List<Query$FindAllOptionsByType$findExpertises> findExpertises;
+
+  final List<Query$FindAllOptionsByType$findIndustries> findIndustries;
+
+  final List<Query$FindAllOptionsByType$findGenders> findGenders;
+
+  final List<Query$FindAllOptionsByType$findLanguages> findLanguages;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findCompanyStages = findCompanyStages;
+    _resultData['findCompanyStages'] =
+        l$findCompanyStages.map((e) => e.toJson()).toList();
+    final l$findCompanyTypes = findCompanyTypes;
+    _resultData['findCompanyTypes'] =
+        l$findCompanyTypes.map((e) => e.toJson()).toList();
+    final l$findCountries = findCountries;
+    _resultData['findCountries'] =
+        l$findCountries.map((e) => e.toJson()).toList();
+    final l$findEducationLevels = findEducationLevels;
+    _resultData['findEducationLevels'] =
+        l$findEducationLevels.map((e) => e.toJson()).toList();
+    final l$findExpertises = findExpertises;
+    _resultData['findExpertises'] =
+        l$findExpertises.map((e) => e.toJson()).toList();
+    final l$findIndustries = findIndustries;
+    _resultData['findIndustries'] =
+        l$findIndustries.map((e) => e.toJson()).toList();
+    final l$findGenders = findGenders;
+    _resultData['findGenders'] = l$findGenders.map((e) => e.toJson()).toList();
+    final l$findLanguages = findLanguages;
+    _resultData['findLanguages'] =
+        l$findLanguages.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findCompanyStages = findCompanyStages;
+    final l$findCompanyTypes = findCompanyTypes;
+    final l$findCountries = findCountries;
+    final l$findEducationLevels = findEducationLevels;
+    final l$findExpertises = findExpertises;
+    final l$findIndustries = findIndustries;
+    final l$findGenders = findGenders;
+    final l$findLanguages = findLanguages;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findCompanyStages.map((v) => v)),
+      Object.hashAll(l$findCompanyTypes.map((v) => v)),
+      Object.hashAll(l$findCountries.map((v) => v)),
+      Object.hashAll(l$findEducationLevels.map((v) => v)),
+      Object.hashAll(l$findExpertises.map((v) => v)),
+      Object.hashAll(l$findIndustries.map((v) => v)),
+      Object.hashAll(l$findGenders.map((v) => v)),
+      Object.hashAll(l$findLanguages.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findCompanyStages = findCompanyStages;
+    final lOther$findCompanyStages = other.findCompanyStages;
+    if (l$findCompanyStages.length != lOther$findCompanyStages.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCompanyStages.length; i++) {
+      final l$findCompanyStages$entry = l$findCompanyStages[i];
+      final lOther$findCompanyStages$entry = lOther$findCompanyStages[i];
+      if (l$findCompanyStages$entry != lOther$findCompanyStages$entry) {
+        return false;
+      }
+    }
+    final l$findCompanyTypes = findCompanyTypes;
+    final lOther$findCompanyTypes = other.findCompanyTypes;
+    if (l$findCompanyTypes.length != lOther$findCompanyTypes.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCompanyTypes.length; i++) {
+      final l$findCompanyTypes$entry = l$findCompanyTypes[i];
+      final lOther$findCompanyTypes$entry = lOther$findCompanyTypes[i];
+      if (l$findCompanyTypes$entry != lOther$findCompanyTypes$entry) {
+        return false;
+      }
+    }
+    final l$findCountries = findCountries;
+    final lOther$findCountries = other.findCountries;
+    if (l$findCountries.length != lOther$findCountries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findCountries.length; i++) {
+      final l$findCountries$entry = l$findCountries[i];
+      final lOther$findCountries$entry = lOther$findCountries[i];
+      if (l$findCountries$entry != lOther$findCountries$entry) {
+        return false;
+      }
+    }
+    final l$findEducationLevels = findEducationLevels;
+    final lOther$findEducationLevels = other.findEducationLevels;
+    if (l$findEducationLevels.length != lOther$findEducationLevels.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findEducationLevels.length; i++) {
+      final l$findEducationLevels$entry = l$findEducationLevels[i];
+      final lOther$findEducationLevels$entry = lOther$findEducationLevels[i];
+      if (l$findEducationLevels$entry != lOther$findEducationLevels$entry) {
+        return false;
+      }
+    }
+    final l$findExpertises = findExpertises;
+    final lOther$findExpertises = other.findExpertises;
+    if (l$findExpertises.length != lOther$findExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findExpertises.length; i++) {
+      final l$findExpertises$entry = l$findExpertises[i];
+      final lOther$findExpertises$entry = lOther$findExpertises[i];
+      if (l$findExpertises$entry != lOther$findExpertises$entry) {
+        return false;
+      }
+    }
+    final l$findIndustries = findIndustries;
+    final lOther$findIndustries = other.findIndustries;
+    if (l$findIndustries.length != lOther$findIndustries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findIndustries.length; i++) {
+      final l$findIndustries$entry = l$findIndustries[i];
+      final lOther$findIndustries$entry = lOther$findIndustries[i];
+      if (l$findIndustries$entry != lOther$findIndustries$entry) {
+        return false;
+      }
+    }
+    final l$findGenders = findGenders;
+    final lOther$findGenders = other.findGenders;
+    if (l$findGenders.length != lOther$findGenders.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findGenders.length; i++) {
+      final l$findGenders$entry = l$findGenders[i];
+      final lOther$findGenders$entry = lOther$findGenders[i];
+      if (l$findGenders$entry != lOther$findGenders$entry) {
+        return false;
+      }
+    }
+    final l$findLanguages = findLanguages;
+    final lOther$findLanguages = other.findLanguages;
+    if (l$findLanguages.length != lOther$findLanguages.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findLanguages.length; i++) {
+      final l$findLanguages$entry = l$findLanguages[i];
+      final lOther$findLanguages$entry = lOther$findLanguages[i];
+      if (l$findLanguages$entry != lOther$findLanguages$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType
+    on Query$FindAllOptionsByType {
+  CopyWith$Query$FindAllOptionsByType<Query$FindAllOptionsByType>
+      get copyWith => CopyWith$Query$FindAllOptionsByType(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType(
+    Query$FindAllOptionsByType instance,
+    TRes Function(Query$FindAllOptionsByType) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType;
+
+  factory CopyWith$Query$FindAllOptionsByType.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType;
+
+  TRes call({
+    List<Query$FindAllOptionsByType$findCompanyStages>? findCompanyStages,
+    List<Query$FindAllOptionsByType$findCompanyTypes>? findCompanyTypes,
+    List<Query$FindAllOptionsByType$findCountries>? findCountries,
+    List<Query$FindAllOptionsByType$findEducationLevels>? findEducationLevels,
+    List<Query$FindAllOptionsByType$findExpertises>? findExpertises,
+    List<Query$FindAllOptionsByType$findIndustries>? findIndustries,
+    List<Query$FindAllOptionsByType$findGenders>? findGenders,
+    List<Query$FindAllOptionsByType$findLanguages>? findLanguages,
+    String? $__typename,
+  });
+  TRes findCompanyStages(
+      Iterable<Query$FindAllOptionsByType$findCompanyStages> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findCompanyStages<
+                      Query$FindAllOptionsByType$findCompanyStages>>)
+          _fn);
+  TRes findCompanyTypes(
+      Iterable<Query$FindAllOptionsByType$findCompanyTypes> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findCompanyTypes<
+                      Query$FindAllOptionsByType$findCompanyTypes>>)
+          _fn);
+  TRes findCountries(
+      Iterable<Query$FindAllOptionsByType$findCountries> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findCountries<
+                      Query$FindAllOptionsByType$findCountries>>)
+          _fn);
+  TRes findEducationLevels(
+      Iterable<Query$FindAllOptionsByType$findEducationLevels> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findEducationLevels<
+                      Query$FindAllOptionsByType$findEducationLevels>>)
+          _fn);
+  TRes findExpertises(
+      Iterable<Query$FindAllOptionsByType$findExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findExpertises<
+                      Query$FindAllOptionsByType$findExpertises>>)
+          _fn);
+  TRes findIndustries(
+      Iterable<Query$FindAllOptionsByType$findIndustries> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findIndustries<
+                      Query$FindAllOptionsByType$findIndustries>>)
+          _fn);
+  TRes findGenders(
+      Iterable<Query$FindAllOptionsByType$findGenders> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findGenders<
+                      Query$FindAllOptionsByType$findGenders>>)
+          _fn);
+  TRes findLanguages(
+      Iterable<Query$FindAllOptionsByType$findLanguages> Function(
+              Iterable<
+                  CopyWith$Query$FindAllOptionsByType$findLanguages<
+                      Query$FindAllOptionsByType$findLanguages>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType<TRes>
+    implements CopyWith$Query$FindAllOptionsByType<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType _instance;
+
+  final TRes Function(Query$FindAllOptionsByType) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findCompanyStages = _undefined,
+    Object? findCompanyTypes = _undefined,
+    Object? findCountries = _undefined,
+    Object? findEducationLevels = _undefined,
+    Object? findExpertises = _undefined,
+    Object? findIndustries = _undefined,
+    Object? findGenders = _undefined,
+    Object? findLanguages = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType(
+        findCompanyStages:
+            findCompanyStages == _undefined || findCompanyStages == null
+                ? _instance.findCompanyStages
+                : (findCompanyStages
+                    as List<Query$FindAllOptionsByType$findCompanyStages>),
+        findCompanyTypes:
+            findCompanyTypes == _undefined || findCompanyTypes == null
+                ? _instance.findCompanyTypes
+                : (findCompanyTypes
+                    as List<Query$FindAllOptionsByType$findCompanyTypes>),
+        findCountries: findCountries == _undefined || findCountries == null
+            ? _instance.findCountries
+            : (findCountries as List<Query$FindAllOptionsByType$findCountries>),
+        findEducationLevels:
+            findEducationLevels == _undefined || findEducationLevels == null
+                ? _instance.findEducationLevels
+                : (findEducationLevels
+                    as List<Query$FindAllOptionsByType$findEducationLevels>),
+        findExpertises: findExpertises == _undefined || findExpertises == null
+            ? _instance.findExpertises
+            : (findExpertises
+                as List<Query$FindAllOptionsByType$findExpertises>),
+        findIndustries: findIndustries == _undefined || findIndustries == null
+            ? _instance.findIndustries
+            : (findIndustries
+                as List<Query$FindAllOptionsByType$findIndustries>),
+        findGenders: findGenders == _undefined || findGenders == null
+            ? _instance.findGenders
+            : (findGenders as List<Query$FindAllOptionsByType$findGenders>),
+        findLanguages: findLanguages == _undefined || findLanguages == null
+            ? _instance.findLanguages
+            : (findLanguages as List<Query$FindAllOptionsByType$findLanguages>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findCompanyStages(
+          Iterable<Query$FindAllOptionsByType$findCompanyStages> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findCompanyStages<
+                          Query$FindAllOptionsByType$findCompanyStages>>)
+              _fn) =>
+      call(
+          findCompanyStages: _fn(_instance.findCompanyStages
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findCompanyStages(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findCompanyTypes(
+          Iterable<Query$FindAllOptionsByType$findCompanyTypes> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findCompanyTypes<
+                          Query$FindAllOptionsByType$findCompanyTypes>>)
+              _fn) =>
+      call(
+          findCompanyTypes: _fn(_instance.findCompanyTypes
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findCompanyTypes(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findCountries(
+          Iterable<Query$FindAllOptionsByType$findCountries> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findCountries<
+                          Query$FindAllOptionsByType$findCountries>>)
+              _fn) =>
+      call(
+          findCountries: _fn(_instance.findCountries
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findCountries(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findEducationLevels(
+          Iterable<Query$FindAllOptionsByType$findEducationLevels> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findEducationLevels<
+                          Query$FindAllOptionsByType$findEducationLevels>>)
+              _fn) =>
+      call(
+          findEducationLevels: _fn(_instance.findEducationLevels.map(
+              (e) => CopyWith$Query$FindAllOptionsByType$findEducationLevels(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findExpertises(
+          Iterable<Query$FindAllOptionsByType$findExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findExpertises<
+                          Query$FindAllOptionsByType$findExpertises>>)
+              _fn) =>
+      call(
+          findExpertises: _fn(_instance.findExpertises
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findExpertises(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findIndustries(
+          Iterable<Query$FindAllOptionsByType$findIndustries> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findIndustries<
+                          Query$FindAllOptionsByType$findIndustries>>)
+              _fn) =>
+      call(
+          findIndustries: _fn(_instance.findIndustries
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findIndustries(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findGenders(
+          Iterable<Query$FindAllOptionsByType$findGenders> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findGenders<
+                          Query$FindAllOptionsByType$findGenders>>)
+              _fn) =>
+      call(
+          findGenders: _fn(_instance.findGenders
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findGenders(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes findLanguages(
+          Iterable<Query$FindAllOptionsByType$findLanguages> Function(
+                  Iterable<
+                      CopyWith$Query$FindAllOptionsByType$findLanguages<
+                          Query$FindAllOptionsByType$findLanguages>>)
+              _fn) =>
+      call(
+          findLanguages: _fn(_instance.findLanguages
+              .map((e) => CopyWith$Query$FindAllOptionsByType$findLanguages(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType<TRes>
+    implements CopyWith$Query$FindAllOptionsByType<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindAllOptionsByType$findCompanyStages>? findCompanyStages,
+    List<Query$FindAllOptionsByType$findCompanyTypes>? findCompanyTypes,
+    List<Query$FindAllOptionsByType$findCountries>? findCountries,
+    List<Query$FindAllOptionsByType$findEducationLevels>? findEducationLevels,
+    List<Query$FindAllOptionsByType$findExpertises>? findExpertises,
+    List<Query$FindAllOptionsByType$findIndustries>? findIndustries,
+    List<Query$FindAllOptionsByType$findGenders>? findGenders,
+    List<Query$FindAllOptionsByType$findLanguages>? findLanguages,
+    String? $__typename,
+  }) =>
+      _res;
+  findCompanyStages(_fn) => _res;
+  findCompanyTypes(_fn) => _res;
+  findCountries(_fn) => _res;
+  findEducationLevels(_fn) => _res;
+  findExpertises(_fn) => _res;
+  findIndustries(_fn) => _res;
+  findGenders(_fn) => _res;
+  findLanguages(_fn) => _res;
+}
+
+const documentNodeQueryFindAllOptionsByType = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindAllOptionsByType'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findCompanyStages'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findCompanyTypes'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findCountries'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'alpha2Key'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findEducationLevels'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findExpertises'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findIndustries'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findGenders'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: 'findLanguages'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'isUiLanguage'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'shortLangCode'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'longLangCode'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindAllOptionsByType$findCompanyStages {
+  Query$FindAllOptionsByType$findCompanyStages({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$FindAllOptionsByType$findCompanyStages.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findCompanyStages(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findCompanyStages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findCompanyStages
+    on Query$FindAllOptionsByType$findCompanyStages {
+  CopyWith$Query$FindAllOptionsByType$findCompanyStages<
+          Query$FindAllOptionsByType$findCompanyStages>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findCompanyStages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findCompanyStages<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findCompanyStages(
+    Query$FindAllOptionsByType$findCompanyStages instance,
+    TRes Function(Query$FindAllOptionsByType$findCompanyStages) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findCompanyStages;
+
+  factory CopyWith$Query$FindAllOptionsByType$findCompanyStages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyStages;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findCompanyStages<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCompanyStages<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findCompanyStages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findCompanyStages _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findCompanyStages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findCompanyStages(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyStages<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCompanyStages<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyStages(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findCompanyTypes {
+  Query$FindAllOptionsByType$findCompanyTypes({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'CompanyType',
+  });
+
+  factory Query$FindAllOptionsByType$findCompanyTypes.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findCompanyTypes(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findCompanyTypes) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findCompanyTypes
+    on Query$FindAllOptionsByType$findCompanyTypes {
+  CopyWith$Query$FindAllOptionsByType$findCompanyTypes<
+          Query$FindAllOptionsByType$findCompanyTypes>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findCompanyTypes(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findCompanyTypes<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findCompanyTypes(
+    Query$FindAllOptionsByType$findCompanyTypes instance,
+    TRes Function(Query$FindAllOptionsByType$findCompanyTypes) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findCompanyTypes;
+
+  factory CopyWith$Query$FindAllOptionsByType$findCompanyTypes.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyTypes;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCompanyTypes<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findCompanyTypes(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findCompanyTypes _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findCompanyTypes) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findCompanyTypes(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyTypes<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCompanyTypes<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findCompanyTypes(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findCountries {
+  Query$FindAllOptionsByType$findCountries({
+    required this.alpha2Key,
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindAllOptionsByType$findCountries.fromJson(
+      Map<String, dynamic> json) {
+    final l$alpha2Key = json['alpha2Key'];
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findCountries(
+      alpha2Key: (l$alpha2Key as String),
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String alpha2Key;
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$alpha2Key = alpha2Key;
+    _resultData['alpha2Key'] = l$alpha2Key;
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$alpha2Key = alpha2Key;
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$alpha2Key,
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findCountries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$alpha2Key = alpha2Key;
+    final lOther$alpha2Key = other.alpha2Key;
+    if (l$alpha2Key != lOther$alpha2Key) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findCountries
+    on Query$FindAllOptionsByType$findCountries {
+  CopyWith$Query$FindAllOptionsByType$findCountries<
+          Query$FindAllOptionsByType$findCountries>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findCountries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findCountries<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findCountries(
+    Query$FindAllOptionsByType$findCountries instance,
+    TRes Function(Query$FindAllOptionsByType$findCountries) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findCountries;
+
+  factory CopyWith$Query$FindAllOptionsByType$findCountries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findCountries;
+
+  TRes call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findCountries<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCountries<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findCountries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findCountries _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findCountries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? alpha2Key = _undefined,
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findCountries(
+        alpha2Key: alpha2Key == _undefined || alpha2Key == null
+            ? _instance.alpha2Key
+            : (alpha2Key as String),
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findCountries<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findCountries<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findCountries(this._res);
+
+  TRes _res;
+
+  call({
+    String? alpha2Key,
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findEducationLevels {
+  Query$FindAllOptionsByType$findEducationLevels({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'EducationLevel',
+  });
+
+  factory Query$FindAllOptionsByType$findEducationLevels.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findEducationLevels(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findEducationLevels) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findEducationLevels
+    on Query$FindAllOptionsByType$findEducationLevels {
+  CopyWith$Query$FindAllOptionsByType$findEducationLevels<
+          Query$FindAllOptionsByType$findEducationLevels>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findEducationLevels(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findEducationLevels<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findEducationLevels(
+    Query$FindAllOptionsByType$findEducationLevels instance,
+    TRes Function(Query$FindAllOptionsByType$findEducationLevels) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findEducationLevels;
+
+  factory CopyWith$Query$FindAllOptionsByType$findEducationLevels.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findEducationLevels;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findEducationLevels<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findEducationLevels<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findEducationLevels(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findEducationLevels _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findEducationLevels) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findEducationLevels(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findEducationLevels<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findEducationLevels<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findEducationLevels(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findExpertises {
+  Query$FindAllOptionsByType$findExpertises({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindAllOptionsByType$findExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findExpertises(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findExpertises
+    on Query$FindAllOptionsByType$findExpertises {
+  CopyWith$Query$FindAllOptionsByType$findExpertises<
+          Query$FindAllOptionsByType$findExpertises>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findExpertises<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findExpertises(
+    Query$FindAllOptionsByType$findExpertises instance,
+    TRes Function(Query$FindAllOptionsByType$findExpertises) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findExpertises;
+
+  factory CopyWith$Query$FindAllOptionsByType$findExpertises.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findExpertises;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findExpertises<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findExpertises<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findExpertises _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findExpertises) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findExpertises(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findExpertises<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findExpertises<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findExpertises(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findIndustries {
+  Query$FindAllOptionsByType$findIndustries({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindAllOptionsByType$findIndustries.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findIndustries(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findIndustries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findIndustries
+    on Query$FindAllOptionsByType$findIndustries {
+  CopyWith$Query$FindAllOptionsByType$findIndustries<
+          Query$FindAllOptionsByType$findIndustries>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findIndustries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findIndustries<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findIndustries(
+    Query$FindAllOptionsByType$findIndustries instance,
+    TRes Function(Query$FindAllOptionsByType$findIndustries) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findIndustries;
+
+  factory CopyWith$Query$FindAllOptionsByType$findIndustries.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findIndustries;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findIndustries<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findIndustries<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findIndustries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findIndustries _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findIndustries) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findIndustries(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findIndustries<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findIndustries<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findIndustries(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findGenders {
+  Query$FindAllOptionsByType$findGenders({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Gender',
+  });
+
+  factory Query$FindAllOptionsByType$findGenders.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findGenders(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findGenders) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findGenders
+    on Query$FindAllOptionsByType$findGenders {
+  CopyWith$Query$FindAllOptionsByType$findGenders<
+          Query$FindAllOptionsByType$findGenders>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findGenders(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findGenders<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findGenders(
+    Query$FindAllOptionsByType$findGenders instance,
+    TRes Function(Query$FindAllOptionsByType$findGenders) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findGenders;
+
+  factory CopyWith$Query$FindAllOptionsByType$findGenders.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findGenders;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findGenders<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findGenders<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findGenders(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findGenders _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findGenders) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findGenders(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findGenders<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findGenders<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findGenders(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindAllOptionsByType$findLanguages {
+  Query$FindAllOptionsByType$findLanguages({
+    required this.textId,
+    this.translatedValue,
+    required this.isUiLanguage,
+    this.shortLangCode,
+    this.longLangCode,
+    this.$__typename = 'Language',
+  });
+
+  factory Query$FindAllOptionsByType$findLanguages.fromJson(
+      Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$isUiLanguage = json['isUiLanguage'];
+    final l$shortLangCode = json['shortLangCode'];
+    final l$longLangCode = json['longLangCode'];
+    final l$$__typename = json['__typename'];
+    return Query$FindAllOptionsByType$findLanguages(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      isUiLanguage: (l$isUiLanguage as bool),
+      shortLangCode: (l$shortLangCode as String?),
+      longLangCode: (l$longLangCode as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final bool isUiLanguage;
+
+  final String? shortLangCode;
+
+  final String? longLangCode;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$isUiLanguage = isUiLanguage;
+    _resultData['isUiLanguage'] = l$isUiLanguage;
+    final l$shortLangCode = shortLangCode;
+    _resultData['shortLangCode'] = l$shortLangCode;
+    final l$longLangCode = longLangCode;
+    _resultData['longLangCode'] = l$longLangCode;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$isUiLanguage = isUiLanguage;
+    final l$shortLangCode = shortLangCode;
+    final l$longLangCode = longLangCode;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$isUiLanguage,
+      l$shortLangCode,
+      l$longLangCode,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindAllOptionsByType$findLanguages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$isUiLanguage = isUiLanguage;
+    final lOther$isUiLanguage = other.isUiLanguage;
+    if (l$isUiLanguage != lOther$isUiLanguage) {
+      return false;
+    }
+    final l$shortLangCode = shortLangCode;
+    final lOther$shortLangCode = other.shortLangCode;
+    if (l$shortLangCode != lOther$shortLangCode) {
+      return false;
+    }
+    final l$longLangCode = longLangCode;
+    final lOther$longLangCode = other.longLangCode;
+    if (l$longLangCode != lOther$longLangCode) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindAllOptionsByType$findLanguages
+    on Query$FindAllOptionsByType$findLanguages {
+  CopyWith$Query$FindAllOptionsByType$findLanguages<
+          Query$FindAllOptionsByType$findLanguages>
+      get copyWith => CopyWith$Query$FindAllOptionsByType$findLanguages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindAllOptionsByType$findLanguages<TRes> {
+  factory CopyWith$Query$FindAllOptionsByType$findLanguages(
+    Query$FindAllOptionsByType$findLanguages instance,
+    TRes Function(Query$FindAllOptionsByType$findLanguages) then,
+  ) = _CopyWithImpl$Query$FindAllOptionsByType$findLanguages;
+
+  factory CopyWith$Query$FindAllOptionsByType$findLanguages.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindAllOptionsByType$findLanguages;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    bool? isUiLanguage,
+    String? shortLangCode,
+    String? longLangCode,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindAllOptionsByType$findLanguages<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findLanguages<TRes> {
+  _CopyWithImpl$Query$FindAllOptionsByType$findLanguages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindAllOptionsByType$findLanguages _instance;
+
+  final TRes Function(Query$FindAllOptionsByType$findLanguages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? isUiLanguage = _undefined,
+    Object? shortLangCode = _undefined,
+    Object? longLangCode = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindAllOptionsByType$findLanguages(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        isUiLanguage: isUiLanguage == _undefined || isUiLanguage == null
+            ? _instance.isUiLanguage
+            : (isUiLanguage as bool),
+        shortLangCode: shortLangCode == _undefined
+            ? _instance.shortLangCode
+            : (shortLangCode as String?),
+        longLangCode: longLangCode == _undefined
+            ? _instance.longLangCode
+            : (longLangCode as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindAllOptionsByType$findLanguages<TRes>
+    implements CopyWith$Query$FindAllOptionsByType$findLanguages<TRes> {
+  _CopyWithStubImpl$Query$FindAllOptionsByType$findLanguages(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    bool? isUiLanguage,
+    String? shortLangCode,
+    String? longLangCode,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
 class Query$FindCompanyStages {
   Query$FindCompanyStages({
     required this.findCompanyStages,

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -774,6 +774,20 @@ const documentNodeQueryFindAllUsers = DocumentNode(definitions: [
             selectionSet: null,
           ),
           FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
             name: NameNode(value: 'fullName'),
             alias: null,
             arguments: [],
@@ -818,6 +832,8 @@ class Query$FindAllUsers$findUsers {
   Query$FindAllUsers$findUsers({
     required this.id,
     this.email,
+    this.firstName,
+    this.lastName,
     this.fullName,
     this.avatarUrl,
     this.userHandle,
@@ -827,6 +843,8 @@ class Query$FindAllUsers$findUsers {
   factory Query$FindAllUsers$findUsers.fromJson(Map<String, dynamic> json) {
     final l$id = json['id'];
     final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
     final l$fullName = json['fullName'];
     final l$avatarUrl = json['avatarUrl'];
     final l$userHandle = json['userHandle'];
@@ -834,6 +852,8 @@ class Query$FindAllUsers$findUsers {
     return Query$FindAllUsers$findUsers(
       id: (l$id as String),
       email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
       fullName: (l$fullName as String?),
       avatarUrl: (l$avatarUrl as String?),
       userHandle: (l$userHandle as String?),
@@ -844,6 +864,10 @@ class Query$FindAllUsers$findUsers {
   final String id;
 
   final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
 
   final String? fullName;
 
@@ -859,6 +883,10 @@ class Query$FindAllUsers$findUsers {
     _resultData['id'] = l$id;
     final l$email = email;
     _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
     final l$fullName = fullName;
     _resultData['fullName'] = l$fullName;
     final l$avatarUrl = avatarUrl;
@@ -874,6 +902,8 @@ class Query$FindAllUsers$findUsers {
   int get hashCode {
     final l$id = id;
     final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
     final l$fullName = fullName;
     final l$avatarUrl = avatarUrl;
     final l$userHandle = userHandle;
@@ -881,6 +911,8 @@ class Query$FindAllUsers$findUsers {
     return Object.hashAll([
       l$id,
       l$email,
+      l$firstName,
+      l$lastName,
       l$fullName,
       l$avatarUrl,
       l$userHandle,
@@ -905,6 +937,16 @@ class Query$FindAllUsers$findUsers {
     final l$email = email;
     final lOther$email = other.email;
     if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
       return false;
     }
     final l$fullName = fullName;
@@ -952,6 +994,8 @@ abstract class CopyWith$Query$FindAllUsers$findUsers<TRes> {
   TRes call({
     String? id,
     String? email,
+    String? firstName,
+    String? lastName,
     String? fullName,
     String? avatarUrl,
     String? userHandle,
@@ -975,6 +1019,8 @@ class _CopyWithImpl$Query$FindAllUsers$findUsers<TRes>
   TRes call({
     Object? id = _undefined,
     Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
     Object? fullName = _undefined,
     Object? avatarUrl = _undefined,
     Object? userHandle = _undefined,
@@ -983,6 +1029,11 @@ class _CopyWithImpl$Query$FindAllUsers$findUsers<TRes>
       _then(Query$FindAllUsers$findUsers(
         id: id == _undefined || id == null ? _instance.id : (id as String),
         email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
         fullName:
             fullName == _undefined ? _instance.fullName : (fullName as String?),
         avatarUrl: avatarUrl == _undefined
@@ -1006,9 +1057,4562 @@ class _CopyWithStubImpl$Query$FindAllUsers$findUsers<TRes>
   call({
     String? id,
     String? email,
+    String? firstName,
+    String? lastName,
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindMenteeUsers {
+  factory Variables$Query$FindMenteeUsers({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  }) =>
+      Variables$Query$FindMenteeUsers._({
+        if (options != null) r'options': options,
+        if (filter != null) r'filter': filter,
+        if (match != null) r'match': match,
+      });
+
+  Variables$Query$FindMenteeUsers._(this._$data);
+
+  factory Variables$Query$FindMenteeUsers.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('options')) {
+      final l$options = data['options'];
+      result$data['options'] = l$options == null
+          ? null
+          : Input$FindObjectsOptions.fromJson(
+              (l$options as Map<String, dynamic>));
+    }
+    if (data.containsKey('filter')) {
+      final l$filter = data['filter'];
+      result$data['filter'] = l$filter == null
+          ? null
+          : Input$UserListFilter.fromJson((l$filter as Map<String, dynamic>));
+    }
+    if (data.containsKey('match')) {
+      final l$match = data['match'];
+      result$data['match'] = l$match == null
+          ? null
+          : Input$UserInput.fromJson((l$match as Map<String, dynamic>));
+    }
+    return Variables$Query$FindMenteeUsers._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Input$FindObjectsOptions? get options =>
+      (_$data['options'] as Input$FindObjectsOptions?);
+  Input$UserListFilter? get filter =>
+      (_$data['filter'] as Input$UserListFilter?);
+  Input$UserInput? get match => (_$data['match'] as Input$UserInput?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('options')) {
+      final l$options = options;
+      result$data['options'] = l$options?.toJson();
+    }
+    if (_$data.containsKey('filter')) {
+      final l$filter = filter;
+      result$data['filter'] = l$filter?.toJson();
+    }
+    if (_$data.containsKey('match')) {
+      final l$match = match;
+      result$data['match'] = l$match?.toJson();
+    }
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindMenteeUsers<Variables$Query$FindMenteeUsers>
+      get copyWith => CopyWith$Variables$Query$FindMenteeUsers(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindMenteeUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$options = options;
+    final lOther$options = other.options;
+    if (_$data.containsKey('options') != other._$data.containsKey('options')) {
+      return false;
+    }
+    if (l$options != lOther$options) {
+      return false;
+    }
+    final l$filter = filter;
+    final lOther$filter = other.filter;
+    if (_$data.containsKey('filter') != other._$data.containsKey('filter')) {
+      return false;
+    }
+    if (l$filter != lOther$filter) {
+      return false;
+    }
+    final l$match = match;
+    final lOther$match = other.match;
+    if (_$data.containsKey('match') != other._$data.containsKey('match')) {
+      return false;
+    }
+    if (l$match != lOther$match) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$options = options;
+    final l$filter = filter;
+    final l$match = match;
+    return Object.hashAll([
+      _$data.containsKey('options') ? l$options : const {},
+      _$data.containsKey('filter') ? l$filter : const {},
+      _$data.containsKey('match') ? l$match : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindMenteeUsers<TRes> {
+  factory CopyWith$Variables$Query$FindMenteeUsers(
+    Variables$Query$FindMenteeUsers instance,
+    TRes Function(Variables$Query$FindMenteeUsers) then,
+  ) = _CopyWithImpl$Variables$Query$FindMenteeUsers;
+
+  factory CopyWith$Variables$Query$FindMenteeUsers.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindMenteeUsers;
+
+  TRes call({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  });
+}
+
+class _CopyWithImpl$Variables$Query$FindMenteeUsers<TRes>
+    implements CopyWith$Variables$Query$FindMenteeUsers<TRes> {
+  _CopyWithImpl$Variables$Query$FindMenteeUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindMenteeUsers _instance;
+
+  final TRes Function(Variables$Query$FindMenteeUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? options = _undefined,
+    Object? filter = _undefined,
+    Object? match = _undefined,
+  }) =>
+      _then(Variables$Query$FindMenteeUsers._({
+        ..._instance._$data,
+        if (options != _undefined)
+          'options': (options as Input$FindObjectsOptions?),
+        if (filter != _undefined) 'filter': (filter as Input$UserListFilter?),
+        if (match != _undefined) 'match': (match as Input$UserInput?),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindMenteeUsers<TRes>
+    implements CopyWith$Variables$Query$FindMenteeUsers<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindMenteeUsers(this._res);
+
+  TRes _res;
+
+  call({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUsers {
+  Query$FindMenteeUsers({
+    required this.findUsers,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindMenteeUsers.fromJson(Map<String, dynamic> json) {
+    final l$findUsers = json['findUsers'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers(
+      findUsers: (l$findUsers as List<dynamic>)
+          .map((e) => Query$FindMenteeUsers$findUsers.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindMenteeUsers$findUsers> findUsers;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUsers = findUsers;
+    _resultData['findUsers'] = l$findUsers.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUsers = findUsers;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findUsers.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUsers = findUsers;
+    final lOther$findUsers = other.findUsers;
+    if (l$findUsers.length != lOther$findUsers.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findUsers.length; i++) {
+      final l$findUsers$entry = l$findUsers[i];
+      final lOther$findUsers$entry = lOther$findUsers[i];
+      if (l$findUsers$entry != lOther$findUsers$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers on Query$FindMenteeUsers {
+  CopyWith$Query$FindMenteeUsers<Query$FindMenteeUsers> get copyWith =>
+      CopyWith$Query$FindMenteeUsers(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers<TRes> {
+  factory CopyWith$Query$FindMenteeUsers(
+    Query$FindMenteeUsers instance,
+    TRes Function(Query$FindMenteeUsers) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers;
+
+  factory CopyWith$Query$FindMenteeUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers;
+
+  TRes call({
+    List<Query$FindMenteeUsers$findUsers>? findUsers,
+    String? $__typename,
+  });
+  TRes findUsers(
+      Iterable<Query$FindMenteeUsers$findUsers> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUsers$findUsers<
+                      Query$FindMenteeUsers$findUsers>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers<TRes>
+    implements CopyWith$Query$FindMenteeUsers<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers _instance;
+
+  final TRes Function(Query$FindMenteeUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUsers = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUsers(
+        findUsers: findUsers == _undefined || findUsers == null
+            ? _instance.findUsers
+            : (findUsers as List<Query$FindMenteeUsers$findUsers>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findUsers(
+          Iterable<Query$FindMenteeUsers$findUsers> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUsers$findUsers<
+                          Query$FindMenteeUsers$findUsers>>)
+              _fn) =>
+      call(
+          findUsers: _fn(_instance.findUsers
+              .map((e) => CopyWith$Query$FindMenteeUsers$findUsers(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers<TRes>
+    implements CopyWith$Query$FindMenteeUsers<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindMenteeUsers$findUsers>? findUsers,
+    String? $__typename,
+  }) =>
+      _res;
+  findUsers(_fn) => _res;
+}
+
+const documentNodeQueryFindMenteeUsers = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindMenteeUsers'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'options')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'FindObjectsOptions'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'filter')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserListFilter'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'match')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserInput'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUsers'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'options'),
+            value: VariableNode(name: NameNode(value: 'options')),
+          ),
+          ArgumentNode(
+            name: NameNode(value: 'filter'),
+            value: VariableNode(name: NameNode(value: 'filter')),
+          ),
+          ArgumentNode(
+            name: NameNode(value: 'match'),
+            value: VariableNode(name: NameNode(value: 'match')),
+          ),
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'email'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userHandle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'groupMemberships'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MenteesGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'soughtExpertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'industry'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'companies'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'companyStage'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'translatedValue'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindMenteeUsers$findUsers {
+  Query$FindMenteeUsers$findUsers({
+    required this.id,
+    this.email,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    this.cityOfResidence,
+    this.regionOfResidence,
+    this.countryOfResidence,
+    this.jobTitle,
+    required this.groupMemberships,
+    required this.companies,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindMenteeUsers$findUsers.fromJson(Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$jobTitle = json['jobTitle'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$companies = json['companies'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers(
+      id: (l$id as String),
+      email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindMenteeUsers$findUsers$countryOfResidence.fromJson(
+              (l$countryOfResidence as Map<String, dynamic>)),
+      jobTitle: (l$jobTitle as String?),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) => Query$FindMenteeUsers$findUsers$groupMemberships.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      companies: (l$companies as List<dynamic>)
+          .map((e) => Query$FindMenteeUsers$findUsers$companies.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
+  final Query$FindMenteeUsers$findUsers$countryOfResidence? countryOfResidence;
+
+  final String? jobTitle;
+
+  final List<Query$FindMenteeUsers$findUsers$groupMemberships> groupMemberships;
+
+  final List<Query$FindMenteeUsers$findUsers$companies> companies;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    final l$jobTitle = jobTitle;
+    final l$groupMemberships = groupMemberships;
+    final l$companies = companies;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$cityOfResidence,
+      l$regionOfResidence,
+      l$countryOfResidence,
+      l$jobTitle,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      Object.hashAll(l$companies.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers$findUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers
+    on Query$FindMenteeUsers$findUsers {
+  CopyWith$Query$FindMenteeUsers$findUsers<Query$FindMenteeUsers$findUsers>
+      get copyWith => CopyWith$Query$FindMenteeUsers$findUsers(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers<TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers(
+    Query$FindMenteeUsers$findUsers instance,
+    TRes Function(Query$FindMenteeUsers$findUsers) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindMenteeUsers$findUsers$countryOfResidence? countryOfResidence,
+    String? jobTitle,
+    List<Query$FindMenteeUsers$findUsers$groupMemberships>? groupMemberships,
+    List<Query$FindMenteeUsers$findUsers$companies>? companies,
+    String? $__typename,
+  });
+  CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence;
+  TRes groupMemberships(
+      Iterable<Query$FindMenteeUsers$findUsers$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<
+                      Query$FindMenteeUsers$findUsers$groupMemberships>>)
+          _fn);
+  TRes companies(
+      Iterable<Query$FindMenteeUsers$findUsers$companies> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUsers$findUsers$companies<
+                      Query$FindMenteeUsers$findUsers$companies>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers _instance;
+
+  final TRes Function(Query$FindMenteeUsers$findUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? jobTitle = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? companies = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUsers$findUsers(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindMenteeUsers$findUsers$countryOfResidence?),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        groupMemberships:
+            groupMemberships == _undefined || groupMemberships == null
+                ? _instance.groupMemberships
+                : (groupMemberships
+                    as List<Query$FindMenteeUsers$findUsers$groupMemberships>),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<Query$FindMenteeUsers$findUsers$companies>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence.stub(
+            _then(_instance))
+        : CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  TRes groupMemberships(
+          Iterable<Query$FindMenteeUsers$findUsers$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<
+                          Query$FindMenteeUsers$findUsers$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map(
+              (e) => CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes companies(
+          Iterable<Query$FindMenteeUsers$findUsers$companies> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUsers$findUsers$companies<
+                          Query$FindMenteeUsers$findUsers$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies
+              .map((e) => CopyWith$Query$FindMenteeUsers$findUsers$companies(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindMenteeUsers$findUsers$countryOfResidence? countryOfResidence,
+    String? jobTitle,
+    List<Query$FindMenteeUsers$findUsers$groupMemberships>? groupMemberships,
+    List<Query$FindMenteeUsers$findUsers$companies>? companies,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence.stub(
+              _res);
+  groupMemberships(_fn) => _res;
+  companies(_fn) => _res;
+}
+
+class Query$FindMenteeUsers$findUsers$countryOfResidence {
+  Query$FindMenteeUsers$findUsers$countryOfResidence({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers$findUsers$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$countryOfResidence
+    on Query$FindMenteeUsers$findUsers$countryOfResidence {
+  CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<
+          Query$FindMenteeUsers$findUsers$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence(
+    Query$FindMenteeUsers$findUsers$countryOfResidence instance,
+    TRes Function(Query$FindMenteeUsers$findUsers$countryOfResidence) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$countryOfResidence;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$countryOfResidence _instance;
+
+  final TRes Function(Query$FindMenteeUsers$findUsers$countryOfResidence) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUsers$findUsers$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships {
+  Query$FindMenteeUsers$findUsers$groupMemberships({required this.$__typename});
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MenteesGroupMembership":
+        return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      case "MentorsGroupMembership":
+        return Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      default:
+        final l$$__typename = json['__typename'];
+        return Query$FindMenteeUsers$findUsers$groupMemberships(
+            $__typename: (l$$__typename as String));
+    }
+  }
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers$findUsers$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships
+    on Query$FindMenteeUsers$findUsers$groupMemberships {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<
+          Query$FindMenteeUsers$findUsers$groupMemberships>
+      get copyWith => CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership);
+
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership)?
+        groupMembership,
+    _T Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships(
+    Query$FindMenteeUsers$findUsers$groupMemberships instance,
+    TRes Function(Query$FindMenteeUsers$findUsers$groupMemberships) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships;
+
+  TRes call({String? $__typename});
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships _instance;
+
+  final TRes Function(Query$FindMenteeUsers$findUsers$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? $__typename = _undefined}) =>
+      _then(Query$FindMenteeUsers$findUsers$groupMemberships(
+          $__typename: $__typename == _undefined || $__typename == null
+              ? _instance.$__typename
+              : ($__typename as String)));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships(this._res);
+
+  TRes _res;
+
+  call({String? $__typename}) => _res;
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership
+    implements Query$FindMenteeUsers$findUsers$groupMemberships {
+  Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership({
+    required this.soughtExpertises,
+    this.industry,
+    this.$__typename = 'MenteesGroupMembership',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$soughtExpertises = json['soughtExpertises'];
+    final l$industry = json['industry'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+      soughtExpertises: (l$soughtExpertises as List<dynamic>)
+          .map((e) =>
+              Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industry: l$industry == null
+          ? null
+          : Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+              .fromJson((l$industry as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      soughtExpertises;
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry?
+      industry;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$soughtExpertises = soughtExpertises;
+    _resultData['soughtExpertises'] =
+        l$soughtExpertises.map((e) => e.toJson()).toList();
+    final l$industry = industry;
+    _resultData['industry'] = l$industry?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$soughtExpertises = soughtExpertises;
+    final l$industry = industry;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$soughtExpertises.map((v) => v)),
+      l$industry,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$soughtExpertises = soughtExpertises;
+    final lOther$soughtExpertises = other.soughtExpertises;
+    if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$soughtExpertises.length; i++) {
+      final l$soughtExpertises$entry = l$soughtExpertises[i];
+      final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
+      if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+        return false;
+      }
+    }
+    final l$industry = industry;
+    final lOther$industry = other.industry;
+    if (l$industry != lOther$industry) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership
+    on Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    List<Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+  });
+  TRes soughtExpertises(
+      Iterable<Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                      Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+          _fn);
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry;
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? soughtExpertises = _undefined,
+    Object? industry = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+        soughtExpertises: soughtExpertises == _undefined ||
+                soughtExpertises == null
+            ? _instance.soughtExpertises
+            : (soughtExpertises as List<
+                Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
+        industry: industry == _undefined
+            ? _instance.industry
+            : (industry
+                as Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes soughtExpertises(
+          Iterable<Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+              _fn) =>
+      call(
+          soughtExpertises: _fn(_instance.soughtExpertises.map((e) =>
+              CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+                e,
+                (i) => i,
+              ))).toList());
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry {
+    final local$industry = _instance.industry;
+    return local$industry == null
+        ? CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+            local$industry, (e) => call(industry: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+  }) =>
+      _res;
+  soughtExpertises(_fn) => _res;
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+          TRes>
+      get industry =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+              .stub(_res);
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+    on Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+        instance,
+    TRes Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry {
+  Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+    on Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+        instance,
+    TRes Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership
+    implements Query$FindMenteeUsers$findUsers$groupMemberships {
+  Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+      {this.$__typename = 'GroupMembership'});
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+        $__typename: (l$$__typename as String));
+  }
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership
+    on Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+    Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership instance,
+    TRes Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership;
+
+  TRes call({String? $__typename});
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+      Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? $__typename = _undefined}) =>
+      _then(Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+          $__typename: $__typename == _undefined || $__typename == null
+              ? _instance.$__typename
+              : ($__typename as String)));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({String? $__typename}) => _res;
+}
+
+class Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership
+    implements Query$FindMenteeUsers$findUsers$groupMemberships {
+  Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+      {this.$__typename = 'MentorsGroupMembership'});
+
+  factory Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+        $__typename: (l$$__typename as String));
+  }
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership
+    on Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+    Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({String? $__typename});
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? $__typename = _undefined}) => _then(
+      Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+          $__typename: $__typename == _undefined || $__typename == null
+              ? _instance.$__typename
+              : ($__typename as String)));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({String? $__typename}) => _res;
+}
+
+class Query$FindMenteeUsers$findUsers$companies {
+  Query$FindMenteeUsers$findUsers$companies({
+    this.companyStage,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$companyStage = json['companyStage'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$companies(
+      companyStage: l$companyStage == null
+          ? null
+          : Query$FindMenteeUsers$findUsers$companies$companyStage.fromJson(
+              (l$companyStage as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindMenteeUsers$findUsers$companies$companyStage? companyStage;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$companyStage = companyStage;
+    _resultData['companyStage'] = l$companyStage?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$companyStage = companyStage;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$companyStage,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers$findUsers$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$companyStage = companyStage;
+    final lOther$companyStage = other.companyStage;
+    if (l$companyStage != lOther$companyStage) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$companies
+    on Query$FindMenteeUsers$findUsers$companies {
+  CopyWith$Query$FindMenteeUsers$findUsers$companies<
+          Query$FindMenteeUsers$findUsers$companies>
+      get copyWith => CopyWith$Query$FindMenteeUsers$findUsers$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$companies<TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$companies(
+    Query$FindMenteeUsers$findUsers$companies instance,
+    TRes Function(Query$FindMenteeUsers$findUsers$companies) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$companies.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies;
+
+  TRes call({
+    Query$FindMenteeUsers$findUsers$companies$companyStage? companyStage,
+    String? $__typename,
+  });
+  CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes>
+      get companyStage;
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers$companies<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$companies _instance;
+
+  final TRes Function(Query$FindMenteeUsers$findUsers$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? companyStage = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUsers$findUsers$companies(
+        companyStage: companyStage == _undefined
+            ? _instance.companyStage
+            : (companyStage
+                as Query$FindMenteeUsers$findUsers$companies$companyStage?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes>
+      get companyStage {
+    final local$companyStage = _instance.companyStage;
+    return local$companyStage == null
+        ? CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage.stub(
+            _then(_instance))
+        : CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage(
+            local$companyStage, (e) => call(companyStage: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies<TRes>
+    implements CopyWith$Query$FindMenteeUsers$findUsers$companies<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindMenteeUsers$findUsers$companies$companyStage? companyStage,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes>
+      get companyStage =>
+          CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage.stub(
+              _res);
+}
+
+class Query$FindMenteeUsers$findUsers$companies$companyStage {
+  Query$FindMenteeUsers$findUsers$companies$companyStage({
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$FindMenteeUsers$findUsers$companies$companyStage.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUsers$findUsers$companies$companyStage(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUsers$findUsers$companies$companyStage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUsers$findUsers$companies$companyStage
+    on Query$FindMenteeUsers$findUsers$companies$companyStage {
+  CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<
+          Query$FindMenteeUsers$findUsers$companies$companyStage>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage(
+    Query$FindMenteeUsers$findUsers$companies$companyStage instance,
+    TRes Function(Query$FindMenteeUsers$findUsers$companies$companyStage) then,
+  ) = _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies$companyStage;
+
+  factory CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies$companyStage;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes> {
+  _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies$companyStage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUsers$findUsers$companies$companyStage _instance;
+
+  final TRes Function(Query$FindMenteeUsers$findUsers$companies$companyStage)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUsers$findUsers$companies$companyStage(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies$companyStage(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindMentorUsers {
+  factory Variables$Query$FindMentorUsers({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  }) =>
+      Variables$Query$FindMentorUsers._({
+        if (options != null) r'options': options,
+        if (filter != null) r'filter': filter,
+        if (match != null) r'match': match,
+      });
+
+  Variables$Query$FindMentorUsers._(this._$data);
+
+  factory Variables$Query$FindMentorUsers.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('options')) {
+      final l$options = data['options'];
+      result$data['options'] = l$options == null
+          ? null
+          : Input$FindObjectsOptions.fromJson(
+              (l$options as Map<String, dynamic>));
+    }
+    if (data.containsKey('filter')) {
+      final l$filter = data['filter'];
+      result$data['filter'] = l$filter == null
+          ? null
+          : Input$UserListFilter.fromJson((l$filter as Map<String, dynamic>));
+    }
+    if (data.containsKey('match')) {
+      final l$match = data['match'];
+      result$data['match'] = l$match == null
+          ? null
+          : Input$UserInput.fromJson((l$match as Map<String, dynamic>));
+    }
+    return Variables$Query$FindMentorUsers._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Input$FindObjectsOptions? get options =>
+      (_$data['options'] as Input$FindObjectsOptions?);
+  Input$UserListFilter? get filter =>
+      (_$data['filter'] as Input$UserListFilter?);
+  Input$UserInput? get match => (_$data['match'] as Input$UserInput?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('options')) {
+      final l$options = options;
+      result$data['options'] = l$options?.toJson();
+    }
+    if (_$data.containsKey('filter')) {
+      final l$filter = filter;
+      result$data['filter'] = l$filter?.toJson();
+    }
+    if (_$data.containsKey('match')) {
+      final l$match = match;
+      result$data['match'] = l$match?.toJson();
+    }
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindMentorUsers<Variables$Query$FindMentorUsers>
+      get copyWith => CopyWith$Variables$Query$FindMentorUsers(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindMentorUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$options = options;
+    final lOther$options = other.options;
+    if (_$data.containsKey('options') != other._$data.containsKey('options')) {
+      return false;
+    }
+    if (l$options != lOther$options) {
+      return false;
+    }
+    final l$filter = filter;
+    final lOther$filter = other.filter;
+    if (_$data.containsKey('filter') != other._$data.containsKey('filter')) {
+      return false;
+    }
+    if (l$filter != lOther$filter) {
+      return false;
+    }
+    final l$match = match;
+    final lOther$match = other.match;
+    if (_$data.containsKey('match') != other._$data.containsKey('match')) {
+      return false;
+    }
+    if (l$match != lOther$match) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$options = options;
+    final l$filter = filter;
+    final l$match = match;
+    return Object.hashAll([
+      _$data.containsKey('options') ? l$options : const {},
+      _$data.containsKey('filter') ? l$filter : const {},
+      _$data.containsKey('match') ? l$match : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindMentorUsers<TRes> {
+  factory CopyWith$Variables$Query$FindMentorUsers(
+    Variables$Query$FindMentorUsers instance,
+    TRes Function(Variables$Query$FindMentorUsers) then,
+  ) = _CopyWithImpl$Variables$Query$FindMentorUsers;
+
+  factory CopyWith$Variables$Query$FindMentorUsers.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindMentorUsers;
+
+  TRes call({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  });
+}
+
+class _CopyWithImpl$Variables$Query$FindMentorUsers<TRes>
+    implements CopyWith$Variables$Query$FindMentorUsers<TRes> {
+  _CopyWithImpl$Variables$Query$FindMentorUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindMentorUsers _instance;
+
+  final TRes Function(Variables$Query$FindMentorUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? options = _undefined,
+    Object? filter = _undefined,
+    Object? match = _undefined,
+  }) =>
+      _then(Variables$Query$FindMentorUsers._({
+        ..._instance._$data,
+        if (options != _undefined)
+          'options': (options as Input$FindObjectsOptions?),
+        if (filter != _undefined) 'filter': (filter as Input$UserListFilter?),
+        if (match != _undefined) 'match': (match as Input$UserInput?),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindMentorUsers<TRes>
+    implements CopyWith$Variables$Query$FindMentorUsers<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindMentorUsers(this._res);
+
+  TRes _res;
+
+  call({
+    Input$FindObjectsOptions? options,
+    Input$UserListFilter? filter,
+    Input$UserInput? match,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers {
+  Query$FindMentorUsers({
+    required this.findUsers,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindMentorUsers.fromJson(Map<String, dynamic> json) {
+    final l$findUsers = json['findUsers'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers(
+      findUsers: (l$findUsers as List<dynamic>)
+          .map((e) => Query$FindMentorUsers$findUsers.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindMentorUsers$findUsers> findUsers;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUsers = findUsers;
+    _resultData['findUsers'] = l$findUsers.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUsers = findUsers;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findUsers.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUsers) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUsers = findUsers;
+    final lOther$findUsers = other.findUsers;
+    if (l$findUsers.length != lOther$findUsers.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findUsers.length; i++) {
+      final l$findUsers$entry = l$findUsers[i];
+      final lOther$findUsers$entry = lOther$findUsers[i];
+      if (l$findUsers$entry != lOther$findUsers$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers on Query$FindMentorUsers {
+  CopyWith$Query$FindMentorUsers<Query$FindMentorUsers> get copyWith =>
+      CopyWith$Query$FindMentorUsers(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindMentorUsers<TRes> {
+  factory CopyWith$Query$FindMentorUsers(
+    Query$FindMentorUsers instance,
+    TRes Function(Query$FindMentorUsers) then,
+  ) = _CopyWithImpl$Query$FindMentorUsers;
+
+  factory CopyWith$Query$FindMentorUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers;
+
+  TRes call({
+    List<Query$FindMentorUsers$findUsers>? findUsers,
+    String? $__typename,
+  });
+  TRes findUsers(
+      Iterable<Query$FindMentorUsers$findUsers> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUsers$findUsers<
+                      Query$FindMentorUsers$findUsers>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMentorUsers<TRes>
+    implements CopyWith$Query$FindMentorUsers<TRes> {
+  _CopyWithImpl$Query$FindMentorUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers _instance;
+
+  final TRes Function(Query$FindMentorUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUsers = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUsers(
+        findUsers: findUsers == _undefined || findUsers == null
+            ? _instance.findUsers
+            : (findUsers as List<Query$FindMentorUsers$findUsers>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findUsers(
+          Iterable<Query$FindMentorUsers$findUsers> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUsers$findUsers<
+                          Query$FindMentorUsers$findUsers>>)
+              _fn) =>
+      call(
+          findUsers: _fn(_instance.findUsers
+              .map((e) => CopyWith$Query$FindMentorUsers$findUsers(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers<TRes>
+    implements CopyWith$Query$FindMentorUsers<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindMentorUsers$findUsers>? findUsers,
+    String? $__typename,
+  }) =>
+      _res;
+  findUsers(_fn) => _res;
+}
+
+const documentNodeQueryFindMentorUsers = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindMentorUsers'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'options')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'FindObjectsOptions'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'filter')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserListFilter'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'match')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserInput'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUsers'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'options'),
+            value: VariableNode(name: NameNode(value: 'options')),
+          ),
+          ArgumentNode(
+            name: NameNode(value: 'filter'),
+            value: VariableNode(name: NameNode(value: 'filter')),
+          ),
+          ArgumentNode(
+            name: NameNode(value: 'match'),
+            value: VariableNode(name: NameNode(value: 'match')),
+          ),
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'email'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userHandle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'groupMemberships'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'groupId'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MentorsGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'expertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'industries'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'endorsements'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindMentorUsers$findUsers {
+  Query$FindMentorUsers$findUsers({
+    required this.id,
+    this.email,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    this.cityOfResidence,
+    this.regionOfResidence,
+    this.countryOfResidence,
+    this.jobTitle,
+    required this.groupMemberships,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindMentorUsers$findUsers.fromJson(Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$jobTitle = json['jobTitle'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers(
+      id: (l$id as String),
+      email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindMentorUsers$findUsers$countryOfResidence.fromJson(
+              (l$countryOfResidence as Map<String, dynamic>)),
+      jobTitle: (l$jobTitle as String?),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) => Query$FindMentorUsers$findUsers$groupMemberships.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
+  final Query$FindMentorUsers$findUsers$countryOfResidence? countryOfResidence;
+
+  final String? jobTitle;
+
+  final List<Query$FindMentorUsers$findUsers$groupMemberships> groupMemberships;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    final l$jobTitle = jobTitle;
+    final l$groupMemberships = groupMemberships;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$cityOfResidence,
+      l$regionOfResidence,
+      l$countryOfResidence,
+      l$jobTitle,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUsers$findUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers
+    on Query$FindMentorUsers$findUsers {
+  CopyWith$Query$FindMentorUsers$findUsers<Query$FindMentorUsers$findUsers>
+      get copyWith => CopyWith$Query$FindMentorUsers$findUsers(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers<TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers(
+    Query$FindMentorUsers$findUsers instance,
+    TRes Function(Query$FindMentorUsers$findUsers) then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindMentorUsers$findUsers$countryOfResidence? countryOfResidence,
+    String? jobTitle,
+    List<Query$FindMentorUsers$findUsers$groupMemberships>? groupMemberships,
+    String? $__typename,
+  });
+  CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence;
+  TRes groupMemberships(
+      Iterable<Query$FindMentorUsers$findUsers$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<
+                      Query$FindMentorUsers$findUsers$groupMemberships>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers<TRes>
+    implements CopyWith$Query$FindMentorUsers$findUsers<TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers _instance;
+
+  final TRes Function(Query$FindMentorUsers$findUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? jobTitle = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUsers$findUsers(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindMentorUsers$findUsers$countryOfResidence?),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        groupMemberships:
+            groupMemberships == _undefined || groupMemberships == null
+                ? _instance.groupMemberships
+                : (groupMemberships
+                    as List<Query$FindMentorUsers$findUsers$groupMemberships>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence.stub(
+            _then(_instance))
+        : CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  TRes groupMemberships(
+          Iterable<Query$FindMentorUsers$findUsers$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<
+                          Query$FindMentorUsers$findUsers$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map(
+              (e) => CopyWith$Query$FindMentorUsers$findUsers$groupMemberships(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers<TRes>
+    implements CopyWith$Query$FindMentorUsers$findUsers<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindMentorUsers$findUsers$countryOfResidence? countryOfResidence,
+    String? jobTitle,
+    List<Query$FindMentorUsers$findUsers$groupMemberships>? groupMemberships,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence.stub(
+              _res);
+  groupMemberships(_fn) => _res;
+}
+
+class Query$FindMentorUsers$findUsers$countryOfResidence {
+  Query$FindMentorUsers$findUsers$countryOfResidence({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMentorUsers$findUsers$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUsers$findUsers$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$countryOfResidence
+    on Query$FindMentorUsers$findUsers$countryOfResidence {
+  CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<
+          Query$FindMentorUsers$findUsers$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence(
+    Query$FindMentorUsers$findUsers$countryOfResidence instance,
+    TRes Function(Query$FindMentorUsers$findUsers$countryOfResidence) then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$countryOfResidence;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$countryOfResidence _instance;
+
+  final TRes Function(Query$FindMentorUsers$findUsers$countryOfResidence) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUsers$findUsers$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships {
+  Query$FindMentorUsers$findUsers$groupMemberships({
+    required this.groupId,
+    required this.$__typename,
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MentorsGroupMembership":
+        return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      case "MenteesGroupMembership":
+        return Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupId = json['groupId'];
+        final l$$__typename = json['__typename'];
+        return Query$FindMentorUsers$findUsers$groupMemberships(
+          groupId: (l$groupId as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupId;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUsers$findUsers$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships
+    on Query$FindMentorUsers$findUsers$groupMemberships {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<
+          Query$FindMentorUsers$findUsers$groupMemberships>
+      get copyWith => CopyWith$Query$FindMentorUsers$findUsers$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership);
+
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership)?
+        groupMembership,
+    _T Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships(
+    Query$FindMentorUsers$findUsers$groupMemberships instance,
+    TRes Function(Query$FindMentorUsers$findUsers$groupMemberships) then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships;
+
+  TRes call({
+    String? groupId,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships<TRes>
+    implements CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships _instance;
+
+  final TRes Function(Query$FindMentorUsers$findUsers$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUsers$findUsers$groupMemberships(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships<TRes>
+    implements CopyWith$Query$FindMentorUsers$findUsers$groupMemberships<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships(this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership
+    implements Query$FindMentorUsers$findUsers$groupMemberships {
+  Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership({
+    required this.expertises,
+    required this.industries,
+    this.endorsements,
+    this.$__typename = 'MentorsGroupMembership',
+    required this.groupId,
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$expertises = json['expertises'];
+    final l$industries = json['industries'];
+    final l$endorsements = json['endorsements'];
+    final l$$__typename = json['__typename'];
+    final l$groupId = json['groupId'];
+    return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+      expertises: (l$expertises as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industries: (l$industries as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      endorsements: (l$endorsements as int?),
+      $__typename: (l$$__typename as String),
+      groupId: (l$groupId as String),
+    );
+  }
+
+  final List<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      expertises;
+
+  final List<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>
+      industries;
+
+  final int? endorsements;
+
+  final String $__typename;
+
+  final String groupId;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$expertises = expertises;
+    _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
+    final l$industries = industries;
+    _resultData['industries'] = l$industries.map((e) => e.toJson()).toList();
+    final l$endorsements = endorsements;
+    _resultData['endorsements'] = l$endorsements;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$expertises = expertises;
+    final l$industries = industries;
+    final l$endorsements = endorsements;
+    final l$$__typename = $__typename;
+    final l$groupId = groupId;
+    return Object.hashAll([
+      Object.hashAll(l$expertises.map((v) => v)),
+      Object.hashAll(l$industries.map((v) => v)),
+      l$endorsements,
+      l$$__typename,
+      l$groupId,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$expertises = expertises;
+    final lOther$expertises = other.expertises;
+    if (l$expertises.length != lOther$expertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$expertises.length; i++) {
+      final l$expertises$entry = l$expertises[i];
+      final lOther$expertises$entry = lOther$expertises[i];
+      if (l$expertises$entry != lOther$expertises$entry) {
+        return false;
+      }
+    }
+    final l$industries = industries;
+    final lOther$industries = other.industries;
+    if (l$industries.length != lOther$industries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$industries.length; i++) {
+      final l$industries$entry = l$industries[i];
+      final lOther$industries$entry = lOther$industries[i];
+      if (l$industries$entry != lOther$industries$entry) {
+        return false;
+      }
+    }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership
+    on Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+    Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    List<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupId,
+  });
+  TRes expertises(
+      Iterable<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                      Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+          _fn);
+  TRes industries(
+      Iterable<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+                      Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? expertises = _undefined,
+    Object? industries = _undefined,
+    Object? endorsements = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupId = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+        expertises: expertises == _undefined || expertises == null
+            ? _instance.expertises
+            : (expertises as List<
+                Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>),
+        industries: industries == _undefined || industries == null
+            ? _instance.industries
+            : (industries as List<
+                Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>),
+        endorsements: endorsements == _undefined
+            ? _instance.endorsements
+            : (endorsements as int?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+      ));
+  TRes expertises(
+          Iterable<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+              _fn) =>
+      call(
+          expertises: _fn(_instance.expertises.map((e) =>
+              CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes industries(
+          Iterable<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+                          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+              _fn) =>
+      call(
+          industries: _fn(_instance.industries.map((e) =>
+              CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupId,
+  }) =>
+      _res;
+  expertises(_fn) => _res;
+  industries(_fn) => _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises
+    on Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises
+        instance,
+    TRes Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries {
+  Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries
+    on Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+    Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries
+        instance,
+    TRes Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership
+    implements Query$FindMentorUsers$findUsers$groupMemberships {
+  Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership({
+    required this.groupId,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+      groupId: (l$groupId as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership
+    on Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+          Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+    Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership instance,
+    TRes Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+      Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership
+    implements Query$FindMentorUsers$findUsers$groupMemberships {
+  Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership({
+    required this.groupId,
+    this.$__typename = 'MenteesGroupMembership',
+  });
+
+  factory Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+      groupId: (l$groupId as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership
+    on Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+          Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+    Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
     String? $__typename,
   }) =>
       _res;

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -234,7 +234,7 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
     this.fullName,
     this.avatarUrl,
     this.userHandle,
-    this.profileCompletionPercentage,
+    required this.profileCompletionPercentage,
     this.updatedAt,
     this.$__typename = 'User',
   });
@@ -255,7 +255,7 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
       fullName: (l$fullName as String?),
       avatarUrl: (l$avatarUrl as String?),
       userHandle: (l$userHandle as String?),
-      profileCompletionPercentage: (l$profileCompletionPercentage as int?),
+      profileCompletionPercentage: (l$profileCompletionPercentage as int),
       updatedAt:
           l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
       $__typename: (l$$__typename as String),
@@ -272,7 +272,7 @@ class Query$GetAuthenticatedUser$getAuthenticatedUser {
 
   final String? userHandle;
 
-  final int? profileCompletionPercentage;
+  final int profileCompletionPercentage;
 
   final DateTime? updatedAt;
 
@@ -441,9 +441,11 @@ class _CopyWithImpl$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes>
         userHandle: userHandle == _undefined
             ? _instance.userHandle
             : (userHandle as String?),
-        profileCompletionPercentage: profileCompletionPercentage == _undefined
-            ? _instance.profileCompletionPercentage
-            : (profileCompletionPercentage as int?),
+        profileCompletionPercentage:
+            profileCompletionPercentage == _undefined ||
+                    profileCompletionPercentage == null
+                ? _instance.profileCompletionPercentage
+                : (profileCompletionPercentage as int),
         updatedAt: updatedAt == _undefined
             ? _instance.updatedAt
             : (updatedAt as DateTime?),

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -1516,6 +1516,13 @@ const documentNodeQueryFindMenteeUsers = DocumentNode(definitions: [
             directives: [],
             selectionSet: SelectionSetNode(selections: [
               FieldNode(
+                name: NameNode(value: 'textId'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'translatedValue'),
                 alias: null,
                 arguments: [],
@@ -1559,6 +1566,13 @@ const documentNodeQueryFindMenteeUsers = DocumentNode(definitions: [
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
                       FieldNode(
+                        name: NameNode(value: 'textId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
                         name: NameNode(value: 'translatedValue'),
                         alias: null,
                         arguments: [],
@@ -1580,6 +1594,13 @@ const documentNodeQueryFindMenteeUsers = DocumentNode(definitions: [
                     arguments: [],
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'textId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
                       FieldNode(
                         name: NameNode(value: 'translatedValue'),
                         alias: null,
@@ -1626,6 +1647,13 @@ const documentNodeQueryFindMenteeUsers = DocumentNode(definitions: [
                 arguments: [],
                 directives: [],
                 selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'textId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
                   FieldNode(
                     name: NameNode(value: 'translatedValue'),
                     alias: null,
@@ -2112,19 +2140,24 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers<TRes>
 
 class Query$FindMenteeUsers$findUsers$countryOfResidence {
   Query$FindMenteeUsers$findUsers$countryOfResidence({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Country',
   });
 
   factory Query$FindMenteeUsers$findUsers$countryOfResidence.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMenteeUsers$findUsers$countryOfResidence(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -2132,6 +2165,8 @@ class Query$FindMenteeUsers$findUsers$countryOfResidence {
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -2141,9 +2176,11 @@ class Query$FindMenteeUsers$findUsers$countryOfResidence {
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -2156,6 +2193,11 @@ class Query$FindMenteeUsers$findUsers$countryOfResidence {
     }
     if (!(other is Query$FindMenteeUsers$findUsers$countryOfResidence) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -2195,6 +2237,7 @@ abstract class CopyWith$Query$FindMenteeUsers$findUsers$countryOfResidence<
       _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$countryOfResidence;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -2215,10 +2258,14 @@ class _CopyWithImpl$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindMenteeUsers$findUsers$countryOfResidence(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -2237,6 +2284,7 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$countryOfResidence<TRes>
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -2652,19 +2700,24 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
 
 class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
   Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Expertise',
   });
 
   factory Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -2672,6 +2725,8 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$s
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -2681,9 +2736,11 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$s
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -2697,6 +2754,11 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$s
     if (!(other
             is Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -2739,6 +2801,7 @@ abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
       _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -2764,11 +2827,15 @@ class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGro
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
           Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -2789,6 +2856,7 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -2797,19 +2865,24 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
 
 class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry {
   Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Industry',
   });
 
   factory Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -2817,6 +2890,8 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$i
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -2826,9 +2901,11 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$i
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -2842,6 +2919,11 @@ class Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$i
     if (!(other
             is Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -2884,6 +2966,7 @@ abstract class CopyWith$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
       _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -2909,11 +2992,15 @@ class _CopyWithImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGro
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
           Query$FindMenteeUsers$findUsers$groupMemberships$$MenteesGroupMembership$industry(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -2934,6 +3021,7 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$groupMemberships$$Mentee
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -3312,19 +3400,24 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies<TRes>
 
 class Query$FindMenteeUsers$findUsers$companies$companyStage {
   Query$FindMenteeUsers$findUsers$companies$companyStage({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'CompanyStage',
   });
 
   factory Query$FindMenteeUsers$findUsers$companies$companyStage.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMenteeUsers$findUsers$companies$companyStage(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -3332,6 +3425,8 @@ class Query$FindMenteeUsers$findUsers$companies$companyStage {
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -3341,9 +3436,11 @@ class Query$FindMenteeUsers$findUsers$companies$companyStage {
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -3356,6 +3453,11 @@ class Query$FindMenteeUsers$findUsers$companies$companyStage {
     }
     if (!(other is Query$FindMenteeUsers$findUsers$companies$companyStage) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -3395,6 +3497,7 @@ abstract class CopyWith$Query$FindMenteeUsers$findUsers$companies$companyStage<
       _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies$companyStage;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -3416,10 +3519,14 @@ class _CopyWithImpl$Query$FindMenteeUsers$findUsers$companies$companyStage<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindMenteeUsers$findUsers$companies$companyStage(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -3439,6 +3546,7 @@ class _CopyWithStubImpl$Query$FindMenteeUsers$findUsers$companies$companyStage<
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -3894,6 +4002,13 @@ const documentNodeQueryFindMentorUsers = DocumentNode(definitions: [
             directives: [],
             selectionSet: SelectionSetNode(selections: [
               FieldNode(
+                name: NameNode(value: 'textId'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'translatedValue'),
                 alias: null,
                 arguments: [],
@@ -3944,6 +4059,13 @@ const documentNodeQueryFindMentorUsers = DocumentNode(definitions: [
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
                       FieldNode(
+                        name: NameNode(value: 'textId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
                         name: NameNode(value: 'translatedValue'),
                         alias: null,
                         arguments: [],
@@ -3965,6 +4087,13 @@ const documentNodeQueryFindMentorUsers = DocumentNode(definitions: [
                     arguments: [],
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'textId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
                       FieldNode(
                         name: NameNode(value: 'translatedValue'),
                         alias: null,
@@ -4418,19 +4547,24 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers<TRes>
 
 class Query$FindMentorUsers$findUsers$countryOfResidence {
   Query$FindMentorUsers$findUsers$countryOfResidence({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Country',
   });
 
   factory Query$FindMentorUsers$findUsers$countryOfResidence.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMentorUsers$findUsers$countryOfResidence(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -4438,6 +4572,8 @@ class Query$FindMentorUsers$findUsers$countryOfResidence {
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -4447,9 +4583,11 @@ class Query$FindMentorUsers$findUsers$countryOfResidence {
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -4462,6 +4600,11 @@ class Query$FindMentorUsers$findUsers$countryOfResidence {
     }
     if (!(other is Query$FindMentorUsers$findUsers$countryOfResidence) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -4501,6 +4644,7 @@ abstract class CopyWith$Query$FindMentorUsers$findUsers$countryOfResidence<
       _CopyWithStubImpl$Query$FindMentorUsers$findUsers$countryOfResidence;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -4521,10 +4665,14 @@ class _CopyWithImpl$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindMentorUsers$findUsers$countryOfResidence(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -4543,6 +4691,7 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$countryOfResidence<TRes>
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -5041,19 +5190,24 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
 
 class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises {
   Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Expertise',
   });
 
   factory Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -5061,6 +5215,8 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$e
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -5070,9 +5226,11 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$e
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -5086,6 +5244,11 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$e
     if (!(other
             is Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -5128,6 +5291,7 @@ abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
       _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -5153,11 +5317,15 @@ class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGro
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
           Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$expertises(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -5178,6 +5346,7 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>
@@ -5186,19 +5355,24 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
 
 class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries {
   Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries({
+    required this.textId,
     this.translatedValue,
     this.$__typename = 'Industry',
   });
 
   factory Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries.fromJson(
       Map<String, dynamic> json) {
+    final l$textId = json['textId'];
     final l$translatedValue = json['translatedValue'];
     final l$$__typename = json['__typename'];
     return Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+      textId: (l$textId as String),
       translatedValue: (l$translatedValue as String?),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final String textId;
 
   final String? translatedValue;
 
@@ -5206,6 +5380,8 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$i
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
     final l$$__typename = $__typename;
@@ -5215,9 +5391,11 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$i
 
   @override
   int get hashCode {
+    final l$textId = textId;
     final l$translatedValue = translatedValue;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$textId,
       l$translatedValue,
       l$$__typename,
     ]);
@@ -5231,6 +5409,11 @@ class Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$i
     if (!(other
             is Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
       return false;
     }
     final l$translatedValue = translatedValue;
@@ -5273,6 +5456,7 @@ abstract class CopyWith$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
       _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries;
 
   TRes call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   });
@@ -5298,11 +5482,15 @@ class _CopyWithImpl$Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGro
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? textId = _undefined,
     Object? translatedValue = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
           Query$FindMentorUsers$findUsers$groupMemberships$$MentorsGroupMembership$industries(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
@@ -5323,6 +5511,7 @@ class _CopyWithStubImpl$Query$FindMentorUsers$findUsers$groupMemberships$$Mentor
   TRes _res;
 
   call({
+    String? textId,
     String? translatedValue,
     String? $__typename,
   }) =>

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -12041,6 +12041,796 @@ class _CopyWithStubImpl$Input$UserSearchListFilter<TRes>
       _res;
 }
 
+class Input$CompanyInput {
+  factory Input$CompanyInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    String? createdAt,
+    String? createdBy,
+    String? updatedAt,
+    String? updatedBy,
+    String? deletedAt,
+    String? deletedBy,
+    String? name,
+    String? description,
+    String? companyTypeTextId,
+    String? companyStageTextId,
+    String? foundedAt,
+    List<Input$LabeledStringValueInput>? websites,
+    List<String>? industries,
+    bool? isOperational,
+    bool? isFundraising,
+    int? annualRevenue,
+    int? employeeCount,
+    List<String>? addUserIds,
+  }) =>
+      Input$CompanyInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (name != null) r'name': name,
+        if (description != null) r'description': description,
+        if (companyTypeTextId != null) r'companyTypeTextId': companyTypeTextId,
+        if (companyStageTextId != null)
+          r'companyStageTextId': companyStageTextId,
+        if (foundedAt != null) r'foundedAt': foundedAt,
+        if (websites != null) r'websites': websites,
+        if (industries != null) r'industries': industries,
+        if (isOperational != null) r'isOperational': isOperational,
+        if (isFundraising != null) r'isFundraising': isFundraising,
+        if (annualRevenue != null) r'annualRevenue': annualRevenue,
+        if (employeeCount != null) r'employeeCount': employeeCount,
+        if (addUserIds != null) r'addUserIds': addUserIds,
+      });
+
+  Input$CompanyInput._(this._$data);
+
+  factory Input$CompanyInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] = (l$createdAt as String?);
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] = (l$updatedAt as String?);
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] = (l$deletedAt as String?);
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('name')) {
+      final l$name = data['name'];
+      result$data['name'] = (l$name as String?);
+    }
+    if (data.containsKey('description')) {
+      final l$description = data['description'];
+      result$data['description'] = (l$description as String?);
+    }
+    if (data.containsKey('companyTypeTextId')) {
+      final l$companyTypeTextId = data['companyTypeTextId'];
+      result$data['companyTypeTextId'] = (l$companyTypeTextId as String?);
+    }
+    if (data.containsKey('companyStageTextId')) {
+      final l$companyStageTextId = data['companyStageTextId'];
+      result$data['companyStageTextId'] = (l$companyStageTextId as String?);
+    }
+    if (data.containsKey('foundedAt')) {
+      final l$foundedAt = data['foundedAt'];
+      result$data['foundedAt'] = (l$foundedAt as String?);
+    }
+    if (data.containsKey('websites')) {
+      final l$websites = data['websites'];
+      result$data['websites'] = (l$websites as List<dynamic>?)
+          ?.map((e) => Input$LabeledStringValueInput.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('industries')) {
+      final l$industries = data['industries'];
+      result$data['industries'] =
+          (l$industries as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('isOperational')) {
+      final l$isOperational = data['isOperational'];
+      result$data['isOperational'] = (l$isOperational as bool?);
+    }
+    if (data.containsKey('isFundraising')) {
+      final l$isFundraising = data['isFundraising'];
+      result$data['isFundraising'] = (l$isFundraising as bool?);
+    }
+    if (data.containsKey('annualRevenue')) {
+      final l$annualRevenue = data['annualRevenue'];
+      result$data['annualRevenue'] = (l$annualRevenue as int?);
+    }
+    if (data.containsKey('employeeCount')) {
+      final l$employeeCount = data['employeeCount'];
+      result$data['employeeCount'] = (l$employeeCount as int?);
+    }
+    if (data.containsKey('addUserIds')) {
+      final l$addUserIds = data['addUserIds'];
+      result$data['addUserIds'] =
+          (l$addUserIds as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    return Input$CompanyInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  String? get createdAt => (_$data['createdAt'] as String?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  String? get updatedAt => (_$data['updatedAt'] as String?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  String? get deletedAt => (_$data['deletedAt'] as String?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  String? get name => (_$data['name'] as String?);
+  String? get description => (_$data['description'] as String?);
+  String? get companyTypeTextId => (_$data['companyTypeTextId'] as String?);
+  String? get companyStageTextId => (_$data['companyStageTextId'] as String?);
+  String? get foundedAt => (_$data['foundedAt'] as String?);
+  List<Input$LabeledStringValueInput>? get websites =>
+      (_$data['websites'] as List<Input$LabeledStringValueInput>?);
+  List<String>? get industries => (_$data['industries'] as List<String>?);
+  bool? get isOperational => (_$data['isOperational'] as bool?);
+  bool? get isFundraising => (_$data['isFundraising'] as bool?);
+  int? get annualRevenue => (_$data['annualRevenue'] as int?);
+  int? get employeeCount => (_$data['employeeCount'] as int?);
+  List<String>? get addUserIds => (_$data['addUserIds'] as List<String>?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt;
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt;
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt;
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('name')) {
+      final l$name = name;
+      result$data['name'] = l$name;
+    }
+    if (_$data.containsKey('description')) {
+      final l$description = description;
+      result$data['description'] = l$description;
+    }
+    if (_$data.containsKey('companyTypeTextId')) {
+      final l$companyTypeTextId = companyTypeTextId;
+      result$data['companyTypeTextId'] = l$companyTypeTextId;
+    }
+    if (_$data.containsKey('companyStageTextId')) {
+      final l$companyStageTextId = companyStageTextId;
+      result$data['companyStageTextId'] = l$companyStageTextId;
+    }
+    if (_$data.containsKey('foundedAt')) {
+      final l$foundedAt = foundedAt;
+      result$data['foundedAt'] = l$foundedAt;
+    }
+    if (_$data.containsKey('websites')) {
+      final l$websites = websites;
+      result$data['websites'] = l$websites?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('industries')) {
+      final l$industries = industries;
+      result$data['industries'] = l$industries?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('isOperational')) {
+      final l$isOperational = isOperational;
+      result$data['isOperational'] = l$isOperational;
+    }
+    if (_$data.containsKey('isFundraising')) {
+      final l$isFundraising = isFundraising;
+      result$data['isFundraising'] = l$isFundraising;
+    }
+    if (_$data.containsKey('annualRevenue')) {
+      final l$annualRevenue = annualRevenue;
+      result$data['annualRevenue'] = l$annualRevenue;
+    }
+    if (_$data.containsKey('employeeCount')) {
+      final l$employeeCount = employeeCount;
+      result$data['employeeCount'] = l$employeeCount;
+    }
+    if (_$data.containsKey('addUserIds')) {
+      final l$addUserIds = addUserIds;
+      result$data['addUserIds'] = l$addUserIds?.map((e) => e).toList();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$CompanyInput<Input$CompanyInput> get copyWith =>
+      CopyWith$Input$CompanyInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$CompanyInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (_$data.containsKey('name') != other._$data.containsKey('name')) {
+      return false;
+    }
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$description = description;
+    final lOther$description = other.description;
+    if (_$data.containsKey('description') !=
+        other._$data.containsKey('description')) {
+      return false;
+    }
+    if (l$description != lOther$description) {
+      return false;
+    }
+    final l$companyTypeTextId = companyTypeTextId;
+    final lOther$companyTypeTextId = other.companyTypeTextId;
+    if (_$data.containsKey('companyTypeTextId') !=
+        other._$data.containsKey('companyTypeTextId')) {
+      return false;
+    }
+    if (l$companyTypeTextId != lOther$companyTypeTextId) {
+      return false;
+    }
+    final l$companyStageTextId = companyStageTextId;
+    final lOther$companyStageTextId = other.companyStageTextId;
+    if (_$data.containsKey('companyStageTextId') !=
+        other._$data.containsKey('companyStageTextId')) {
+      return false;
+    }
+    if (l$companyStageTextId != lOther$companyStageTextId) {
+      return false;
+    }
+    final l$foundedAt = foundedAt;
+    final lOther$foundedAt = other.foundedAt;
+    if (_$data.containsKey('foundedAt') !=
+        other._$data.containsKey('foundedAt')) {
+      return false;
+    }
+    if (l$foundedAt != lOther$foundedAt) {
+      return false;
+    }
+    final l$websites = websites;
+    final lOther$websites = other.websites;
+    if (_$data.containsKey('websites') !=
+        other._$data.containsKey('websites')) {
+      return false;
+    }
+    if (l$websites != null && lOther$websites != null) {
+      if (l$websites.length != lOther$websites.length) {
+        return false;
+      }
+      for (int i = 0; i < l$websites.length; i++) {
+        final l$websites$entry = l$websites[i];
+        final lOther$websites$entry = lOther$websites[i];
+        if (l$websites$entry != lOther$websites$entry) {
+          return false;
+        }
+      }
+    } else if (l$websites != lOther$websites) {
+      return false;
+    }
+    final l$industries = industries;
+    final lOther$industries = other.industries;
+    if (_$data.containsKey('industries') !=
+        other._$data.containsKey('industries')) {
+      return false;
+    }
+    if (l$industries != null && lOther$industries != null) {
+      if (l$industries.length != lOther$industries.length) {
+        return false;
+      }
+      for (int i = 0; i < l$industries.length; i++) {
+        final l$industries$entry = l$industries[i];
+        final lOther$industries$entry = lOther$industries[i];
+        if (l$industries$entry != lOther$industries$entry) {
+          return false;
+        }
+      }
+    } else if (l$industries != lOther$industries) {
+      return false;
+    }
+    final l$isOperational = isOperational;
+    final lOther$isOperational = other.isOperational;
+    if (_$data.containsKey('isOperational') !=
+        other._$data.containsKey('isOperational')) {
+      return false;
+    }
+    if (l$isOperational != lOther$isOperational) {
+      return false;
+    }
+    final l$isFundraising = isFundraising;
+    final lOther$isFundraising = other.isFundraising;
+    if (_$data.containsKey('isFundraising') !=
+        other._$data.containsKey('isFundraising')) {
+      return false;
+    }
+    if (l$isFundraising != lOther$isFundraising) {
+      return false;
+    }
+    final l$annualRevenue = annualRevenue;
+    final lOther$annualRevenue = other.annualRevenue;
+    if (_$data.containsKey('annualRevenue') !=
+        other._$data.containsKey('annualRevenue')) {
+      return false;
+    }
+    if (l$annualRevenue != lOther$annualRevenue) {
+      return false;
+    }
+    final l$employeeCount = employeeCount;
+    final lOther$employeeCount = other.employeeCount;
+    if (_$data.containsKey('employeeCount') !=
+        other._$data.containsKey('employeeCount')) {
+      return false;
+    }
+    if (l$employeeCount != lOther$employeeCount) {
+      return false;
+    }
+    final l$addUserIds = addUserIds;
+    final lOther$addUserIds = other.addUserIds;
+    if (_$data.containsKey('addUserIds') !=
+        other._$data.containsKey('addUserIds')) {
+      return false;
+    }
+    if (l$addUserIds != null && lOther$addUserIds != null) {
+      if (l$addUserIds.length != lOther$addUserIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$addUserIds.length; i++) {
+        final l$addUserIds$entry = l$addUserIds[i];
+        final lOther$addUserIds$entry = lOther$addUserIds[i];
+        if (l$addUserIds$entry != lOther$addUserIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$addUserIds != lOther$addUserIds) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$name = name;
+    final l$description = description;
+    final l$companyTypeTextId = companyTypeTextId;
+    final l$companyStageTextId = companyStageTextId;
+    final l$foundedAt = foundedAt;
+    final l$websites = websites;
+    final l$industries = industries;
+    final l$isOperational = isOperational;
+    final l$isFundraising = isFundraising;
+    final l$annualRevenue = annualRevenue;
+    final l$employeeCount = employeeCount;
+    final l$addUserIds = addUserIds;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('name') ? l$name : const {},
+      _$data.containsKey('description') ? l$description : const {},
+      _$data.containsKey('companyTypeTextId') ? l$companyTypeTextId : const {},
+      _$data.containsKey('companyStageTextId')
+          ? l$companyStageTextId
+          : const {},
+      _$data.containsKey('foundedAt') ? l$foundedAt : const {},
+      _$data.containsKey('websites')
+          ? l$websites == null
+              ? null
+              : Object.hashAll(l$websites.map((v) => v))
+          : const {},
+      _$data.containsKey('industries')
+          ? l$industries == null
+              ? null
+              : Object.hashAll(l$industries.map((v) => v))
+          : const {},
+      _$data.containsKey('isOperational') ? l$isOperational : const {},
+      _$data.containsKey('isFundraising') ? l$isFundraising : const {},
+      _$data.containsKey('annualRevenue') ? l$annualRevenue : const {},
+      _$data.containsKey('employeeCount') ? l$employeeCount : const {},
+      _$data.containsKey('addUserIds')
+          ? l$addUserIds == null
+              ? null
+              : Object.hashAll(l$addUserIds.map((v) => v))
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$CompanyInput<TRes> {
+  factory CopyWith$Input$CompanyInput(
+    Input$CompanyInput instance,
+    TRes Function(Input$CompanyInput) then,
+  ) = _CopyWithImpl$Input$CompanyInput;
+
+  factory CopyWith$Input$CompanyInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$CompanyInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    String? createdAt,
+    String? createdBy,
+    String? updatedAt,
+    String? updatedBy,
+    String? deletedAt,
+    String? deletedBy,
+    String? name,
+    String? description,
+    String? companyTypeTextId,
+    String? companyStageTextId,
+    String? foundedAt,
+    List<Input$LabeledStringValueInput>? websites,
+    List<String>? industries,
+    bool? isOperational,
+    bool? isFundraising,
+    int? annualRevenue,
+    int? employeeCount,
+    List<String>? addUserIds,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+  TRes websites(
+      Iterable<Input$LabeledStringValueInput>? Function(
+              Iterable<
+                  CopyWith$Input$LabeledStringValueInput<
+                      Input$LabeledStringValueInput>>?)
+          _fn);
+}
+
+class _CopyWithImpl$Input$CompanyInput<TRes>
+    implements CopyWith$Input$CompanyInput<TRes> {
+  _CopyWithImpl$Input$CompanyInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$CompanyInput _instance;
+
+  final TRes Function(Input$CompanyInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? name = _undefined,
+    Object? description = _undefined,
+    Object? companyTypeTextId = _undefined,
+    Object? companyStageTextId = _undefined,
+    Object? foundedAt = _undefined,
+    Object? websites = _undefined,
+    Object? industries = _undefined,
+    Object? isOperational = _undefined,
+    Object? isFundraising = _undefined,
+    Object? annualRevenue = _undefined,
+    Object? employeeCount = _undefined,
+    Object? addUserIds = _undefined,
+  }) =>
+      _then(Input$CompanyInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (name != _undefined) 'name': (name as String?),
+        if (description != _undefined) 'description': (description as String?),
+        if (companyTypeTextId != _undefined)
+          'companyTypeTextId': (companyTypeTextId as String?),
+        if (companyStageTextId != _undefined)
+          'companyStageTextId': (companyStageTextId as String?),
+        if (foundedAt != _undefined) 'foundedAt': (foundedAt as String?),
+        if (websites != _undefined)
+          'websites': (websites as List<Input$LabeledStringValueInput>?),
+        if (industries != _undefined)
+          'industries': (industries as List<String>?),
+        if (isOperational != _undefined)
+          'isOperational': (isOperational as bool?),
+        if (isFundraising != _undefined)
+          'isFundraising': (isFundraising as bool?),
+        if (annualRevenue != _undefined)
+          'annualRevenue': (annualRevenue as int?),
+        if (employeeCount != _undefined)
+          'employeeCount': (employeeCount as int?),
+        if (addUserIds != _undefined)
+          'addUserIds': (addUserIds as List<String>?),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+
+  TRes websites(
+          Iterable<Input$LabeledStringValueInput>? Function(
+                  Iterable<
+                      CopyWith$Input$LabeledStringValueInput<
+                          Input$LabeledStringValueInput>>?)
+              _fn) =>
+      call(
+          websites: _fn(_instance.websites
+              ?.map((e) => CopyWith$Input$LabeledStringValueInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+}
+
+class _CopyWithStubImpl$Input$CompanyInput<TRes>
+    implements CopyWith$Input$CompanyInput<TRes> {
+  _CopyWithStubImpl$Input$CompanyInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    String? createdAt,
+    String? createdBy,
+    String? updatedAt,
+    String? updatedBy,
+    String? deletedAt,
+    String? deletedBy,
+    String? name,
+    String? description,
+    String? companyTypeTextId,
+    String? companyStageTextId,
+    String? foundedAt,
+    List<Input$LabeledStringValueInput>? websites,
+    List<String>? industries,
+    bool? isOperational,
+    bool? isFundraising,
+    int? annualRevenue,
+    int? employeeCount,
+    List<String>? addUserIds,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+  websites(_fn) => _res;
+}
+
 class Input$UserSignInInput {
   factory Input$UserSignInInput({
     String? ident,
@@ -15060,7 +15850,6 @@ class Input$MentorsGroupMembershipInput {
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
-    int? endorsements,
   }) =>
       Input$MentorsGroupMembershipInput._({
         if (id != null) r'id': id,
@@ -15083,7 +15872,6 @@ class Input$MentorsGroupMembershipInput {
           r'expectationsForMentees': expectationsForMentees,
         if (menteePreparationInstructions != null)
           r'menteePreparationInstructions': menteePreparationInstructions,
-        if (endorsements != null) r'endorsements': endorsements,
       });
 
   Input$MentorsGroupMembershipInput._(this._$data);
@@ -15178,10 +15966,6 @@ class Input$MentorsGroupMembershipInput {
       result$data['menteePreparationInstructions'] =
           (l$menteePreparationInstructions as String?);
     }
-    if (data.containsKey('endorsements')) {
-      final l$endorsements = data['endorsements'];
-      result$data['endorsements'] = (l$endorsements as int?);
-    }
     return Input$MentorsGroupMembershipInput._(result$data);
   }
 
@@ -15212,7 +15996,6 @@ class Input$MentorsGroupMembershipInput {
       (_$data['expectationsForMentees'] as String?);
   String? get menteePreparationInstructions =>
       (_$data['menteePreparationInstructions'] as String?);
-  int? get endorsements => (_$data['endorsements'] as int?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -15291,10 +16074,6 @@ class Input$MentorsGroupMembershipInput {
       final l$menteePreparationInstructions = menteePreparationInstructions;
       result$data['menteePreparationInstructions'] =
           l$menteePreparationInstructions;
-    }
-    if (_$data.containsKey('endorsements')) {
-      final l$endorsements = endorsements;
-      result$data['endorsements'] = l$endorsements;
     }
     return result$data;
   }
@@ -15516,15 +16295,6 @@ class Input$MentorsGroupMembershipInput {
         lOther$menteePreparationInstructions) {
       return false;
     }
-    final l$endorsements = endorsements;
-    final lOther$endorsements = other.endorsements;
-    if (_$data.containsKey('endorsements') !=
-        other._$data.containsKey('endorsements')) {
-      return false;
-    }
-    if (l$endorsements != lOther$endorsements) {
-      return false;
-    }
     return true;
   }
 
@@ -15548,7 +16318,6 @@ class Input$MentorsGroupMembershipInput {
     final l$helpICanOffer = helpICanOffer;
     final l$expectationsForMentees = expectationsForMentees;
     final l$menteePreparationInstructions = menteePreparationInstructions;
-    final l$endorsements = endorsements;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -15588,7 +16357,6 @@ class Input$MentorsGroupMembershipInput {
       _$data.containsKey('menteePreparationInstructions')
           ? l$menteePreparationInstructions
           : const {},
-      _$data.containsKey('endorsements') ? l$endorsements : const {},
     ]);
   }
 }
@@ -15621,7 +16389,6 @@ abstract class CopyWith$Input$MentorsGroupMembershipInput<TRes> {
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
-    int? endorsements,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -15662,7 +16429,6 @@ class _CopyWithImpl$Input$MentorsGroupMembershipInput<TRes>
     Object? helpICanOffer = _undefined,
     Object? expectationsForMentees = _undefined,
     Object? menteePreparationInstructions = _undefined,
-    Object? endorsements = _undefined,
   }) =>
       _then(Input$MentorsGroupMembershipInput._({
         ..._instance._$data,
@@ -15693,7 +16459,6 @@ class _CopyWithImpl$Input$MentorsGroupMembershipInput<TRes>
         if (menteePreparationInstructions != _undefined)
           'menteePreparationInstructions':
               (menteePreparationInstructions as String?),
-        if (endorsements != _undefined) 'endorsements': (endorsements as int?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -15740,7 +16505,6 @@ class _CopyWithStubImpl$Input$MentorsGroupMembershipInput<TRes>
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
-    int? endorsements,
   }) =>
       _res;
   events(_fn) => _res;
@@ -22031,37 +22795,12 @@ Enum$MultiStepActionResult fromJson$Enum$MultiStepActionResult(String value) {
   }
 }
 
-enum Enum$ChannelMessageEvent { received, seen, unset, $unknown }
-
-String toJson$Enum$ChannelMessageEvent(Enum$ChannelMessageEvent e) {
-  switch (e) {
-    case Enum$ChannelMessageEvent.received:
-      return r'received';
-    case Enum$ChannelMessageEvent.seen:
-      return r'seen';
-    case Enum$ChannelMessageEvent.unset:
-      return r'unset';
-    case Enum$ChannelMessageEvent.$unknown:
-      return r'$unknown';
-  }
-}
-
-Enum$ChannelMessageEvent fromJson$Enum$ChannelMessageEvent(String value) {
-  switch (value) {
-    case r'received':
-      return Enum$ChannelMessageEvent.received;
-    case r'seen':
-      return Enum$ChannelMessageEvent.seen;
-    case r'unset':
-      return Enum$ChannelMessageEvent.unset;
-    default:
-      return Enum$ChannelMessageEvent.$unknown;
-  }
-}
-
 enum Enum$ServiceRequestType {
   graphQlQueryUserInbox,
   graphQlQueryUserUserSearches,
+  graphQlMutationCreateCompany,
+  graphQlMutationDeleteCompany,
+  graphQlMutationUpdateCompany,
   graphQlMutationAddChannelMessageEvent,
   graphQlMutationCreateChannel,
   graphQlMutationCreateChannelInvitation,
@@ -22167,6 +22906,12 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryUserInbox';
     case Enum$ServiceRequestType.graphQlQueryUserUserSearches:
       return r'graphQlQueryUserUserSearches';
+    case Enum$ServiceRequestType.graphQlMutationCreateCompany:
+      return r'graphQlMutationCreateCompany';
+    case Enum$ServiceRequestType.graphQlMutationDeleteCompany:
+      return r'graphQlMutationDeleteCompany';
+    case Enum$ServiceRequestType.graphQlMutationUpdateCompany:
+      return r'graphQlMutationUpdateCompany';
     case Enum$ServiceRequestType.graphQlMutationAddChannelMessageEvent:
       return r'graphQlMutationAddChannelMessageEvent';
     case Enum$ServiceRequestType.graphQlMutationCreateChannel:
@@ -22371,6 +23116,12 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryUserInbox;
     case r'graphQlQueryUserUserSearches':
       return Enum$ServiceRequestType.graphQlQueryUserUserSearches;
+    case r'graphQlMutationCreateCompany':
+      return Enum$ServiceRequestType.graphQlMutationCreateCompany;
+    case r'graphQlMutationDeleteCompany':
+      return Enum$ServiceRequestType.graphQlMutationDeleteCompany;
+    case r'graphQlMutationUpdateCompany':
+      return Enum$ServiceRequestType.graphQlMutationUpdateCompany;
     case r'graphQlMutationAddChannelMessageEvent':
       return Enum$ServiceRequestType.graphQlMutationAddChannelMessageEvent;
     case r'graphQlMutationCreateChannel':
@@ -23036,6 +23787,34 @@ Enum$ErrorCode fromJson$Enum$ErrorCode(String value) {
       return Enum$ErrorCode.authTokenNoMatch;
     default:
       return Enum$ErrorCode.$unknown;
+  }
+}
+
+enum Enum$ChannelMessageEvent { received, seen, unset, $unknown }
+
+String toJson$Enum$ChannelMessageEvent(Enum$ChannelMessageEvent e) {
+  switch (e) {
+    case Enum$ChannelMessageEvent.received:
+      return r'received';
+    case Enum$ChannelMessageEvent.seen:
+      return r'seen';
+    case Enum$ChannelMessageEvent.unset:
+      return r'unset';
+    case Enum$ChannelMessageEvent.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$ChannelMessageEvent fromJson$Enum$ChannelMessageEvent(String value) {
+  switch (value) {
+    case r'received':
+      return Enum$ChannelMessageEvent.received;
+    case r'seen':
+      return Enum$ChannelMessageEvent.seen;
+    case r'unset':
+      return Enum$ChannelMessageEvent.unset;
+    default:
+      return Enum$ChannelMessageEvent.$unknown;
   }
 }
 

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -169,7 +169,7 @@ class _CopyWithStubImpl$Input$FindUserByIdentOptions<TRes>
 class Input$FindObjectsOptions {
   factory Input$FindObjectsOptions({
     int? limit,
-    String? sort,
+    List<Input$SortItem>? sort,
     int? skip,
     bool? timeout,
     bool? tailable,
@@ -213,7 +213,9 @@ class Input$FindObjectsOptions {
     }
     if (data.containsKey('sort')) {
       final l$sort = data['sort'];
-      result$data['sort'] = (l$sort as String?);
+      result$data['sort'] = (l$sort as List<dynamic>?)
+          ?.map((e) => Input$SortItem.fromJson((e as Map<String, dynamic>)))
+          .toList();
     }
     if (data.containsKey('skip')) {
       final l$skip = data['skip'];
@@ -273,7 +275,7 @@ class Input$FindObjectsOptions {
   Map<String, dynamic> _$data;
 
   int? get limit => (_$data['limit'] as int?);
-  String? get sort => (_$data['sort'] as String?);
+  List<Input$SortItem>? get sort => (_$data['sort'] as List<Input$SortItem>?);
   int? get skip => (_$data['skip'] as int?);
   bool? get timeout => (_$data['timeout'] as bool?);
   bool? get tailable => (_$data['tailable'] as bool?);
@@ -295,7 +297,7 @@ class Input$FindObjectsOptions {
     }
     if (_$data.containsKey('sort')) {
       final l$sort = sort;
-      result$data['sort'] = l$sort;
+      result$data['sort'] = l$sort?.map((e) => e.toJson()).toList();
     }
     if (_$data.containsKey('skip')) {
       final l$skip = skip;
@@ -379,7 +381,18 @@ class Input$FindObjectsOptions {
     if (_$data.containsKey('sort') != other._$data.containsKey('sort')) {
       return false;
     }
-    if (l$sort != lOther$sort) {
+    if (l$sort != null && lOther$sort != null) {
+      if (l$sort.length != lOther$sort.length) {
+        return false;
+      }
+      for (int i = 0; i < l$sort.length; i++) {
+        final l$sort$entry = l$sort[i];
+        final lOther$sort$entry = lOther$sort[i];
+        if (l$sort$entry != lOther$sort$entry) {
+          return false;
+        }
+      }
+    } else if (l$sort != lOther$sort) {
       return false;
     }
     final l$skip = skip;
@@ -519,7 +532,11 @@ class Input$FindObjectsOptions {
     final l$includeDeleted = includeDeleted;
     return Object.hashAll([
       _$data.containsKey('limit') ? l$limit : const {},
-      _$data.containsKey('sort') ? l$sort : const {},
+      _$data.containsKey('sort')
+          ? l$sort == null
+              ? null
+              : Object.hashAll(l$sort.map((v) => v))
+          : const {},
       _$data.containsKey('skip') ? l$skip : const {},
       _$data.containsKey('timeout') ? l$timeout : const {},
       _$data.containsKey('tailable') ? l$tailable : const {},
@@ -550,7 +567,7 @@ abstract class CopyWith$Input$FindObjectsOptions<TRes> {
 
   TRes call({
     int? limit,
-    String? sort,
+    List<Input$SortItem>? sort,
     int? skip,
     bool? timeout,
     bool? tailable,
@@ -565,6 +582,10 @@ abstract class CopyWith$Input$FindObjectsOptions<TRes> {
     bool? showRecordId,
     bool? includeDeleted,
   });
+  TRes sort(
+      Iterable<Input$SortItem>? Function(
+              Iterable<CopyWith$Input$SortItem<Input$SortItem>>?)
+          _fn);
 }
 
 class _CopyWithImpl$Input$FindObjectsOptions<TRes>
@@ -600,7 +621,7 @@ class _CopyWithImpl$Input$FindObjectsOptions<TRes>
       _then(Input$FindObjectsOptions._({
         ..._instance._$data,
         if (limit != _undefined) 'limit': (limit as int?),
-        if (sort != _undefined) 'sort': (sort as String?),
+        if (sort != _undefined) 'sort': (sort as List<Input$SortItem>?),
         if (skip != _undefined) 'skip': (skip as int?),
         if (timeout != _undefined) 'timeout': (timeout as bool?),
         if (tailable != _undefined) 'tailable': (tailable as bool?),
@@ -619,6 +640,15 @@ class _CopyWithImpl$Input$FindObjectsOptions<TRes>
         if (includeDeleted != _undefined)
           'includeDeleted': (includeDeleted as bool?),
       }));
+  TRes sort(
+          Iterable<Input$SortItem>? Function(
+                  Iterable<CopyWith$Input$SortItem<Input$SortItem>>?)
+              _fn) =>
+      call(
+          sort: _fn(_instance.sort?.map((e) => CopyWith$Input$SortItem(
+                e,
+                (i) => i,
+              )))?.toList());
 }
 
 class _CopyWithStubImpl$Input$FindObjectsOptions<TRes>
@@ -629,7 +659,7 @@ class _CopyWithStubImpl$Input$FindObjectsOptions<TRes>
 
   call({
     int? limit,
-    String? sort,
+    List<Input$SortItem>? sort,
     int? skip,
     bool? timeout,
     bool? tailable,
@@ -643,6 +673,150 @@ class _CopyWithStubImpl$Input$FindObjectsOptions<TRes>
     bool? allowPartialResults,
     bool? showRecordId,
     bool? includeDeleted,
+  }) =>
+      _res;
+  sort(_fn) => _res;
+}
+
+class Input$SortItem {
+  factory Input$SortItem({
+    String? field,
+    Enum$SortDirection? direction,
+  }) =>
+      Input$SortItem._({
+        if (field != null) r'field': field,
+        if (direction != null) r'direction': direction,
+      });
+
+  Input$SortItem._(this._$data);
+
+  factory Input$SortItem.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('field')) {
+      final l$field = data['field'];
+      result$data['field'] = (l$field as String);
+    }
+    if (data.containsKey('direction')) {
+      final l$direction = data['direction'];
+      result$data['direction'] = l$direction == null
+          ? null
+          : fromJson$Enum$SortDirection((l$direction as String));
+    }
+    return Input$SortItem._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get field => (_$data['field'] as String?);
+  Enum$SortDirection? get direction =>
+      (_$data['direction'] as Enum$SortDirection?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('field')) {
+      final l$field = field;
+      result$data['field'] = (l$field as String);
+    }
+    if (_$data.containsKey('direction')) {
+      final l$direction = direction;
+      result$data['direction'] =
+          l$direction == null ? null : toJson$Enum$SortDirection(l$direction);
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$SortItem<Input$SortItem> get copyWith =>
+      CopyWith$Input$SortItem(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$SortItem) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$field = field;
+    final lOther$field = other.field;
+    if (_$data.containsKey('field') != other._$data.containsKey('field')) {
+      return false;
+    }
+    if (l$field != lOther$field) {
+      return false;
+    }
+    final l$direction = direction;
+    final lOther$direction = other.direction;
+    if (_$data.containsKey('direction') !=
+        other._$data.containsKey('direction')) {
+      return false;
+    }
+    if (l$direction != lOther$direction) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$field = field;
+    final l$direction = direction;
+    return Object.hashAll([
+      _$data.containsKey('field') ? l$field : const {},
+      _$data.containsKey('direction') ? l$direction : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$SortItem<TRes> {
+  factory CopyWith$Input$SortItem(
+    Input$SortItem instance,
+    TRes Function(Input$SortItem) then,
+  ) = _CopyWithImpl$Input$SortItem;
+
+  factory CopyWith$Input$SortItem.stub(TRes res) =
+      _CopyWithStubImpl$Input$SortItem;
+
+  TRes call({
+    String? field,
+    Enum$SortDirection? direction,
+  });
+}
+
+class _CopyWithImpl$Input$SortItem<TRes>
+    implements CopyWith$Input$SortItem<TRes> {
+  _CopyWithImpl$Input$SortItem(
+    this._instance,
+    this._then,
+  );
+
+  final Input$SortItem _instance;
+
+  final TRes Function(Input$SortItem) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? field = _undefined,
+    Object? direction = _undefined,
+  }) =>
+      _then(Input$SortItem._({
+        ..._instance._$data,
+        if (field != _undefined && field != null) 'field': (field as String),
+        if (direction != _undefined)
+          'direction': (direction as Enum$SortDirection?),
+      }));
+}
+
+class _CopyWithStubImpl$Input$SortItem<TRes>
+    implements CopyWith$Input$SortItem<TRes> {
+  _CopyWithStubImpl$Input$SortItem(this._res);
+
+  TRes _res;
+
+  call({
+    String? field,
+    Enum$SortDirection? direction,
   }) =>
       _res;
 }
@@ -672,7 +846,7 @@ class Input$UserInput {
     String? gender,
     String? cityOfResidence,
     String? regionOfResidence,
-    String? countryOfResidence,
+    String? countryOfResidenceTextId,
     String? postalCode,
     String? avatarUrl,
     String? jobTitle,
@@ -682,8 +856,8 @@ class Input$UserInput {
     String? newPassword,
     String? tfaBackupCodes,
     String? passwordUpdatedAt,
-    String? preferredLanguage,
-    String? uiLanguage,
+    Enum$UiLanguage? preferredLanguage,
+    Enum$UiLanguage? uiLanguage,
     List<String>? spokenLanguages,
     List<Enum$UserRole>? roles,
     List<Enum$AppFeature>? appFeatures,
@@ -704,11 +878,12 @@ class Input$UserInput {
     int? birthYear,
     String? genderSelfDescribed,
     String? ethnicity,
-    Enum$EducationLevel? educationLevel,
+    String? educationLevelTextId,
     String? professionalBackground,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
+    String? oneLiner,
   }) =>
       Input$UserInput._({
         if (id != null) r'id': id,
@@ -736,8 +911,8 @@ class Input$UserInput {
         if (gender != null) r'gender': gender,
         if (cityOfResidence != null) r'cityOfResidence': cityOfResidence,
         if (regionOfResidence != null) r'regionOfResidence': regionOfResidence,
-        if (countryOfResidence != null)
-          r'countryOfResidence': countryOfResidence,
+        if (countryOfResidenceTextId != null)
+          r'countryOfResidenceTextId': countryOfResidenceTextId,
         if (postalCode != null) r'postalCode': postalCode,
         if (avatarUrl != null) r'avatarUrl': avatarUrl,
         if (jobTitle != null) r'jobTitle': jobTitle,
@@ -771,7 +946,8 @@ class Input$UserInput {
         if (genderSelfDescribed != null)
           r'genderSelfDescribed': genderSelfDescribed,
         if (ethnicity != null) r'ethnicity': ethnicity,
-        if (educationLevel != null) r'educationLevel': educationLevel,
+        if (educationLevelTextId != null)
+          r'educationLevelTextId': educationLevelTextId,
         if (professionalBackground != null)
           r'professionalBackground': professionalBackground,
         if (yearsManagementExperience != null)
@@ -779,6 +955,7 @@ class Input$UserInput {
         if (yearsOwnershipExperience != null)
           r'yearsOwnershipExperience': yearsOwnershipExperience,
         if (ssoIdp != null) r'ssoIdp': ssoIdp,
+        if (oneLiner != null) r'oneLiner': oneLiner,
       });
 
   Input$UserInput._(this._$data);
@@ -883,9 +1060,10 @@ class Input$UserInput {
       final l$regionOfResidence = data['regionOfResidence'];
       result$data['regionOfResidence'] = (l$regionOfResidence as String?);
     }
-    if (data.containsKey('countryOfResidence')) {
-      final l$countryOfResidence = data['countryOfResidence'];
-      result$data['countryOfResidence'] = (l$countryOfResidence as String?);
+    if (data.containsKey('countryOfResidenceTextId')) {
+      final l$countryOfResidenceTextId = data['countryOfResidenceTextId'];
+      result$data['countryOfResidenceTextId'] =
+          (l$countryOfResidenceTextId as String?);
     }
     if (data.containsKey('postalCode')) {
       final l$postalCode = data['postalCode'];
@@ -930,11 +1108,15 @@ class Input$UserInput {
     }
     if (data.containsKey('preferredLanguage')) {
       final l$preferredLanguage = data['preferredLanguage'];
-      result$data['preferredLanguage'] = (l$preferredLanguage as String?);
+      result$data['preferredLanguage'] = l$preferredLanguage == null
+          ? null
+          : fromJson$Enum$UiLanguage((l$preferredLanguage as String));
     }
     if (data.containsKey('uiLanguage')) {
       final l$uiLanguage = data['uiLanguage'];
-      result$data['uiLanguage'] = (l$uiLanguage as String?);
+      result$data['uiLanguage'] = l$uiLanguage == null
+          ? null
+          : fromJson$Enum$UiLanguage((l$uiLanguage as String));
     }
     if (data.containsKey('spokenLanguages')) {
       final l$spokenLanguages = data['spokenLanguages'];
@@ -1031,11 +1213,9 @@ class Input$UserInput {
       final l$ethnicity = data['ethnicity'];
       result$data['ethnicity'] = (l$ethnicity as String?);
     }
-    if (data.containsKey('educationLevel')) {
-      final l$educationLevel = data['educationLevel'];
-      result$data['educationLevel'] = l$educationLevel == null
-          ? null
-          : fromJson$Enum$EducationLevel((l$educationLevel as String));
+    if (data.containsKey('educationLevelTextId')) {
+      final l$educationLevelTextId = data['educationLevelTextId'];
+      result$data['educationLevelTextId'] = (l$educationLevelTextId as String?);
     }
     if (data.containsKey('professionalBackground')) {
       final l$professionalBackground = data['professionalBackground'];
@@ -1055,6 +1235,10 @@ class Input$UserInput {
     if (data.containsKey('ssoIdp')) {
       final l$ssoIdp = data['ssoIdp'];
       result$data['ssoIdp'] = (l$ssoIdp as String?);
+    }
+    if (data.containsKey('oneLiner')) {
+      final l$oneLiner = data['oneLiner'];
+      result$data['oneLiner'] = (l$oneLiner as String?);
     }
     return Input$UserInput._(result$data);
   }
@@ -1087,7 +1271,8 @@ class Input$UserInput {
   String? get gender => (_$data['gender'] as String?);
   String? get cityOfResidence => (_$data['cityOfResidence'] as String?);
   String? get regionOfResidence => (_$data['regionOfResidence'] as String?);
-  String? get countryOfResidence => (_$data['countryOfResidence'] as String?);
+  String? get countryOfResidenceTextId =>
+      (_$data['countryOfResidenceTextId'] as String?);
   String? get postalCode => (_$data['postalCode'] as String?);
   String? get avatarUrl => (_$data['avatarUrl'] as String?);
   String? get jobTitle => (_$data['jobTitle'] as String?);
@@ -1098,8 +1283,9 @@ class Input$UserInput {
   String? get newPassword => (_$data['newPassword'] as String?);
   String? get tfaBackupCodes => (_$data['tfaBackupCodes'] as String?);
   String? get passwordUpdatedAt => (_$data['passwordUpdatedAt'] as String?);
-  String? get preferredLanguage => (_$data['preferredLanguage'] as String?);
-  String? get uiLanguage => (_$data['uiLanguage'] as String?);
+  Enum$UiLanguage? get preferredLanguage =>
+      (_$data['preferredLanguage'] as Enum$UiLanguage?);
+  Enum$UiLanguage? get uiLanguage => (_$data['uiLanguage'] as Enum$UiLanguage?);
   List<String>? get spokenLanguages =>
       (_$data['spokenLanguages'] as List<String>?);
   List<Enum$UserRole>? get roles => (_$data['roles'] as List<Enum$UserRole>?);
@@ -1124,8 +1310,8 @@ class Input$UserInput {
   int? get birthYear => (_$data['birthYear'] as int?);
   String? get genderSelfDescribed => (_$data['genderSelfDescribed'] as String?);
   String? get ethnicity => (_$data['ethnicity'] as String?);
-  Enum$EducationLevel? get educationLevel =>
-      (_$data['educationLevel'] as Enum$EducationLevel?);
+  String? get educationLevelTextId =>
+      (_$data['educationLevelTextId'] as String?);
   String? get professionalBackground =>
       (_$data['professionalBackground'] as String?);
   int? get yearsManagementExperience =>
@@ -1133,6 +1319,7 @@ class Input$UserInput {
   int? get yearsOwnershipExperience =>
       (_$data['yearsOwnershipExperience'] as int?);
   String? get ssoIdp => (_$data['ssoIdp'] as String?);
+  String? get oneLiner => (_$data['oneLiner'] as String?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -1227,9 +1414,9 @@ class Input$UserInput {
       final l$regionOfResidence = regionOfResidence;
       result$data['regionOfResidence'] = l$regionOfResidence;
     }
-    if (_$data.containsKey('countryOfResidence')) {
-      final l$countryOfResidence = countryOfResidence;
-      result$data['countryOfResidence'] = l$countryOfResidence;
+    if (_$data.containsKey('countryOfResidenceTextId')) {
+      final l$countryOfResidenceTextId = countryOfResidenceTextId;
+      result$data['countryOfResidenceTextId'] = l$countryOfResidenceTextId;
     }
     if (_$data.containsKey('postalCode')) {
       final l$postalCode = postalCode;
@@ -1270,11 +1457,14 @@ class Input$UserInput {
     }
     if (_$data.containsKey('preferredLanguage')) {
       final l$preferredLanguage = preferredLanguage;
-      result$data['preferredLanguage'] = l$preferredLanguage;
+      result$data['preferredLanguage'] = l$preferredLanguage == null
+          ? null
+          : toJson$Enum$UiLanguage(l$preferredLanguage);
     }
     if (_$data.containsKey('uiLanguage')) {
       final l$uiLanguage = uiLanguage;
-      result$data['uiLanguage'] = l$uiLanguage;
+      result$data['uiLanguage'] =
+          l$uiLanguage == null ? null : toJson$Enum$UiLanguage(l$uiLanguage);
     }
     if (_$data.containsKey('spokenLanguages')) {
       final l$spokenLanguages = spokenLanguages;
@@ -1361,11 +1551,9 @@ class Input$UserInput {
       final l$ethnicity = ethnicity;
       result$data['ethnicity'] = l$ethnicity;
     }
-    if (_$data.containsKey('educationLevel')) {
-      final l$educationLevel = educationLevel;
-      result$data['educationLevel'] = l$educationLevel == null
-          ? null
-          : toJson$Enum$EducationLevel(l$educationLevel);
+    if (_$data.containsKey('educationLevelTextId')) {
+      final l$educationLevelTextId = educationLevelTextId;
+      result$data['educationLevelTextId'] = l$educationLevelTextId;
     }
     if (_$data.containsKey('professionalBackground')) {
       final l$professionalBackground = professionalBackground;
@@ -1382,6 +1570,10 @@ class Input$UserInput {
     if (_$data.containsKey('ssoIdp')) {
       final l$ssoIdp = ssoIdp;
       result$data['ssoIdp'] = l$ssoIdp;
+    }
+    if (_$data.containsKey('oneLiner')) {
+      final l$oneLiner = oneLiner;
+      result$data['oneLiner'] = l$oneLiner;
     }
     return result$data;
   }
@@ -1613,13 +1805,13 @@ class Input$UserInput {
     if (l$regionOfResidence != lOther$regionOfResidence) {
       return false;
     }
-    final l$countryOfResidence = countryOfResidence;
-    final lOther$countryOfResidence = other.countryOfResidence;
-    if (_$data.containsKey('countryOfResidence') !=
-        other._$data.containsKey('countryOfResidence')) {
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    final lOther$countryOfResidenceTextId = other.countryOfResidenceTextId;
+    if (_$data.containsKey('countryOfResidenceTextId') !=
+        other._$data.containsKey('countryOfResidenceTextId')) {
       return false;
     }
-    if (l$countryOfResidence != lOther$countryOfResidence) {
+    if (l$countryOfResidenceTextId != lOther$countryOfResidenceTextId) {
       return false;
     }
     final l$postalCode = postalCode;
@@ -1976,13 +2168,13 @@ class Input$UserInput {
     if (l$ethnicity != lOther$ethnicity) {
       return false;
     }
-    final l$educationLevel = educationLevel;
-    final lOther$educationLevel = other.educationLevel;
-    if (_$data.containsKey('educationLevel') !=
-        other._$data.containsKey('educationLevel')) {
+    final l$educationLevelTextId = educationLevelTextId;
+    final lOther$educationLevelTextId = other.educationLevelTextId;
+    if (_$data.containsKey('educationLevelTextId') !=
+        other._$data.containsKey('educationLevelTextId')) {
       return false;
     }
-    if (l$educationLevel != lOther$educationLevel) {
+    if (l$educationLevelTextId != lOther$educationLevelTextId) {
       return false;
     }
     final l$professionalBackground = professionalBackground;
@@ -2020,6 +2212,15 @@ class Input$UserInput {
     if (l$ssoIdp != lOther$ssoIdp) {
       return false;
     }
+    final l$oneLiner = oneLiner;
+    final lOther$oneLiner = other.oneLiner;
+    if (_$data.containsKey('oneLiner') !=
+        other._$data.containsKey('oneLiner')) {
+      return false;
+    }
+    if (l$oneLiner != lOther$oneLiner) {
+      return false;
+    }
     return true;
   }
 
@@ -2048,7 +2249,7 @@ class Input$UserInput {
     final l$gender = gender;
     final l$cityOfResidence = cityOfResidence;
     final l$regionOfResidence = regionOfResidence;
-    final l$countryOfResidence = countryOfResidence;
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
     final l$postalCode = postalCode;
     final l$avatarUrl = avatarUrl;
     final l$jobTitle = jobTitle;
@@ -2080,11 +2281,12 @@ class Input$UserInput {
     final l$birthYear = birthYear;
     final l$genderSelfDescribed = genderSelfDescribed;
     final l$ethnicity = ethnicity;
-    final l$educationLevel = educationLevel;
+    final l$educationLevelTextId = educationLevelTextId;
     final l$professionalBackground = professionalBackground;
     final l$yearsManagementExperience = yearsManagementExperience;
     final l$yearsOwnershipExperience = yearsOwnershipExperience;
     final l$ssoIdp = ssoIdp;
+    final l$oneLiner = oneLiner;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -2117,8 +2319,8 @@ class Input$UserInput {
       _$data.containsKey('gender') ? l$gender : const {},
       _$data.containsKey('cityOfResidence') ? l$cityOfResidence : const {},
       _$data.containsKey('regionOfResidence') ? l$regionOfResidence : const {},
-      _$data.containsKey('countryOfResidence')
-          ? l$countryOfResidence
+      _$data.containsKey('countryOfResidenceTextId')
+          ? l$countryOfResidenceTextId
           : const {},
       _$data.containsKey('postalCode') ? l$postalCode : const {},
       _$data.containsKey('avatarUrl') ? l$avatarUrl : const {},
@@ -2181,7 +2383,9 @@ class Input$UserInput {
           ? l$genderSelfDescribed
           : const {},
       _$data.containsKey('ethnicity') ? l$ethnicity : const {},
-      _$data.containsKey('educationLevel') ? l$educationLevel : const {},
+      _$data.containsKey('educationLevelTextId')
+          ? l$educationLevelTextId
+          : const {},
       _$data.containsKey('professionalBackground')
           ? l$professionalBackground
           : const {},
@@ -2192,6 +2396,7 @@ class Input$UserInput {
           ? l$yearsOwnershipExperience
           : const {},
       _$data.containsKey('ssoIdp') ? l$ssoIdp : const {},
+      _$data.containsKey('oneLiner') ? l$oneLiner : const {},
     ]);
   }
 }
@@ -2229,7 +2434,7 @@ abstract class CopyWith$Input$UserInput<TRes> {
     String? gender,
     String? cityOfResidence,
     String? regionOfResidence,
-    String? countryOfResidence,
+    String? countryOfResidenceTextId,
     String? postalCode,
     String? avatarUrl,
     String? jobTitle,
@@ -2239,8 +2444,8 @@ abstract class CopyWith$Input$UserInput<TRes> {
     String? newPassword,
     String? tfaBackupCodes,
     String? passwordUpdatedAt,
-    String? preferredLanguage,
-    String? uiLanguage,
+    Enum$UiLanguage? preferredLanguage,
+    Enum$UiLanguage? uiLanguage,
     List<String>? spokenLanguages,
     List<Enum$UserRole>? roles,
     List<Enum$AppFeature>? appFeatures,
@@ -2261,11 +2466,12 @@ abstract class CopyWith$Input$UserInput<TRes> {
     int? birthYear,
     String? genderSelfDescribed,
     String? ethnicity,
-    Enum$EducationLevel? educationLevel,
+    String? educationLevelTextId,
     String? professionalBackground,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
+    String? oneLiner,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -2318,7 +2524,7 @@ class _CopyWithImpl$Input$UserInput<TRes>
     Object? gender = _undefined,
     Object? cityOfResidence = _undefined,
     Object? regionOfResidence = _undefined,
-    Object? countryOfResidence = _undefined,
+    Object? countryOfResidenceTextId = _undefined,
     Object? postalCode = _undefined,
     Object? avatarUrl = _undefined,
     Object? jobTitle = _undefined,
@@ -2350,11 +2556,12 @@ class _CopyWithImpl$Input$UserInput<TRes>
     Object? birthYear = _undefined,
     Object? genderSelfDescribed = _undefined,
     Object? ethnicity = _undefined,
-    Object? educationLevel = _undefined,
+    Object? educationLevelTextId = _undefined,
     Object? professionalBackground = _undefined,
     Object? yearsManagementExperience = _undefined,
     Object? yearsOwnershipExperience = _undefined,
     Object? ssoIdp = _undefined,
+    Object? oneLiner = _undefined,
   }) =>
       _then(Input$UserInput._({
         ..._instance._$data,
@@ -2390,8 +2597,8 @@ class _CopyWithImpl$Input$UserInput<TRes>
           'cityOfResidence': (cityOfResidence as String?),
         if (regionOfResidence != _undefined)
           'regionOfResidence': (regionOfResidence as String?),
-        if (countryOfResidence != _undefined)
-          'countryOfResidence': (countryOfResidence as String?),
+        if (countryOfResidenceTextId != _undefined)
+          'countryOfResidenceTextId': (countryOfResidenceTextId as String?),
         if (postalCode != _undefined) 'postalCode': (postalCode as String?),
         if (avatarUrl != _undefined) 'avatarUrl': (avatarUrl as String?),
         if (jobTitle != _undefined) 'jobTitle': (jobTitle as String?),
@@ -2406,8 +2613,9 @@ class _CopyWithImpl$Input$UserInput<TRes>
         if (passwordUpdatedAt != _undefined)
           'passwordUpdatedAt': (passwordUpdatedAt as String?),
         if (preferredLanguage != _undefined)
-          'preferredLanguage': (preferredLanguage as String?),
-        if (uiLanguage != _undefined) 'uiLanguage': (uiLanguage as String?),
+          'preferredLanguage': (preferredLanguage as Enum$UiLanguage?),
+        if (uiLanguage != _undefined)
+          'uiLanguage': (uiLanguage as Enum$UiLanguage?),
         if (spokenLanguages != _undefined && spokenLanguages != null)
           'spokenLanguages': (spokenLanguages as List<String>),
         if (roles != _undefined && roles != null)
@@ -2440,8 +2648,8 @@ class _CopyWithImpl$Input$UserInput<TRes>
         if (genderSelfDescribed != _undefined)
           'genderSelfDescribed': (genderSelfDescribed as String?),
         if (ethnicity != _undefined) 'ethnicity': (ethnicity as String?),
-        if (educationLevel != _undefined)
-          'educationLevel': (educationLevel as Enum$EducationLevel?),
+        if (educationLevelTextId != _undefined)
+          'educationLevelTextId': (educationLevelTextId as String?),
         if (professionalBackground != _undefined)
           'professionalBackground': (professionalBackground as String?),
         if (yearsManagementExperience != _undefined)
@@ -2449,6 +2657,7 @@ class _CopyWithImpl$Input$UserInput<TRes>
         if (yearsOwnershipExperience != _undefined)
           'yearsOwnershipExperience': (yearsOwnershipExperience as int?),
         if (ssoIdp != _undefined) 'ssoIdp': (ssoIdp as String?),
+        if (oneLiner != _undefined) 'oneLiner': (oneLiner as String?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -2520,7 +2729,7 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
     String? gender,
     String? cityOfResidence,
     String? regionOfResidence,
-    String? countryOfResidence,
+    String? countryOfResidenceTextId,
     String? postalCode,
     String? avatarUrl,
     String? jobTitle,
@@ -2530,8 +2739,8 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
     String? newPassword,
     String? tfaBackupCodes,
     String? passwordUpdatedAt,
-    String? preferredLanguage,
-    String? uiLanguage,
+    Enum$UiLanguage? preferredLanguage,
+    Enum$UiLanguage? uiLanguage,
     List<String>? spokenLanguages,
     List<Enum$UserRole>? roles,
     List<Enum$AppFeature>? appFeatures,
@@ -2552,11 +2761,12 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
     int? birthYear,
     String? genderSelfDescribed,
     String? ethnicity,
-    Enum$EducationLevel? educationLevel,
+    String? educationLevelTextId,
     String? professionalBackground,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
+    String? oneLiner,
   }) =>
       _res;
   events(_fn) => _res;
@@ -2843,10 +3053,12 @@ class Input$LabeledStringValueInput {
   factory Input$LabeledStringValueInput({
     String? label,
     String? value,
+    List<String>? tags,
   }) =>
       Input$LabeledStringValueInput._({
         if (label != null) r'label': label,
         if (value != null) r'value': value,
+        if (tags != null) r'tags': tags,
       });
 
   Input$LabeledStringValueInput._(this._$data);
@@ -2861,6 +3073,11 @@ class Input$LabeledStringValueInput {
       final l$value = data['value'];
       result$data['value'] = (l$value as String?);
     }
+    if (data.containsKey('tags')) {
+      final l$tags = data['tags'];
+      result$data['tags'] =
+          (l$tags as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
     return Input$LabeledStringValueInput._(result$data);
   }
 
@@ -2868,6 +3085,7 @@ class Input$LabeledStringValueInput {
 
   String? get label => (_$data['label'] as String?);
   String? get value => (_$data['value'] as String?);
+  List<String>? get tags => (_$data['tags'] as List<String>?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('label')) {
@@ -2877,6 +3095,10 @@ class Input$LabeledStringValueInput {
     if (_$data.containsKey('value')) {
       final l$value = value;
       result$data['value'] = l$value;
+    }
+    if (_$data.containsKey('tags')) {
+      final l$tags = tags;
+      result$data['tags'] = l$tags?.map((e) => e).toList();
     }
     return result$data;
   }
@@ -2911,6 +3133,25 @@ class Input$LabeledStringValueInput {
     if (l$value != lOther$value) {
       return false;
     }
+    final l$tags = tags;
+    final lOther$tags = other.tags;
+    if (_$data.containsKey('tags') != other._$data.containsKey('tags')) {
+      return false;
+    }
+    if (l$tags != null && lOther$tags != null) {
+      if (l$tags.length != lOther$tags.length) {
+        return false;
+      }
+      for (int i = 0; i < l$tags.length; i++) {
+        final l$tags$entry = l$tags[i];
+        final lOther$tags$entry = lOther$tags[i];
+        if (l$tags$entry != lOther$tags$entry) {
+          return false;
+        }
+      }
+    } else if (l$tags != lOther$tags) {
+      return false;
+    }
     return true;
   }
 
@@ -2918,9 +3159,15 @@ class Input$LabeledStringValueInput {
   int get hashCode {
     final l$label = label;
     final l$value = value;
+    final l$tags = tags;
     return Object.hashAll([
       _$data.containsKey('label') ? l$label : const {},
       _$data.containsKey('value') ? l$value : const {},
+      _$data.containsKey('tags')
+          ? l$tags == null
+              ? null
+              : Object.hashAll(l$tags.map((v) => v))
+          : const {},
     ]);
   }
 }
@@ -2937,6 +3184,7 @@ abstract class CopyWith$Input$LabeledStringValueInput<TRes> {
   TRes call({
     String? label,
     String? value,
+    List<String>? tags,
   });
 }
 
@@ -2956,11 +3204,13 @@ class _CopyWithImpl$Input$LabeledStringValueInput<TRes>
   TRes call({
     Object? label = _undefined,
     Object? value = _undefined,
+    Object? tags = _undefined,
   }) =>
       _then(Input$LabeledStringValueInput._({
         ..._instance._$data,
         if (label != _undefined) 'label': (label as String?),
         if (value != _undefined) 'value': (value as String?),
+        if (tags != _undefined) 'tags': (tags as List<String>?),
       }));
 }
 
@@ -2973,6 +3223,7 @@ class _CopyWithStubImpl$Input$LabeledStringValueInput<TRes>
   call({
     String? label,
     String? value,
+    List<String>? tags,
   }) =>
       _res;
 }
@@ -3467,7 +3718,7 @@ class Input$UserListFilter {
     String? createdAtUntil,
     String? updatedAtFrom,
     String? updatedAtUntil,
-    List<Enum$UserRole>? roles,
+    List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
   }) =>
@@ -3480,7 +3731,7 @@ class Input$UserListFilter {
         if (createdAtUntil != null) r'createdAtUntil': createdAtUntil,
         if (updatedAtFrom != null) r'updatedAtFrom': updatedAtFrom,
         if (updatedAtUntil != null) r'updatedAtUntil': updatedAtUntil,
-        if (roles != null) r'roles': roles,
+        if (rolesIn != null) r'rolesIn': rolesIn,
         if (companyId != null) r'companyId': companyId,
         if (syncedWithMm2 != null) r'syncedWithMm2': syncedWithMm2,
       });
@@ -3524,9 +3775,9 @@ class Input$UserListFilter {
       final l$updatedAtUntil = data['updatedAtUntil'];
       result$data['updatedAtUntil'] = (l$updatedAtUntil as String?);
     }
-    if (data.containsKey('roles')) {
-      final l$roles = data['roles'];
-      result$data['roles'] = (l$roles as List<dynamic>?)
+    if (data.containsKey('rolesIn')) {
+      final l$rolesIn = data['rolesIn'];
+      result$data['rolesIn'] = (l$rolesIn as List<dynamic>?)
           ?.map((e) => fromJson$Enum$UserRole((e as String)))
           .toList();
     }
@@ -3552,7 +3803,8 @@ class Input$UserListFilter {
   String? get createdAtUntil => (_$data['createdAtUntil'] as String?);
   String? get updatedAtFrom => (_$data['updatedAtFrom'] as String?);
   String? get updatedAtUntil => (_$data['updatedAtUntil'] as String?);
-  List<Enum$UserRole>? get roles => (_$data['roles'] as List<Enum$UserRole>?);
+  List<Enum$UserRole>? get rolesIn =>
+      (_$data['rolesIn'] as List<Enum$UserRole>?);
   String? get companyId => (_$data['companyId'] as String?);
   bool? get syncedWithMm2 => (_$data['syncedWithMm2'] as bool?);
   Map<String, dynamic> toJson() {
@@ -3590,10 +3842,10 @@ class Input$UserListFilter {
       final l$updatedAtUntil = updatedAtUntil;
       result$data['updatedAtUntil'] = l$updatedAtUntil;
     }
-    if (_$data.containsKey('roles')) {
-      final l$roles = roles;
-      result$data['roles'] =
-          l$roles?.map((e) => toJson$Enum$UserRole(e)).toList();
+    if (_$data.containsKey('rolesIn')) {
+      final l$rolesIn = rolesIn;
+      result$data['rolesIn'] =
+          l$rolesIn?.map((e) => toJson$Enum$UserRole(e)).toList();
     }
     if (_$data.containsKey('companyId')) {
       final l$companyId = companyId;
@@ -3712,23 +3964,23 @@ class Input$UserListFilter {
     if (l$updatedAtUntil != lOther$updatedAtUntil) {
       return false;
     }
-    final l$roles = roles;
-    final lOther$roles = other.roles;
-    if (_$data.containsKey('roles') != other._$data.containsKey('roles')) {
+    final l$rolesIn = rolesIn;
+    final lOther$rolesIn = other.rolesIn;
+    if (_$data.containsKey('rolesIn') != other._$data.containsKey('rolesIn')) {
       return false;
     }
-    if (l$roles != null && lOther$roles != null) {
-      if (l$roles.length != lOther$roles.length) {
+    if (l$rolesIn != null && lOther$rolesIn != null) {
+      if (l$rolesIn.length != lOther$rolesIn.length) {
         return false;
       }
-      for (int i = 0; i < l$roles.length; i++) {
-        final l$roles$entry = l$roles[i];
-        final lOther$roles$entry = lOther$roles[i];
-        if (l$roles$entry != lOther$roles$entry) {
+      for (int i = 0; i < l$rolesIn.length; i++) {
+        final l$rolesIn$entry = l$rolesIn[i];
+        final lOther$rolesIn$entry = lOther$rolesIn[i];
+        if (l$rolesIn$entry != lOther$rolesIn$entry) {
           return false;
         }
       }
-    } else if (l$roles != lOther$roles) {
+    } else if (l$rolesIn != lOther$rolesIn) {
       return false;
     }
     final l$companyId = companyId;
@@ -3762,7 +4014,7 @@ class Input$UserListFilter {
     final l$createdAtUntil = createdAtUntil;
     final l$updatedAtFrom = updatedAtFrom;
     final l$updatedAtUntil = updatedAtUntil;
-    final l$roles = roles;
+    final l$rolesIn = rolesIn;
     final l$companyId = companyId;
     final l$syncedWithMm2 = syncedWithMm2;
     return Object.hashAll([
@@ -3782,10 +4034,10 @@ class Input$UserListFilter {
       _$data.containsKey('createdAtUntil') ? l$createdAtUntil : const {},
       _$data.containsKey('updatedAtFrom') ? l$updatedAtFrom : const {},
       _$data.containsKey('updatedAtUntil') ? l$updatedAtUntil : const {},
-      _$data.containsKey('roles')
-          ? l$roles == null
+      _$data.containsKey('rolesIn')
+          ? l$rolesIn == null
               ? null
-              : Object.hashAll(l$roles.map((v) => v))
+              : Object.hashAll(l$rolesIn.map((v) => v))
           : const {},
       _$data.containsKey('companyId') ? l$companyId : const {},
       _$data.containsKey('syncedWithMm2') ? l$syncedWithMm2 : const {},
@@ -3811,7 +4063,7 @@ abstract class CopyWith$Input$UserListFilter<TRes> {
     String? createdAtUntil,
     String? updatedAtFrom,
     String? updatedAtUntil,
-    List<Enum$UserRole>? roles,
+    List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
   });
@@ -3839,7 +4091,7 @@ class _CopyWithImpl$Input$UserListFilter<TRes>
     Object? createdAtUntil = _undefined,
     Object? updatedAtFrom = _undefined,
     Object? updatedAtUntil = _undefined,
-    Object? roles = _undefined,
+    Object? rolesIn = _undefined,
     Object? companyId = _undefined,
     Object? syncedWithMm2 = _undefined,
   }) =>
@@ -3859,7 +4111,7 @@ class _CopyWithImpl$Input$UserListFilter<TRes>
           'updatedAtFrom': (updatedAtFrom as String?),
         if (updatedAtUntil != _undefined)
           'updatedAtUntil': (updatedAtUntil as String?),
-        if (roles != _undefined) 'roles': (roles as List<Enum$UserRole>?),
+        if (rolesIn != _undefined) 'rolesIn': (rolesIn as List<Enum$UserRole>?),
         if (companyId != _undefined) 'companyId': (companyId as String?),
         if (syncedWithMm2 != _undefined)
           'syncedWithMm2': (syncedWithMm2 as bool?),
@@ -3881,7 +4133,7 @@ class _CopyWithStubImpl$Input$UserListFilter<TRes>
     String? createdAtUntil,
     String? updatedAtFrom,
     String? updatedAtUntil,
-    List<Enum$UserRole>? roles,
+    List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
   }) =>
@@ -3932,7 +4184,7 @@ class Input$UserDeviceInput {
     String? oAuthRefreshToken,
     String? pushNotificationToken,
     String? trustedAt,
-    String? uiLanguage,
+    Enum$UiLanguage? uiLanguage,
   }) =>
       Input$UserDeviceInput._({
         if (id != null) r'id': id,
@@ -4167,7 +4419,9 @@ class Input$UserDeviceInput {
     }
     if (data.containsKey('uiLanguage')) {
       final l$uiLanguage = data['uiLanguage'];
-      result$data['uiLanguage'] = (l$uiLanguage as String?);
+      result$data['uiLanguage'] = l$uiLanguage == null
+          ? null
+          : fromJson$Enum$UiLanguage((l$uiLanguage as String));
     }
     return Input$UserDeviceInput._(result$data);
   }
@@ -4220,7 +4474,7 @@ class Input$UserDeviceInput {
   String? get pushNotificationToken =>
       (_$data['pushNotificationToken'] as String?);
   String? get trustedAt => (_$data['trustedAt'] as String?);
-  String? get uiLanguage => (_$data['uiLanguage'] as String?);
+  Enum$UiLanguage? get uiLanguage => (_$data['uiLanguage'] as Enum$UiLanguage?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -4393,7 +4647,8 @@ class Input$UserDeviceInput {
     }
     if (_$data.containsKey('uiLanguage')) {
       final l$uiLanguage = uiLanguage;
-      result$data['uiLanguage'] = l$uiLanguage;
+      result$data['uiLanguage'] =
+          l$uiLanguage == null ? null : toJson$Enum$UiLanguage(l$uiLanguage);
     }
     return result$data;
   }
@@ -4965,7 +5220,7 @@ abstract class CopyWith$Input$UserDeviceInput<TRes> {
     String? oAuthRefreshToken,
     String? pushNotificationToken,
     String? trustedAt,
-    String? uiLanguage,
+    Enum$UiLanguage? uiLanguage,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -5088,7 +5343,8 @@ class _CopyWithImpl$Input$UserDeviceInput<TRes>
         if (pushNotificationToken != _undefined)
           'pushNotificationToken': (pushNotificationToken as String?),
         if (trustedAt != _undefined) 'trustedAt': (trustedAt as String?),
-        if (uiLanguage != _undefined) 'uiLanguage': (uiLanguage as String?),
+        if (uiLanguage != _undefined)
+          'uiLanguage': (uiLanguage as Enum$UiLanguage?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -5159,7 +5415,7 @@ class _CopyWithStubImpl$Input$UserDeviceInput<TRes>
     String? oAuthRefreshToken,
     String? pushNotificationToken,
     String? trustedAt,
-    String? uiLanguage,
+    Enum$UiLanguage? uiLanguage,
   }) =>
       _res;
   events(_fn) => _res;
@@ -5528,6 +5784,8 @@ class Input$ChannelInput {
     String? archivedAt,
     String? archivedBy,
     String? assumedMentorId,
+    String? mm2Id,
+    String? syncedWithMm2At,
   }) =>
       Input$ChannelInput._({
         if (id != null) r'id': id,
@@ -5553,6 +5811,8 @@ class Input$ChannelInput {
         if (archivedAt != null) r'archivedAt': archivedAt,
         if (archivedBy != null) r'archivedBy': archivedBy,
         if (assumedMentorId != null) r'assumedMentorId': assumedMentorId,
+        if (mm2Id != null) r'mm2Id': mm2Id,
+        if (syncedWithMm2At != null) r'syncedWithMm2At': syncedWithMm2At,
       });
 
   Input$ChannelInput._(this._$data);
@@ -5665,6 +5925,14 @@ class Input$ChannelInput {
       final l$assumedMentorId = data['assumedMentorId'];
       result$data['assumedMentorId'] = (l$assumedMentorId as String?);
     }
+    if (data.containsKey('mm2Id')) {
+      final l$mm2Id = data['mm2Id'];
+      result$data['mm2Id'] = (l$mm2Id as String?);
+    }
+    if (data.containsKey('syncedWithMm2At')) {
+      final l$syncedWithMm2At = data['syncedWithMm2At'];
+      result$data['syncedWithMm2At'] = (l$syncedWithMm2At as String?);
+    }
     return Input$ChannelInput._(result$data);
   }
 
@@ -5697,6 +5965,8 @@ class Input$ChannelInput {
   String? get archivedAt => (_$data['archivedAt'] as String?);
   String? get archivedBy => (_$data['archivedBy'] as String?);
   String? get assumedMentorId => (_$data['assumedMentorId'] as String?);
+  String? get mm2Id => (_$data['mm2Id'] as String?);
+  String? get syncedWithMm2At => (_$data['syncedWithMm2At'] as String?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -5793,6 +6063,14 @@ class Input$ChannelInput {
     if (_$data.containsKey('assumedMentorId')) {
       final l$assumedMentorId = assumedMentorId;
       result$data['assumedMentorId'] = l$assumedMentorId;
+    }
+    if (_$data.containsKey('mm2Id')) {
+      final l$mm2Id = mm2Id;
+      result$data['mm2Id'] = l$mm2Id;
+    }
+    if (_$data.containsKey('syncedWithMm2At')) {
+      final l$syncedWithMm2At = syncedWithMm2At;
+      result$data['syncedWithMm2At'] = l$syncedWithMm2At;
     }
     return result$data;
   }
@@ -6055,6 +6333,23 @@ class Input$ChannelInput {
     if (l$assumedMentorId != lOther$assumedMentorId) {
       return false;
     }
+    final l$mm2Id = mm2Id;
+    final lOther$mm2Id = other.mm2Id;
+    if (_$data.containsKey('mm2Id') != other._$data.containsKey('mm2Id')) {
+      return false;
+    }
+    if (l$mm2Id != lOther$mm2Id) {
+      return false;
+    }
+    final l$syncedWithMm2At = syncedWithMm2At;
+    final lOther$syncedWithMm2At = other.syncedWithMm2At;
+    if (_$data.containsKey('syncedWithMm2At') !=
+        other._$data.containsKey('syncedWithMm2At')) {
+      return false;
+    }
+    if (l$syncedWithMm2At != lOther$syncedWithMm2At) {
+      return false;
+    }
     return true;
   }
 
@@ -6083,6 +6378,8 @@ class Input$ChannelInput {
     final l$archivedAt = archivedAt;
     final l$archivedBy = archivedBy;
     final l$assumedMentorId = assumedMentorId;
+    final l$mm2Id = mm2Id;
+    final l$syncedWithMm2At = syncedWithMm2At;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -6123,6 +6420,8 @@ class Input$ChannelInput {
       _$data.containsKey('archivedAt') ? l$archivedAt : const {},
       _$data.containsKey('archivedBy') ? l$archivedBy : const {},
       _$data.containsKey('assumedMentorId') ? l$assumedMentorId : const {},
+      _$data.containsKey('mm2Id') ? l$mm2Id : const {},
+      _$data.containsKey('syncedWithMm2At') ? l$syncedWithMm2At : const {},
     ]);
   }
 }
@@ -6160,6 +6459,8 @@ abstract class CopyWith$Input$ChannelInput<TRes> {
     String? archivedAt,
     String? archivedBy,
     String? assumedMentorId,
+    String? mm2Id,
+    String? syncedWithMm2At,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -6205,6 +6506,8 @@ class _CopyWithImpl$Input$ChannelInput<TRes>
     Object? archivedAt = _undefined,
     Object? archivedBy = _undefined,
     Object? assumedMentorId = _undefined,
+    Object? mm2Id = _undefined,
+    Object? syncedWithMm2At = _undefined,
   }) =>
       _then(Input$ChannelInput._({
         ..._instance._$data,
@@ -6237,6 +6540,9 @@ class _CopyWithImpl$Input$ChannelInput<TRes>
         if (archivedBy != _undefined) 'archivedBy': (archivedBy as String?),
         if (assumedMentorId != _undefined)
           'assumedMentorId': (assumedMentorId as String?),
+        if (mm2Id != _undefined) 'mm2Id': (mm2Id as String?),
+        if (syncedWithMm2At != _undefined)
+          'syncedWithMm2At': (syncedWithMm2At as String?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -6288,6 +6594,8 @@ class _CopyWithStubImpl$Input$ChannelInput<TRes>
     String? archivedAt,
     String? archivedBy,
     String? assumedMentorId,
+    String? mm2Id,
+    String? syncedWithMm2At,
   }) =>
       _res;
   events(_fn) => _res;
@@ -14046,3125 +14354,6 @@ class _CopyWithStubImpl$Input$ChannelParticipantInput<TRes>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
-class Input$GenRequest {
-  factory Input$GenRequest({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  }) =>
-      Input$GenRequest._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (clearDb != null) r'clearDb': clearDb,
-        if (conversationCount != null) r'conversationCount': conversationCount,
-        if (messageCount != null) r'messageCount': messageCount,
-        if (users != null) r'users': users,
-        if (groups != null) r'groups': groups,
-        if (publishAppEvents != null) r'publishAppEvents': publishAppEvents,
-      });
-
-  Input$GenRequest._(this._$data);
-
-  factory Input$GenRequest.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('clearDb')) {
-      final l$clearDb = data['clearDb'];
-      result$data['clearDb'] = (l$clearDb as bool);
-    }
-    if (data.containsKey('conversationCount')) {
-      final l$conversationCount = data['conversationCount'];
-      result$data['conversationCount'] = (l$conversationCount as int);
-    }
-    if (data.containsKey('messageCount')) {
-      final l$messageCount = data['messageCount'];
-      result$data['messageCount'] = (l$messageCount as int);
-    }
-    if (data.containsKey('users')) {
-      final l$users = data['users'];
-      result$data['users'] =
-          Input$GenUserInput.fromJson((l$users as Map<String, dynamic>));
-    }
-    if (data.containsKey('groups')) {
-      final l$groups = data['groups'];
-      result$data['groups'] =
-          Input$GenGroupsInput.fromJson((l$groups as Map<String, dynamic>));
-    }
-    if (data.containsKey('publishAppEvents')) {
-      final l$publishAppEvents = data['publishAppEvents'];
-      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
-    }
-    return Input$GenRequest._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get clearDb => (_$data['clearDb'] as bool?);
-  int? get conversationCount => (_$data['conversationCount'] as int?);
-  int? get messageCount => (_$data['messageCount'] as int?);
-  Input$GenUserInput? get users => (_$data['users'] as Input$GenUserInput?);
-  Input$GenGroupsInput? get groups =>
-      (_$data['groups'] as Input$GenGroupsInput?);
-  bool? get publishAppEvents => (_$data['publishAppEvents'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('clearDb')) {
-      final l$clearDb = clearDb;
-      result$data['clearDb'] = (l$clearDb as bool);
-    }
-    if (_$data.containsKey('conversationCount')) {
-      final l$conversationCount = conversationCount;
-      result$data['conversationCount'] = (l$conversationCount as int);
-    }
-    if (_$data.containsKey('messageCount')) {
-      final l$messageCount = messageCount;
-      result$data['messageCount'] = (l$messageCount as int);
-    }
-    if (_$data.containsKey('users')) {
-      final l$users = users;
-      result$data['users'] = (l$users as Input$GenUserInput).toJson();
-    }
-    if (_$data.containsKey('groups')) {
-      final l$groups = groups;
-      result$data['groups'] = (l$groups as Input$GenGroupsInput).toJson();
-    }
-    if (_$data.containsKey('publishAppEvents')) {
-      final l$publishAppEvents = publishAppEvents;
-      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenRequest<Input$GenRequest> get copyWith =>
-      CopyWith$Input$GenRequest(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenRequest) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$clearDb = clearDb;
-    final lOther$clearDb = other.clearDb;
-    if (_$data.containsKey('clearDb') != other._$data.containsKey('clearDb')) {
-      return false;
-    }
-    if (l$clearDb != lOther$clearDb) {
-      return false;
-    }
-    final l$conversationCount = conversationCount;
-    final lOther$conversationCount = other.conversationCount;
-    if (_$data.containsKey('conversationCount') !=
-        other._$data.containsKey('conversationCount')) {
-      return false;
-    }
-    if (l$conversationCount != lOther$conversationCount) {
-      return false;
-    }
-    final l$messageCount = messageCount;
-    final lOther$messageCount = other.messageCount;
-    if (_$data.containsKey('messageCount') !=
-        other._$data.containsKey('messageCount')) {
-      return false;
-    }
-    if (l$messageCount != lOther$messageCount) {
-      return false;
-    }
-    final l$users = users;
-    final lOther$users = other.users;
-    if (_$data.containsKey('users') != other._$data.containsKey('users')) {
-      return false;
-    }
-    if (l$users != lOther$users) {
-      return false;
-    }
-    final l$groups = groups;
-    final lOther$groups = other.groups;
-    if (_$data.containsKey('groups') != other._$data.containsKey('groups')) {
-      return false;
-    }
-    if (l$groups != lOther$groups) {
-      return false;
-    }
-    final l$publishAppEvents = publishAppEvents;
-    final lOther$publishAppEvents = other.publishAppEvents;
-    if (_$data.containsKey('publishAppEvents') !=
-        other._$data.containsKey('publishAppEvents')) {
-      return false;
-    }
-    if (l$publishAppEvents != lOther$publishAppEvents) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$clearDb = clearDb;
-    final l$conversationCount = conversationCount;
-    final l$messageCount = messageCount;
-    final l$users = users;
-    final l$groups = groups;
-    final l$publishAppEvents = publishAppEvents;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('clearDb') ? l$clearDb : const {},
-      _$data.containsKey('conversationCount') ? l$conversationCount : const {},
-      _$data.containsKey('messageCount') ? l$messageCount : const {},
-      _$data.containsKey('users') ? l$users : const {},
-      _$data.containsKey('groups') ? l$groups : const {},
-      _$data.containsKey('publishAppEvents') ? l$publishAppEvents : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenRequest<TRes> {
-  factory CopyWith$Input$GenRequest(
-    Input$GenRequest instance,
-    TRes Function(Input$GenRequest) then,
-  ) = _CopyWithImpl$Input$GenRequest;
-
-  factory CopyWith$Input$GenRequest.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenRequest;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  CopyWith$Input$GenUserInput<TRes> get users;
-  CopyWith$Input$GenGroupsInput<TRes> get groups;
-}
-
-class _CopyWithImpl$Input$GenRequest<TRes>
-    implements CopyWith$Input$GenRequest<TRes> {
-  _CopyWithImpl$Input$GenRequest(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenRequest _instance;
-
-  final TRes Function(Input$GenRequest) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? clearDb = _undefined,
-    Object? conversationCount = _undefined,
-    Object? messageCount = _undefined,
-    Object? users = _undefined,
-    Object? groups = _undefined,
-    Object? publishAppEvents = _undefined,
-  }) =>
-      _then(Input$GenRequest._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (clearDb != _undefined && clearDb != null)
-          'clearDb': (clearDb as bool),
-        if (conversationCount != _undefined && conversationCount != null)
-          'conversationCount': (conversationCount as int),
-        if (messageCount != _undefined && messageCount != null)
-          'messageCount': (messageCount as int),
-        if (users != _undefined && users != null)
-          'users': (users as Input$GenUserInput),
-        if (groups != _undefined && groups != null)
-          'groups': (groups as Input$GenGroupsInput),
-        if (publishAppEvents != _undefined && publishAppEvents != null)
-          'publishAppEvents': (publishAppEvents as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  CopyWith$Input$GenUserInput<TRes> get users {
-    final local$users = _instance.users;
-    return local$users == null
-        ? CopyWith$Input$GenUserInput.stub(_then(_instance))
-        : CopyWith$Input$GenUserInput(local$users, (e) => call(users: e));
-  }
-
-  CopyWith$Input$GenGroupsInput<TRes> get groups {
-    final local$groups = _instance.groups;
-    return local$groups == null
-        ? CopyWith$Input$GenGroupsInput.stub(_then(_instance))
-        : CopyWith$Input$GenGroupsInput(local$groups, (e) => call(groups: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenRequest<TRes>
-    implements CopyWith$Input$GenRequest<TRes> {
-  _CopyWithStubImpl$Input$GenRequest(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  CopyWith$Input$GenUserInput<TRes> get users =>
-      CopyWith$Input$GenUserInput.stub(_res);
-  CopyWith$Input$GenGroupsInput<TRes> get groups =>
-      CopyWith$Input$GenGroupsInput.stub(_res);
-}
-
-class Input$GenUserInput {
-  factory Input$GenUserInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  }) =>
-      Input$GenUserInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (count != null) r'count': count,
-        if (dualRoleCount != null) r'dualRoleCount': dualRoleCount,
-        if (emailDomain != null) r'emailDomain': emailDomain,
-        if (emailPrefix != null) r'emailPrefix': emailPrefix,
-        if (mentorCount != null) r'mentorCount': mentorCount,
-        if (menteeCount != null) r'menteeCount': menteeCount,
-        if (mentorRatio != null) r'mentorRatio': mentorRatio,
-      });
-
-  Input$GenUserInput._(this._$data);
-
-  factory Input$GenUserInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('count')) {
-      final l$count = data['count'];
-      result$data['count'] = (l$count as int);
-    }
-    if (data.containsKey('dualRoleCount')) {
-      final l$dualRoleCount = data['dualRoleCount'];
-      result$data['dualRoleCount'] = (l$dualRoleCount as int?);
-    }
-    if (data.containsKey('emailDomain')) {
-      final l$emailDomain = data['emailDomain'];
-      result$data['emailDomain'] = (l$emailDomain as String);
-    }
-    if (data.containsKey('emailPrefix')) {
-      final l$emailPrefix = data['emailPrefix'];
-      result$data['emailPrefix'] = (l$emailPrefix as String?);
-    }
-    if (data.containsKey('mentorCount')) {
-      final l$mentorCount = data['mentorCount'];
-      result$data['mentorCount'] = (l$mentorCount as int?);
-    }
-    if (data.containsKey('menteeCount')) {
-      final l$menteeCount = data['menteeCount'];
-      result$data['menteeCount'] = (l$menteeCount as int?);
-    }
-    if (data.containsKey('mentorRatio')) {
-      final l$mentorRatio = data['mentorRatio'];
-      result$data['mentorRatio'] = (l$mentorRatio as num?)?.toDouble();
-    }
-    return Input$GenUserInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  int? get count => (_$data['count'] as int?);
-  int? get dualRoleCount => (_$data['dualRoleCount'] as int?);
-  String? get emailDomain => (_$data['emailDomain'] as String?);
-  String? get emailPrefix => (_$data['emailPrefix'] as String?);
-  int? get mentorCount => (_$data['mentorCount'] as int?);
-  int? get menteeCount => (_$data['menteeCount'] as int?);
-  double? get mentorRatio => (_$data['mentorRatio'] as double?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('count')) {
-      final l$count = count;
-      result$data['count'] = (l$count as int);
-    }
-    if (_$data.containsKey('dualRoleCount')) {
-      final l$dualRoleCount = dualRoleCount;
-      result$data['dualRoleCount'] = l$dualRoleCount;
-    }
-    if (_$data.containsKey('emailDomain')) {
-      final l$emailDomain = emailDomain;
-      result$data['emailDomain'] = (l$emailDomain as String);
-    }
-    if (_$data.containsKey('emailPrefix')) {
-      final l$emailPrefix = emailPrefix;
-      result$data['emailPrefix'] = l$emailPrefix;
-    }
-    if (_$data.containsKey('mentorCount')) {
-      final l$mentorCount = mentorCount;
-      result$data['mentorCount'] = l$mentorCount;
-    }
-    if (_$data.containsKey('menteeCount')) {
-      final l$menteeCount = menteeCount;
-      result$data['menteeCount'] = l$menteeCount;
-    }
-    if (_$data.containsKey('mentorRatio')) {
-      final l$mentorRatio = mentorRatio;
-      result$data['mentorRatio'] = l$mentorRatio;
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenUserInput<Input$GenUserInput> get copyWith =>
-      CopyWith$Input$GenUserInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenUserInput) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$count = count;
-    final lOther$count = other.count;
-    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
-      return false;
-    }
-    if (l$count != lOther$count) {
-      return false;
-    }
-    final l$dualRoleCount = dualRoleCount;
-    final lOther$dualRoleCount = other.dualRoleCount;
-    if (_$data.containsKey('dualRoleCount') !=
-        other._$data.containsKey('dualRoleCount')) {
-      return false;
-    }
-    if (l$dualRoleCount != lOther$dualRoleCount) {
-      return false;
-    }
-    final l$emailDomain = emailDomain;
-    final lOther$emailDomain = other.emailDomain;
-    if (_$data.containsKey('emailDomain') !=
-        other._$data.containsKey('emailDomain')) {
-      return false;
-    }
-    if (l$emailDomain != lOther$emailDomain) {
-      return false;
-    }
-    final l$emailPrefix = emailPrefix;
-    final lOther$emailPrefix = other.emailPrefix;
-    if (_$data.containsKey('emailPrefix') !=
-        other._$data.containsKey('emailPrefix')) {
-      return false;
-    }
-    if (l$emailPrefix != lOther$emailPrefix) {
-      return false;
-    }
-    final l$mentorCount = mentorCount;
-    final lOther$mentorCount = other.mentorCount;
-    if (_$data.containsKey('mentorCount') !=
-        other._$data.containsKey('mentorCount')) {
-      return false;
-    }
-    if (l$mentorCount != lOther$mentorCount) {
-      return false;
-    }
-    final l$menteeCount = menteeCount;
-    final lOther$menteeCount = other.menteeCount;
-    if (_$data.containsKey('menteeCount') !=
-        other._$data.containsKey('menteeCount')) {
-      return false;
-    }
-    if (l$menteeCount != lOther$menteeCount) {
-      return false;
-    }
-    final l$mentorRatio = mentorRatio;
-    final lOther$mentorRatio = other.mentorRatio;
-    if (_$data.containsKey('mentorRatio') !=
-        other._$data.containsKey('mentorRatio')) {
-      return false;
-    }
-    if (l$mentorRatio != lOther$mentorRatio) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$count = count;
-    final l$dualRoleCount = dualRoleCount;
-    final l$emailDomain = emailDomain;
-    final l$emailPrefix = emailPrefix;
-    final l$mentorCount = mentorCount;
-    final l$menteeCount = menteeCount;
-    final l$mentorRatio = mentorRatio;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('count') ? l$count : const {},
-      _$data.containsKey('dualRoleCount') ? l$dualRoleCount : const {},
-      _$data.containsKey('emailDomain') ? l$emailDomain : const {},
-      _$data.containsKey('emailPrefix') ? l$emailPrefix : const {},
-      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
-      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
-      _$data.containsKey('mentorRatio') ? l$mentorRatio : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenUserInput<TRes> {
-  factory CopyWith$Input$GenUserInput(
-    Input$GenUserInput instance,
-    TRes Function(Input$GenUserInput) then,
-  ) = _CopyWithImpl$Input$GenUserInput;
-
-  factory CopyWith$Input$GenUserInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenUserInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenUserInput<TRes>
-    implements CopyWith$Input$GenUserInput<TRes> {
-  _CopyWithImpl$Input$GenUserInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenUserInput _instance;
-
-  final TRes Function(Input$GenUserInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? count = _undefined,
-    Object? dualRoleCount = _undefined,
-    Object? emailDomain = _undefined,
-    Object? emailPrefix = _undefined,
-    Object? mentorCount = _undefined,
-    Object? menteeCount = _undefined,
-    Object? mentorRatio = _undefined,
-  }) =>
-      _then(Input$GenUserInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (count != _undefined && count != null) 'count': (count as int),
-        if (dualRoleCount != _undefined)
-          'dualRoleCount': (dualRoleCount as int?),
-        if (emailDomain != _undefined && emailDomain != null)
-          'emailDomain': (emailDomain as String),
-        if (emailPrefix != _undefined) 'emailPrefix': (emailPrefix as String?),
-        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
-        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
-        if (mentorRatio != _undefined) 'mentorRatio': (mentorRatio as double?),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenUserInput<TRes>
-    implements CopyWith$Input$GenUserInput<TRes> {
-  _CopyWithStubImpl$Input$GenUserInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
-class Input$GenGroupsInput {
-  factory Input$GenGroupsInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    required List<Input$GenSpecificGroupInput> specificGroups,
-  }) =>
-      Input$GenGroupsInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (count != null) r'count': count,
-        r'specificGroups': specificGroups,
-      });
-
-  Input$GenGroupsInput._(this._$data);
-
-  factory Input$GenGroupsInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('count')) {
-      final l$count = data['count'];
-      result$data['count'] = (l$count as int);
-    }
-    final l$specificGroups = data['specificGroups'];
-    result$data['specificGroups'] = (l$specificGroups as List<dynamic>)
-        .map((e) =>
-            Input$GenSpecificGroupInput.fromJson((e as Map<String, dynamic>)))
-        .toList();
-    return Input$GenGroupsInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  int? get count => (_$data['count'] as int?);
-  List<Input$GenSpecificGroupInput> get specificGroups =>
-      (_$data['specificGroups'] as List<Input$GenSpecificGroupInput>);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('count')) {
-      final l$count = count;
-      result$data['count'] = (l$count as int);
-    }
-    final l$specificGroups = specificGroups;
-    result$data['specificGroups'] =
-        l$specificGroups.map((e) => e.toJson()).toList();
-    return result$data;
-  }
-
-  CopyWith$Input$GenGroupsInput<Input$GenGroupsInput> get copyWith =>
-      CopyWith$Input$GenGroupsInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenGroupsInput) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$count = count;
-    final lOther$count = other.count;
-    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
-      return false;
-    }
-    if (l$count != lOther$count) {
-      return false;
-    }
-    final l$specificGroups = specificGroups;
-    final lOther$specificGroups = other.specificGroups;
-    if (l$specificGroups.length != lOther$specificGroups.length) {
-      return false;
-    }
-    for (int i = 0; i < l$specificGroups.length; i++) {
-      final l$specificGroups$entry = l$specificGroups[i];
-      final lOther$specificGroups$entry = lOther$specificGroups[i];
-      if (l$specificGroups$entry != lOther$specificGroups$entry) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$count = count;
-    final l$specificGroups = specificGroups;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('count') ? l$count : const {},
-      Object.hashAll(l$specificGroups.map((v) => v)),
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenGroupsInput<TRes> {
-  factory CopyWith$Input$GenGroupsInput(
-    Input$GenGroupsInput instance,
-    TRes Function(Input$GenGroupsInput) then,
-  ) = _CopyWithImpl$Input$GenGroupsInput;
-
-  factory CopyWith$Input$GenGroupsInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenGroupsInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  TRes specificGroups(
-      Iterable<Input$GenSpecificGroupInput> Function(
-              Iterable<
-                  CopyWith$Input$GenSpecificGroupInput<
-                      Input$GenSpecificGroupInput>>)
-          _fn);
-}
-
-class _CopyWithImpl$Input$GenGroupsInput<TRes>
-    implements CopyWith$Input$GenGroupsInput<TRes> {
-  _CopyWithImpl$Input$GenGroupsInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenGroupsInput _instance;
-
-  final TRes Function(Input$GenGroupsInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? count = _undefined,
-    Object? specificGroups = _undefined,
-  }) =>
-      _then(Input$GenGroupsInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (count != _undefined && count != null) 'count': (count as int),
-        if (specificGroups != _undefined && specificGroups != null)
-          'specificGroups':
-              (specificGroups as List<Input$GenSpecificGroupInput>),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  TRes specificGroups(
-          Iterable<Input$GenSpecificGroupInput> Function(
-                  Iterable<
-                      CopyWith$Input$GenSpecificGroupInput<
-                          Input$GenSpecificGroupInput>>)
-              _fn) =>
-      call(
-          specificGroups: _fn(_instance.specificGroups
-              .map((e) => CopyWith$Input$GenSpecificGroupInput(
-                    e,
-                    (i) => i,
-                  ))).toList());
-}
-
-class _CopyWithStubImpl$Input$GenGroupsInput<TRes>
-    implements CopyWith$Input$GenGroupsInput<TRes> {
-  _CopyWithStubImpl$Input$GenGroupsInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  specificGroups(_fn) => _res;
-}
-
-class Input$GenSpecificGroupInput {
-  factory Input$GenSpecificGroupInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  }) =>
-      Input$GenSpecificGroupInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (name != null) r'name': name,
-        if (mentorCount != null) r'mentorCount': mentorCount,
-        if (menteeCount != null) r'menteeCount': menteeCount,
-        if (groupRules != null) r'groupRules': groupRules,
-        if (matchingEngine != null) r'matchingEngine': matchingEngine,
-      });
-
-  Input$GenSpecificGroupInput._(this._$data);
-
-  factory Input$GenSpecificGroupInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('name')) {
-      final l$name = data['name'];
-      result$data['name'] = (l$name as String);
-    }
-    if (data.containsKey('mentorCount')) {
-      final l$mentorCount = data['mentorCount'];
-      result$data['mentorCount'] = (l$mentorCount as int?);
-    }
-    if (data.containsKey('menteeCount')) {
-      final l$menteeCount = data['menteeCount'];
-      result$data['menteeCount'] = (l$menteeCount as int?);
-    }
-    if (data.containsKey('groupRules')) {
-      final l$groupRules = data['groupRules'];
-      result$data['groupRules'] = (l$groupRules as List<dynamic>?)
-          ?.map((e) =>
-              Input$GenGroupRuleInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('matchingEngine')) {
-      final l$matchingEngine = data['matchingEngine'];
-      result$data['matchingEngine'] = l$matchingEngine == null
-          ? null
-          : Input$GenMatchingEngineInput.fromJson(
-              (l$matchingEngine as Map<String, dynamic>));
-    }
-    return Input$GenSpecificGroupInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  String? get name => (_$data['name'] as String?);
-  int? get mentorCount => (_$data['mentorCount'] as int?);
-  int? get menteeCount => (_$data['menteeCount'] as int?);
-  List<Input$GenGroupRuleInput>? get groupRules =>
-      (_$data['groupRules'] as List<Input$GenGroupRuleInput>?);
-  Input$GenMatchingEngineInput? get matchingEngine =>
-      (_$data['matchingEngine'] as Input$GenMatchingEngineInput?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('name')) {
-      final l$name = name;
-      result$data['name'] = (l$name as String);
-    }
-    if (_$data.containsKey('mentorCount')) {
-      final l$mentorCount = mentorCount;
-      result$data['mentorCount'] = l$mentorCount;
-    }
-    if (_$data.containsKey('menteeCount')) {
-      final l$menteeCount = menteeCount;
-      result$data['menteeCount'] = l$menteeCount;
-    }
-    if (_$data.containsKey('groupRules')) {
-      final l$groupRules = groupRules;
-      result$data['groupRules'] = l$groupRules?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('matchingEngine')) {
-      final l$matchingEngine = matchingEngine;
-      result$data['matchingEngine'] = l$matchingEngine?.toJson();
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenSpecificGroupInput<Input$GenSpecificGroupInput>
-      get copyWith => CopyWith$Input$GenSpecificGroupInput(
-            this,
-            (i) => i,
-          );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenSpecificGroupInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$name = name;
-    final lOther$name = other.name;
-    if (_$data.containsKey('name') != other._$data.containsKey('name')) {
-      return false;
-    }
-    if (l$name != lOther$name) {
-      return false;
-    }
-    final l$mentorCount = mentorCount;
-    final lOther$mentorCount = other.mentorCount;
-    if (_$data.containsKey('mentorCount') !=
-        other._$data.containsKey('mentorCount')) {
-      return false;
-    }
-    if (l$mentorCount != lOther$mentorCount) {
-      return false;
-    }
-    final l$menteeCount = menteeCount;
-    final lOther$menteeCount = other.menteeCount;
-    if (_$data.containsKey('menteeCount') !=
-        other._$data.containsKey('menteeCount')) {
-      return false;
-    }
-    if (l$menteeCount != lOther$menteeCount) {
-      return false;
-    }
-    final l$groupRules = groupRules;
-    final lOther$groupRules = other.groupRules;
-    if (_$data.containsKey('groupRules') !=
-        other._$data.containsKey('groupRules')) {
-      return false;
-    }
-    if (l$groupRules != null && lOther$groupRules != null) {
-      if (l$groupRules.length != lOther$groupRules.length) {
-        return false;
-      }
-      for (int i = 0; i < l$groupRules.length; i++) {
-        final l$groupRules$entry = l$groupRules[i];
-        final lOther$groupRules$entry = lOther$groupRules[i];
-        if (l$groupRules$entry != lOther$groupRules$entry) {
-          return false;
-        }
-      }
-    } else if (l$groupRules != lOther$groupRules) {
-      return false;
-    }
-    final l$matchingEngine = matchingEngine;
-    final lOther$matchingEngine = other.matchingEngine;
-    if (_$data.containsKey('matchingEngine') !=
-        other._$data.containsKey('matchingEngine')) {
-      return false;
-    }
-    if (l$matchingEngine != lOther$matchingEngine) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$name = name;
-    final l$mentorCount = mentorCount;
-    final l$menteeCount = menteeCount;
-    final l$groupRules = groupRules;
-    final l$matchingEngine = matchingEngine;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('name') ? l$name : const {},
-      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
-      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
-      _$data.containsKey('groupRules')
-          ? l$groupRules == null
-              ? null
-              : Object.hashAll(l$groupRules.map((v) => v))
-          : const {},
-      _$data.containsKey('matchingEngine') ? l$matchingEngine : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenSpecificGroupInput<TRes> {
-  factory CopyWith$Input$GenSpecificGroupInput(
-    Input$GenSpecificGroupInput instance,
-    TRes Function(Input$GenSpecificGroupInput) then,
-  ) = _CopyWithImpl$Input$GenSpecificGroupInput;
-
-  factory CopyWith$Input$GenSpecificGroupInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenSpecificGroupInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  TRes groupRules(
-      Iterable<Input$GenGroupRuleInput>? Function(
-              Iterable<
-                  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput>>?)
-          _fn);
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine;
-}
-
-class _CopyWithImpl$Input$GenSpecificGroupInput<TRes>
-    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
-  _CopyWithImpl$Input$GenSpecificGroupInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenSpecificGroupInput _instance;
-
-  final TRes Function(Input$GenSpecificGroupInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? name = _undefined,
-    Object? mentorCount = _undefined,
-    Object? menteeCount = _undefined,
-    Object? groupRules = _undefined,
-    Object? matchingEngine = _undefined,
-  }) =>
-      _then(Input$GenSpecificGroupInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (name != _undefined && name != null) 'name': (name as String),
-        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
-        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
-        if (groupRules != _undefined)
-          'groupRules': (groupRules as List<Input$GenGroupRuleInput>?),
-        if (matchingEngine != _undefined)
-          'matchingEngine': (matchingEngine as Input$GenMatchingEngineInput?),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  TRes groupRules(
-          Iterable<Input$GenGroupRuleInput>? Function(
-                  Iterable<
-                      CopyWith$Input$GenGroupRuleInput<
-                          Input$GenGroupRuleInput>>?)
-              _fn) =>
-      call(
-          groupRules: _fn(
-              _instance.groupRules?.map((e) => CopyWith$Input$GenGroupRuleInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine {
-    final local$matchingEngine = _instance.matchingEngine;
-    return local$matchingEngine == null
-        ? CopyWith$Input$GenMatchingEngineInput.stub(_then(_instance))
-        : CopyWith$Input$GenMatchingEngineInput(
-            local$matchingEngine, (e) => call(matchingEngine: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenSpecificGroupInput<TRes>
-    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
-  _CopyWithStubImpl$Input$GenSpecificGroupInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  groupRules(_fn) => _res;
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine =>
-      CopyWith$Input$GenMatchingEngineInput.stub(_res);
-}
-
-class Input$GenGroupRuleInput {
-  factory Input$GenGroupRuleInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  }) =>
-      Input$GenGroupRuleInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (someGroupRule != null) r'someGroupRule': someGroupRule,
-        if (someOtherGroupRule != null)
-          r'someOtherGroupRule': someOtherGroupRule,
-      });
-
-  Input$GenGroupRuleInput._(this._$data);
-
-  factory Input$GenGroupRuleInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('someGroupRule')) {
-      final l$someGroupRule = data['someGroupRule'];
-      result$data['someGroupRule'] = (l$someGroupRule as bool);
-    }
-    if (data.containsKey('someOtherGroupRule')) {
-      final l$someOtherGroupRule = data['someOtherGroupRule'];
-      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
-    }
-    return Input$GenGroupRuleInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get someGroupRule => (_$data['someGroupRule'] as bool?);
-  bool? get someOtherGroupRule => (_$data['someOtherGroupRule'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('someGroupRule')) {
-      final l$someGroupRule = someGroupRule;
-      result$data['someGroupRule'] = (l$someGroupRule as bool);
-    }
-    if (_$data.containsKey('someOtherGroupRule')) {
-      final l$someOtherGroupRule = someOtherGroupRule;
-      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput> get copyWith =>
-      CopyWith$Input$GenGroupRuleInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenGroupRuleInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$someGroupRule = someGroupRule;
-    final lOther$someGroupRule = other.someGroupRule;
-    if (_$data.containsKey('someGroupRule') !=
-        other._$data.containsKey('someGroupRule')) {
-      return false;
-    }
-    if (l$someGroupRule != lOther$someGroupRule) {
-      return false;
-    }
-    final l$someOtherGroupRule = someOtherGroupRule;
-    final lOther$someOtherGroupRule = other.someOtherGroupRule;
-    if (_$data.containsKey('someOtherGroupRule') !=
-        other._$data.containsKey('someOtherGroupRule')) {
-      return false;
-    }
-    if (l$someOtherGroupRule != lOther$someOtherGroupRule) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$someGroupRule = someGroupRule;
-    final l$someOtherGroupRule = someOtherGroupRule;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('someGroupRule') ? l$someGroupRule : const {},
-      _$data.containsKey('someOtherGroupRule')
-          ? l$someOtherGroupRule
-          : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenGroupRuleInput<TRes> {
-  factory CopyWith$Input$GenGroupRuleInput(
-    Input$GenGroupRuleInput instance,
-    TRes Function(Input$GenGroupRuleInput) then,
-  ) = _CopyWithImpl$Input$GenGroupRuleInput;
-
-  factory CopyWith$Input$GenGroupRuleInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenGroupRuleInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenGroupRuleInput<TRes>
-    implements CopyWith$Input$GenGroupRuleInput<TRes> {
-  _CopyWithImpl$Input$GenGroupRuleInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenGroupRuleInput _instance;
-
-  final TRes Function(Input$GenGroupRuleInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? someGroupRule = _undefined,
-    Object? someOtherGroupRule = _undefined,
-  }) =>
-      _then(Input$GenGroupRuleInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (someGroupRule != _undefined && someGroupRule != null)
-          'someGroupRule': (someGroupRule as bool),
-        if (someOtherGroupRule != _undefined && someOtherGroupRule != null)
-          'someOtherGroupRule': (someOtherGroupRule as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenGroupRuleInput<TRes>
-    implements CopyWith$Input$GenGroupRuleInput<TRes> {
-  _CopyWithStubImpl$Input$GenGroupRuleInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
-class Input$GenMatchingEngineInput {
-  factory Input$GenMatchingEngineInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  }) =>
-      Input$GenMatchingEngineInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (someMatchingRule != null) r'someMatchingRule': someMatchingRule,
-        if (someOtherMatchingRule != null)
-          r'someOtherMatchingRule': someOtherMatchingRule,
-      });
-
-  Input$GenMatchingEngineInput._(this._$data);
-
-  factory Input$GenMatchingEngineInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] = (l$createdAt as String?);
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] = (l$updatedAt as String?);
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] = (l$deletedAt as String?);
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('someMatchingRule')) {
-      final l$someMatchingRule = data['someMatchingRule'];
-      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
-    }
-    if (data.containsKey('someOtherMatchingRule')) {
-      final l$someOtherMatchingRule = data['someOtherMatchingRule'];
-      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
-    }
-    return Input$GenMatchingEngineInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  String? get createdAt => (_$data['createdAt'] as String?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  String? get updatedAt => (_$data['updatedAt'] as String?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  String? get deletedAt => (_$data['deletedAt'] as String?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get someMatchingRule => (_$data['someMatchingRule'] as bool?);
-  bool? get someOtherMatchingRule => (_$data['someOtherMatchingRule'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt;
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt;
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt;
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('someMatchingRule')) {
-      final l$someMatchingRule = someMatchingRule;
-      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
-    }
-    if (_$data.containsKey('someOtherMatchingRule')) {
-      final l$someOtherMatchingRule = someOtherMatchingRule;
-      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenMatchingEngineInput<Input$GenMatchingEngineInput>
-      get copyWith => CopyWith$Input$GenMatchingEngineInput(
-            this,
-            (i) => i,
-          );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenMatchingEngineInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$someMatchingRule = someMatchingRule;
-    final lOther$someMatchingRule = other.someMatchingRule;
-    if (_$data.containsKey('someMatchingRule') !=
-        other._$data.containsKey('someMatchingRule')) {
-      return false;
-    }
-    if (l$someMatchingRule != lOther$someMatchingRule) {
-      return false;
-    }
-    final l$someOtherMatchingRule = someOtherMatchingRule;
-    final lOther$someOtherMatchingRule = other.someOtherMatchingRule;
-    if (_$data.containsKey('someOtherMatchingRule') !=
-        other._$data.containsKey('someOtherMatchingRule')) {
-      return false;
-    }
-    if (l$someOtherMatchingRule != lOther$someOtherMatchingRule) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$someMatchingRule = someMatchingRule;
-    final l$someOtherMatchingRule = someOtherMatchingRule;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('someMatchingRule') ? l$someMatchingRule : const {},
-      _$data.containsKey('someOtherMatchingRule')
-          ? l$someOtherMatchingRule
-          : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenMatchingEngineInput<TRes> {
-  factory CopyWith$Input$GenMatchingEngineInput(
-    Input$GenMatchingEngineInput instance,
-    TRes Function(Input$GenMatchingEngineInput) then,
-  ) = _CopyWithImpl$Input$GenMatchingEngineInput;
-
-  factory CopyWith$Input$GenMatchingEngineInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenMatchingEngineInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenMatchingEngineInput<TRes>
-    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
-  _CopyWithImpl$Input$GenMatchingEngineInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenMatchingEngineInput _instance;
-
-  final TRes Function(Input$GenMatchingEngineInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? someMatchingRule = _undefined,
-    Object? someOtherMatchingRule = _undefined,
-  }) =>
-      _then(Input$GenMatchingEngineInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as String?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as String?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as String?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (someMatchingRule != _undefined && someMatchingRule != null)
-          'someMatchingRule': (someMatchingRule as bool),
-        if (someOtherMatchingRule != _undefined &&
-            someOtherMatchingRule != null)
-          'someOtherMatchingRule': (someOtherMatchingRule as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenMatchingEngineInput<TRes>
-    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
-  _CopyWithStubImpl$Input$GenMatchingEngineInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    String? createdAt,
-    String? createdBy,
-    String? updatedAt,
-    String? updatedBy,
-    String? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
 class Input$MenteesGroupMembershipInput {
   factory Input$MenteesGroupMembershipInput({
     String? id,
@@ -17180,8 +14369,8 @@ class Input$MenteesGroupMembershipInput {
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? soughtExpertises,
-    String? industry,
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
     String? actionsTaken,
     String? currentChallenges,
     String? futureGoals,
@@ -17201,8 +14390,9 @@ class Input$MenteesGroupMembershipInput {
         if (groupId != null) r'groupId': groupId,
         if (userId != null) r'userId': userId,
         if (roles != null) r'roles': roles,
-        if (soughtExpertises != null) r'soughtExpertises': soughtExpertises,
-        if (industry != null) r'industry': industry,
+        if (soughtExpertisesTextIds != null)
+          r'soughtExpertisesTextIds': soughtExpertisesTextIds,
+        if (industryTextId != null) r'industryTextId': industryTextId,
         if (actionsTaken != null) r'actionsTaken': actionsTaken,
         if (currentChallenges != null) r'currentChallenges': currentChallenges,
         if (futureGoals != null) r'futureGoals': futureGoals,
@@ -17275,15 +14465,16 @@ class Input$MenteesGroupMembershipInput {
           .map((e) => fromJson$Enum$GroupMembershipRole((e as String)))
           .toList();
     }
-    if (data.containsKey('soughtExpertises')) {
-      final l$soughtExpertises = data['soughtExpertises'];
-      result$data['soughtExpertises'] = (l$soughtExpertises as List<dynamic>)
-          .map((e) => (e as String))
-          .toList();
+    if (data.containsKey('soughtExpertisesTextIds')) {
+      final l$soughtExpertisesTextIds = data['soughtExpertisesTextIds'];
+      result$data['soughtExpertisesTextIds'] =
+          (l$soughtExpertisesTextIds as List<dynamic>)
+              .map((e) => (e as String))
+              .toList();
     }
-    if (data.containsKey('industry')) {
-      final l$industry = data['industry'];
-      result$data['industry'] = (l$industry as String?);
+    if (data.containsKey('industryTextId')) {
+      final l$industryTextId = data['industryTextId'];
+      result$data['industryTextId'] = (l$industryTextId as String?);
     }
     if (data.containsKey('actionsTaken')) {
       final l$actionsTaken = data['actionsTaken'];
@@ -17323,9 +14514,9 @@ class Input$MenteesGroupMembershipInput {
   String? get userId => (_$data['userId'] as String?);
   List<Enum$GroupMembershipRole>? get roles =>
       (_$data['roles'] as List<Enum$GroupMembershipRole>?);
-  List<String>? get soughtExpertises =>
-      (_$data['soughtExpertises'] as List<String>?);
-  String? get industry => (_$data['industry'] as String?);
+  List<String>? get soughtExpertisesTextIds =>
+      (_$data['soughtExpertisesTextIds'] as List<String>?);
+  String? get industryTextId => (_$data['industryTextId'] as String?);
   String? get actionsTaken => (_$data['actionsTaken'] as String?);
   String? get currentChallenges => (_$data['currentChallenges'] as String?);
   String? get futureGoals => (_$data['futureGoals'] as String?);
@@ -17387,14 +14578,14 @@ class Input$MenteesGroupMembershipInput {
           .map((e) => toJson$Enum$GroupMembershipRole(e))
           .toList();
     }
-    if (_$data.containsKey('soughtExpertises')) {
-      final l$soughtExpertises = soughtExpertises;
-      result$data['soughtExpertises'] =
-          (l$soughtExpertises as List<String>).map((e) => e).toList();
+    if (_$data.containsKey('soughtExpertisesTextIds')) {
+      final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+      result$data['soughtExpertisesTextIds'] =
+          (l$soughtExpertisesTextIds as List<String>).map((e) => e).toList();
     }
-    if (_$data.containsKey('industry')) {
-      final l$industry = industry;
-      result$data['industry'] = l$industry;
+    if (_$data.containsKey('industryTextId')) {
+      final l$industryTextId = industryTextId;
+      result$data['industryTextId'] = l$industryTextId;
     }
     if (_$data.containsKey('actionsTaken')) {
       final l$actionsTaken = actionsTaken;
@@ -17563,33 +14754,37 @@ class Input$MenteesGroupMembershipInput {
     } else if (l$roles != lOther$roles) {
       return false;
     }
-    final l$soughtExpertises = soughtExpertises;
-    final lOther$soughtExpertises = other.soughtExpertises;
-    if (_$data.containsKey('soughtExpertises') !=
-        other._$data.containsKey('soughtExpertises')) {
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final lOther$soughtExpertisesTextIds = other.soughtExpertisesTextIds;
+    if (_$data.containsKey('soughtExpertisesTextIds') !=
+        other._$data.containsKey('soughtExpertisesTextIds')) {
       return false;
     }
-    if (l$soughtExpertises != null && lOther$soughtExpertises != null) {
-      if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+    if (l$soughtExpertisesTextIds != null &&
+        lOther$soughtExpertisesTextIds != null) {
+      if (l$soughtExpertisesTextIds.length !=
+          lOther$soughtExpertisesTextIds.length) {
         return false;
       }
-      for (int i = 0; i < l$soughtExpertises.length; i++) {
-        final l$soughtExpertises$entry = l$soughtExpertises[i];
-        final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
-        if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+      for (int i = 0; i < l$soughtExpertisesTextIds.length; i++) {
+        final l$soughtExpertisesTextIds$entry = l$soughtExpertisesTextIds[i];
+        final lOther$soughtExpertisesTextIds$entry =
+            lOther$soughtExpertisesTextIds[i];
+        if (l$soughtExpertisesTextIds$entry !=
+            lOther$soughtExpertisesTextIds$entry) {
           return false;
         }
       }
-    } else if (l$soughtExpertises != lOther$soughtExpertises) {
+    } else if (l$soughtExpertisesTextIds != lOther$soughtExpertisesTextIds) {
       return false;
     }
-    final l$industry = industry;
-    final lOther$industry = other.industry;
-    if (_$data.containsKey('industry') !=
-        other._$data.containsKey('industry')) {
+    final l$industryTextId = industryTextId;
+    final lOther$industryTextId = other.industryTextId;
+    if (_$data.containsKey('industryTextId') !=
+        other._$data.containsKey('industryTextId')) {
       return false;
     }
-    if (l$industry != lOther$industry) {
+    if (l$industryTextId != lOther$industryTextId) {
       return false;
     }
     final l$actionsTaken = actionsTaken;
@@ -17646,8 +14841,8 @@ class Input$MenteesGroupMembershipInput {
     final l$groupId = groupId;
     final l$userId = userId;
     final l$roles = roles;
-    final l$soughtExpertises = soughtExpertises;
-    final l$industry = industry;
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final l$industryTextId = industryTextId;
     final l$actionsTaken = actionsTaken;
     final l$currentChallenges = currentChallenges;
     final l$futureGoals = futureGoals;
@@ -17674,12 +14869,12 @@ class Input$MenteesGroupMembershipInput {
               ? null
               : Object.hashAll(l$roles.map((v) => v))
           : const {},
-      _$data.containsKey('soughtExpertises')
-          ? l$soughtExpertises == null
+      _$data.containsKey('soughtExpertisesTextIds')
+          ? l$soughtExpertisesTextIds == null
               ? null
-              : Object.hashAll(l$soughtExpertises.map((v) => v))
+              : Object.hashAll(l$soughtExpertisesTextIds.map((v) => v))
           : const {},
-      _$data.containsKey('industry') ? l$industry : const {},
+      _$data.containsKey('industryTextId') ? l$industryTextId : const {},
       _$data.containsKey('actionsTaken') ? l$actionsTaken : const {},
       _$data.containsKey('currentChallenges') ? l$currentChallenges : const {},
       _$data.containsKey('futureGoals') ? l$futureGoals : const {},
@@ -17713,8 +14908,8 @@ abstract class CopyWith$Input$MenteesGroupMembershipInput<TRes> {
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? soughtExpertises,
-    String? industry,
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
     String? actionsTaken,
     String? currentChallenges,
     String? futureGoals,
@@ -17754,8 +14949,8 @@ class _CopyWithImpl$Input$MenteesGroupMembershipInput<TRes>
     Object? groupId = _undefined,
     Object? userId = _undefined,
     Object? roles = _undefined,
-    Object? soughtExpertises = _undefined,
-    Object? industry = _undefined,
+    Object? soughtExpertisesTextIds = _undefined,
+    Object? industryTextId = _undefined,
     Object? actionsTaken = _undefined,
     Object? currentChallenges = _undefined,
     Object? futureGoals = _undefined,
@@ -17779,9 +14974,11 @@ class _CopyWithImpl$Input$MenteesGroupMembershipInput<TRes>
         if (userId != _undefined) 'userId': (userId as String?),
         if (roles != _undefined && roles != null)
           'roles': (roles as List<Enum$GroupMembershipRole>),
-        if (soughtExpertises != _undefined && soughtExpertises != null)
-          'soughtExpertises': (soughtExpertises as List<String>),
-        if (industry != _undefined) 'industry': (industry as String?),
+        if (soughtExpertisesTextIds != _undefined &&
+            soughtExpertisesTextIds != null)
+          'soughtExpertisesTextIds': (soughtExpertisesTextIds as List<String>),
+        if (industryTextId != _undefined)
+          'industryTextId': (industryTextId as String?),
         if (actionsTaken != _undefined)
           'actionsTaken': (actionsTaken as String?),
         if (currentChallenges != _undefined)
@@ -17830,8 +15027,8 @@ class _CopyWithStubImpl$Input$MenteesGroupMembershipInput<TRes>
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? soughtExpertises,
-    String? industry,
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
     String? actionsTaken,
     String? currentChallenges,
     String? futureGoals,
@@ -17858,12 +15055,12 @@ class Input$MentorsGroupMembershipInput {
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? expertises,
-    List<String>? industries,
-    String? website,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
+    int? endorsements,
   }) =>
       Input$MentorsGroupMembershipInput._({
         if (id != null) r'id': id,
@@ -17879,14 +15076,14 @@ class Input$MentorsGroupMembershipInput {
         if (groupId != null) r'groupId': groupId,
         if (userId != null) r'userId': userId,
         if (roles != null) r'roles': roles,
-        if (expertises != null) r'expertises': expertises,
-        if (industries != null) r'industries': industries,
-        if (website != null) r'website': website,
+        if (expertisesTextIds != null) r'expertisesTextIds': expertisesTextIds,
+        if (industriesTextIds != null) r'industriesTextIds': industriesTextIds,
         if (helpICanOffer != null) r'helpICanOffer': helpICanOffer,
         if (expectationsForMentees != null)
           r'expectationsForMentees': expectationsForMentees,
         if (menteePreparationInstructions != null)
           r'menteePreparationInstructions': menteePreparationInstructions,
+        if (endorsements != null) r'endorsements': endorsements,
       });
 
   Input$MentorsGroupMembershipInput._(this._$data);
@@ -17954,19 +15151,17 @@ class Input$MentorsGroupMembershipInput {
           .map((e) => fromJson$Enum$GroupMembershipRole((e as String)))
           .toList();
     }
-    if (data.containsKey('expertises')) {
-      final l$expertises = data['expertises'];
-      result$data['expertises'] =
-          (l$expertises as List<dynamic>).map((e) => (e as String)).toList();
+    if (data.containsKey('expertisesTextIds')) {
+      final l$expertisesTextIds = data['expertisesTextIds'];
+      result$data['expertisesTextIds'] = (l$expertisesTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
     }
-    if (data.containsKey('industries')) {
-      final l$industries = data['industries'];
-      result$data['industries'] =
-          (l$industries as List<dynamic>).map((e) => (e as String)).toList();
-    }
-    if (data.containsKey('website')) {
-      final l$website = data['website'];
-      result$data['website'] = (l$website as String?);
+    if (data.containsKey('industriesTextIds')) {
+      final l$industriesTextIds = data['industriesTextIds'];
+      result$data['industriesTextIds'] = (l$industriesTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
     }
     if (data.containsKey('helpICanOffer')) {
       final l$helpICanOffer = data['helpICanOffer'];
@@ -17982,6 +15177,10 @@ class Input$MentorsGroupMembershipInput {
           data['menteePreparationInstructions'];
       result$data['menteePreparationInstructions'] =
           (l$menteePreparationInstructions as String?);
+    }
+    if (data.containsKey('endorsements')) {
+      final l$endorsements = data['endorsements'];
+      result$data['endorsements'] = (l$endorsements as int?);
     }
     return Input$MentorsGroupMembershipInput._(result$data);
   }
@@ -18004,14 +15203,16 @@ class Input$MentorsGroupMembershipInput {
   String? get userId => (_$data['userId'] as String?);
   List<Enum$GroupMembershipRole>? get roles =>
       (_$data['roles'] as List<Enum$GroupMembershipRole>?);
-  List<String>? get expertises => (_$data['expertises'] as List<String>?);
-  List<String>? get industries => (_$data['industries'] as List<String>?);
-  String? get website => (_$data['website'] as String?);
+  List<String>? get expertisesTextIds =>
+      (_$data['expertisesTextIds'] as List<String>?);
+  List<String>? get industriesTextIds =>
+      (_$data['industriesTextIds'] as List<String>?);
   String? get helpICanOffer => (_$data['helpICanOffer'] as String?);
   String? get expectationsForMentees =>
       (_$data['expectationsForMentees'] as String?);
   String? get menteePreparationInstructions =>
       (_$data['menteePreparationInstructions'] as String?);
+  int? get endorsements => (_$data['endorsements'] as int?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -18068,19 +15269,15 @@ class Input$MentorsGroupMembershipInput {
           .map((e) => toJson$Enum$GroupMembershipRole(e))
           .toList();
     }
-    if (_$data.containsKey('expertises')) {
-      final l$expertises = expertises;
-      result$data['expertises'] =
-          (l$expertises as List<String>).map((e) => e).toList();
+    if (_$data.containsKey('expertisesTextIds')) {
+      final l$expertisesTextIds = expertisesTextIds;
+      result$data['expertisesTextIds'] =
+          (l$expertisesTextIds as List<String>).map((e) => e).toList();
     }
-    if (_$data.containsKey('industries')) {
-      final l$industries = industries;
-      result$data['industries'] =
-          (l$industries as List<String>).map((e) => e).toList();
-    }
-    if (_$data.containsKey('website')) {
-      final l$website = website;
-      result$data['website'] = l$website;
+    if (_$data.containsKey('industriesTextIds')) {
+      final l$industriesTextIds = industriesTextIds;
+      result$data['industriesTextIds'] =
+          (l$industriesTextIds as List<String>).map((e) => e).toList();
     }
     if (_$data.containsKey('helpICanOffer')) {
       final l$helpICanOffer = helpICanOffer;
@@ -18094,6 +15291,10 @@ class Input$MentorsGroupMembershipInput {
       final l$menteePreparationInstructions = menteePreparationInstructions;
       result$data['menteePreparationInstructions'] =
           l$menteePreparationInstructions;
+    }
+    if (_$data.containsKey('endorsements')) {
+      final l$endorsements = endorsements;
+      result$data['endorsements'] = l$endorsements;
     }
     return result$data;
   }
@@ -18246,52 +15447,44 @@ class Input$MentorsGroupMembershipInput {
     } else if (l$roles != lOther$roles) {
       return false;
     }
-    final l$expertises = expertises;
-    final lOther$expertises = other.expertises;
-    if (_$data.containsKey('expertises') !=
-        other._$data.containsKey('expertises')) {
+    final l$expertisesTextIds = expertisesTextIds;
+    final lOther$expertisesTextIds = other.expertisesTextIds;
+    if (_$data.containsKey('expertisesTextIds') !=
+        other._$data.containsKey('expertisesTextIds')) {
       return false;
     }
-    if (l$expertises != null && lOther$expertises != null) {
-      if (l$expertises.length != lOther$expertises.length) {
+    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
+      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
         return false;
       }
-      for (int i = 0; i < l$expertises.length; i++) {
-        final l$expertises$entry = l$expertises[i];
-        final lOther$expertises$entry = lOther$expertises[i];
-        if (l$expertises$entry != lOther$expertises$entry) {
+      for (int i = 0; i < l$expertisesTextIds.length; i++) {
+        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
+        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
+        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
           return false;
         }
       }
-    } else if (l$expertises != lOther$expertises) {
+    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
       return false;
     }
-    final l$industries = industries;
-    final lOther$industries = other.industries;
-    if (_$data.containsKey('industries') !=
-        other._$data.containsKey('industries')) {
+    final l$industriesTextIds = industriesTextIds;
+    final lOther$industriesTextIds = other.industriesTextIds;
+    if (_$data.containsKey('industriesTextIds') !=
+        other._$data.containsKey('industriesTextIds')) {
       return false;
     }
-    if (l$industries != null && lOther$industries != null) {
-      if (l$industries.length != lOther$industries.length) {
+    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
+      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
         return false;
       }
-      for (int i = 0; i < l$industries.length; i++) {
-        final l$industries$entry = l$industries[i];
-        final lOther$industries$entry = lOther$industries[i];
-        if (l$industries$entry != lOther$industries$entry) {
+      for (int i = 0; i < l$industriesTextIds.length; i++) {
+        final l$industriesTextIds$entry = l$industriesTextIds[i];
+        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
+        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
           return false;
         }
       }
-    } else if (l$industries != lOther$industries) {
-      return false;
-    }
-    final l$website = website;
-    final lOther$website = other.website;
-    if (_$data.containsKey('website') != other._$data.containsKey('website')) {
-      return false;
-    }
-    if (l$website != lOther$website) {
+    } else if (l$industriesTextIds != lOther$industriesTextIds) {
       return false;
     }
     final l$helpICanOffer = helpICanOffer;
@@ -18323,6 +15516,15 @@ class Input$MentorsGroupMembershipInput {
         lOther$menteePreparationInstructions) {
       return false;
     }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (_$data.containsKey('endorsements') !=
+        other._$data.containsKey('endorsements')) {
+      return false;
+    }
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
     return true;
   }
 
@@ -18341,12 +15543,12 @@ class Input$MentorsGroupMembershipInput {
     final l$groupId = groupId;
     final l$userId = userId;
     final l$roles = roles;
-    final l$expertises = expertises;
-    final l$industries = industries;
-    final l$website = website;
+    final l$expertisesTextIds = expertisesTextIds;
+    final l$industriesTextIds = industriesTextIds;
     final l$helpICanOffer = helpICanOffer;
     final l$expectationsForMentees = expectationsForMentees;
     final l$menteePreparationInstructions = menteePreparationInstructions;
+    final l$endorsements = endorsements;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -18369,17 +15571,16 @@ class Input$MentorsGroupMembershipInput {
               ? null
               : Object.hashAll(l$roles.map((v) => v))
           : const {},
-      _$data.containsKey('expertises')
-          ? l$expertises == null
+      _$data.containsKey('expertisesTextIds')
+          ? l$expertisesTextIds == null
               ? null
-              : Object.hashAll(l$expertises.map((v) => v))
+              : Object.hashAll(l$expertisesTextIds.map((v) => v))
           : const {},
-      _$data.containsKey('industries')
-          ? l$industries == null
+      _$data.containsKey('industriesTextIds')
+          ? l$industriesTextIds == null
               ? null
-              : Object.hashAll(l$industries.map((v) => v))
+              : Object.hashAll(l$industriesTextIds.map((v) => v))
           : const {},
-      _$data.containsKey('website') ? l$website : const {},
       _$data.containsKey('helpICanOffer') ? l$helpICanOffer : const {},
       _$data.containsKey('expectationsForMentees')
           ? l$expectationsForMentees
@@ -18387,6 +15588,7 @@ class Input$MentorsGroupMembershipInput {
       _$data.containsKey('menteePreparationInstructions')
           ? l$menteePreparationInstructions
           : const {},
+      _$data.containsKey('endorsements') ? l$endorsements : const {},
     ]);
   }
 }
@@ -18414,12 +15616,12 @@ abstract class CopyWith$Input$MentorsGroupMembershipInput<TRes> {
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? expertises,
-    List<String>? industries,
-    String? website,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
+    int? endorsements,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -18455,12 +15657,12 @@ class _CopyWithImpl$Input$MentorsGroupMembershipInput<TRes>
     Object? groupId = _undefined,
     Object? userId = _undefined,
     Object? roles = _undefined,
-    Object? expertises = _undefined,
-    Object? industries = _undefined,
-    Object? website = _undefined,
+    Object? expertisesTextIds = _undefined,
+    Object? industriesTextIds = _undefined,
     Object? helpICanOffer = _undefined,
     Object? expectationsForMentees = _undefined,
     Object? menteePreparationInstructions = _undefined,
+    Object? endorsements = _undefined,
   }) =>
       _then(Input$MentorsGroupMembershipInput._({
         ..._instance._$data,
@@ -18480,11 +15682,10 @@ class _CopyWithImpl$Input$MentorsGroupMembershipInput<TRes>
         if (userId != _undefined) 'userId': (userId as String?),
         if (roles != _undefined && roles != null)
           'roles': (roles as List<Enum$GroupMembershipRole>),
-        if (expertises != _undefined && expertises != null)
-          'expertises': (expertises as List<String>),
-        if (industries != _undefined && industries != null)
-          'industries': (industries as List<String>),
-        if (website != _undefined) 'website': (website as String?),
+        if (expertisesTextIds != _undefined && expertisesTextIds != null)
+          'expertisesTextIds': (expertisesTextIds as List<String>),
+        if (industriesTextIds != _undefined && industriesTextIds != null)
+          'industriesTextIds': (industriesTextIds as List<String>),
         if (helpICanOffer != _undefined)
           'helpICanOffer': (helpICanOffer as String?),
         if (expectationsForMentees != _undefined)
@@ -18492,6 +15693,7 @@ class _CopyWithImpl$Input$MentorsGroupMembershipInput<TRes>
         if (menteePreparationInstructions != _undefined)
           'menteePreparationInstructions':
               (menteePreparationInstructions as String?),
+        if (endorsements != _undefined) 'endorsements': (endorsements as int?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -18533,12 +15735,12 @@ class _CopyWithStubImpl$Input$MentorsGroupMembershipInput<TRes>
     String? groupId,
     String? userId,
     List<Enum$GroupMembershipRole>? roles,
-    List<String>? expertises,
-    List<String>? industries,
-    String? website,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
     String? helpICanOffer,
     String? expectationsForMentees,
     String? menteePreparationInstructions,
+    int? endorsements,
   }) =>
       _res;
   events(_fn) => _res;
@@ -23939,6 +21141,109 @@ Enum$ModelEventType fromJson$Enum$ModelEventType(String value) {
   }
 }
 
+enum Enum$OptionType {
+  educationLevel,
+  expertise,
+  industry,
+  companyStage,
+  companyType,
+  country,
+  gender,
+  language,
+  unset,
+  $unknown
+}
+
+String toJson$Enum$OptionType(Enum$OptionType e) {
+  switch (e) {
+    case Enum$OptionType.educationLevel:
+      return r'educationLevel';
+    case Enum$OptionType.expertise:
+      return r'expertise';
+    case Enum$OptionType.industry:
+      return r'industry';
+    case Enum$OptionType.companyStage:
+      return r'companyStage';
+    case Enum$OptionType.companyType:
+      return r'companyType';
+    case Enum$OptionType.country:
+      return r'country';
+    case Enum$OptionType.gender:
+      return r'gender';
+    case Enum$OptionType.language:
+      return r'language';
+    case Enum$OptionType.unset:
+      return r'unset';
+    case Enum$OptionType.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$OptionType fromJson$Enum$OptionType(String value) {
+  switch (value) {
+    case r'educationLevel':
+      return Enum$OptionType.educationLevel;
+    case r'expertise':
+      return Enum$OptionType.expertise;
+    case r'industry':
+      return Enum$OptionType.industry;
+    case r'companyStage':
+      return Enum$OptionType.companyStage;
+    case r'companyType':
+      return Enum$OptionType.companyType;
+    case r'country':
+      return Enum$OptionType.country;
+    case r'gender':
+      return Enum$OptionType.gender;
+    case r'language':
+      return Enum$OptionType.language;
+    case r'unset':
+      return Enum$OptionType.unset;
+    default:
+      return Enum$OptionType.$unknown;
+  }
+}
+
+enum Enum$UiLanguage { ar, en, es, id, ru, so, $unknown }
+
+String toJson$Enum$UiLanguage(Enum$UiLanguage e) {
+  switch (e) {
+    case Enum$UiLanguage.ar:
+      return r'ar';
+    case Enum$UiLanguage.en:
+      return r'en';
+    case Enum$UiLanguage.es:
+      return r'es';
+    case Enum$UiLanguage.id:
+      return r'id';
+    case Enum$UiLanguage.ru:
+      return r'ru';
+    case Enum$UiLanguage.so:
+      return r'so';
+    case Enum$UiLanguage.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$UiLanguage fromJson$Enum$UiLanguage(String value) {
+  switch (value) {
+    case r'ar':
+      return Enum$UiLanguage.ar;
+    case r'en':
+      return Enum$UiLanguage.en;
+    case r'es':
+      return Enum$UiLanguage.es;
+    case r'id':
+      return Enum$UiLanguage.id;
+    case r'ru':
+      return Enum$UiLanguage.ru;
+    case r'so':
+      return Enum$UiLanguage.so;
+    default:
+      return Enum$UiLanguage.$unknown;
+  }
+}
+
 enum Enum$ChannelMessageType { unset, invitation, $unknown }
 
 String toJson$Enum$ChannelMessageType(Enum$ChannelMessageType e) {
@@ -24098,44 +21403,6 @@ Enum$AppFeature fromJson$Enum$AppFeature(String value) {
   }
 }
 
-enum Enum$EducationLevel {
-  doctorate,
-  undergraduate,
-  secondary,
-  primary,
-  $unknown
-}
-
-String toJson$Enum$EducationLevel(Enum$EducationLevel e) {
-  switch (e) {
-    case Enum$EducationLevel.doctorate:
-      return r'doctorate';
-    case Enum$EducationLevel.undergraduate:
-      return r'undergraduate';
-    case Enum$EducationLevel.secondary:
-      return r'secondary';
-    case Enum$EducationLevel.primary:
-      return r'primary';
-    case Enum$EducationLevel.$unknown:
-      return r'$unknown';
-  }
-}
-
-Enum$EducationLevel fromJson$Enum$EducationLevel(String value) {
-  switch (value) {
-    case r'doctorate':
-      return Enum$EducationLevel.doctorate;
-    case r'undergraduate':
-      return Enum$EducationLevel.undergraduate;
-    case r'secondary':
-      return Enum$EducationLevel.secondary;
-    case r'primary':
-      return Enum$EducationLevel.primary;
-    default:
-      return Enum$EducationLevel.$unknown;
-  }
-}
-
 enum Enum$AppAction { editProfile, updateApp, unset, $unknown }
 
 String toJson$Enum$AppAction(Enum$AppAction e) {
@@ -24249,76 +21516,6 @@ Enum$ChannelParticipantRole fromJson$Enum$ChannelParticipantRole(String value) {
       return Enum$ChannelParticipantRole.unset;
     default:
       return Enum$ChannelParticipantRole.$unknown;
-  }
-}
-
-enum Enum$CompanyType {
-  forProfit,
-  nonProfit,
-  socialEnterprise,
-  unsure,
-  $unknown
-}
-
-String toJson$Enum$CompanyType(Enum$CompanyType e) {
-  switch (e) {
-    case Enum$CompanyType.forProfit:
-      return r'forProfit';
-    case Enum$CompanyType.nonProfit:
-      return r'nonProfit';
-    case Enum$CompanyType.socialEnterprise:
-      return r'socialEnterprise';
-    case Enum$CompanyType.unsure:
-      return r'unsure';
-    case Enum$CompanyType.$unknown:
-      return r'$unknown';
-  }
-}
-
-Enum$CompanyType fromJson$Enum$CompanyType(String value) {
-  switch (value) {
-    case r'forProfit':
-      return Enum$CompanyType.forProfit;
-    case r'nonProfit':
-      return Enum$CompanyType.nonProfit;
-    case r'socialEnterprise':
-      return Enum$CompanyType.socialEnterprise;
-    case r'unsure':
-      return Enum$CompanyType.unsure;
-    default:
-      return Enum$CompanyType.$unknown;
-  }
-}
-
-enum Enum$CompanyStage { idea, operational, earning, profitable, $unknown }
-
-String toJson$Enum$CompanyStage(Enum$CompanyStage e) {
-  switch (e) {
-    case Enum$CompanyStage.idea:
-      return r'idea';
-    case Enum$CompanyStage.operational:
-      return r'operational';
-    case Enum$CompanyStage.earning:
-      return r'earning';
-    case Enum$CompanyStage.profitable:
-      return r'profitable';
-    case Enum$CompanyStage.$unknown:
-      return r'$unknown';
-  }
-}
-
-Enum$CompanyStage fromJson$Enum$CompanyStage(String value) {
-  switch (value) {
-    case r'idea':
-      return Enum$CompanyStage.idea;
-    case r'operational':
-      return Enum$CompanyStage.operational;
-    case r'earning':
-      return Enum$CompanyStage.earning;
-    case r'profitable':
-      return Enum$CompanyStage.profitable;
-    default:
-      return Enum$CompanyStage.$unknown;
   }
 }
 
@@ -24518,63 +21715,27 @@ Enum$UserIdentType fromJson$Enum$UserIdentType(String value) {
   }
 }
 
-enum Enum$OptionType { expertise, industry, gender, unset, $unknown }
+enum Enum$SortDirection { asc, desc, $unknown }
 
-String toJson$Enum$OptionType(Enum$OptionType e) {
+String toJson$Enum$SortDirection(Enum$SortDirection e) {
   switch (e) {
-    case Enum$OptionType.expertise:
-      return r'expertise';
-    case Enum$OptionType.industry:
-      return r'industry';
-    case Enum$OptionType.gender:
-      return r'gender';
-    case Enum$OptionType.unset:
-      return r'unset';
-    case Enum$OptionType.$unknown:
+    case Enum$SortDirection.asc:
+      return r'asc';
+    case Enum$SortDirection.desc:
+      return r'desc';
+    case Enum$SortDirection.$unknown:
       return r'$unknown';
   }
 }
 
-Enum$OptionType fromJson$Enum$OptionType(String value) {
+Enum$SortDirection fromJson$Enum$SortDirection(String value) {
   switch (value) {
-    case r'expertise':
-      return Enum$OptionType.expertise;
-    case r'industry':
-      return Enum$OptionType.industry;
-    case r'gender':
-      return Enum$OptionType.gender;
-    case r'unset':
-      return Enum$OptionType.unset;
+    case r'asc':
+      return Enum$SortDirection.asc;
+    case r'desc':
+      return Enum$SortDirection.desc;
     default:
-      return Enum$OptionType.$unknown;
-  }
-}
-
-enum Enum$Language { en, es, id, $unknown }
-
-String toJson$Enum$Language(Enum$Language e) {
-  switch (e) {
-    case Enum$Language.en:
-      return r'en';
-    case Enum$Language.es:
-      return r'es';
-    case Enum$Language.id:
-      return r'id';
-    case Enum$Language.$unknown:
-      return r'$unknown';
-  }
-}
-
-Enum$Language fromJson$Enum$Language(String value) {
-  switch (value) {
-    case r'en':
-      return Enum$Language.en;
-    case r'es':
-      return Enum$Language.es;
-    case r'id':
-      return Enum$Language.id;
-    default:
-      return Enum$Language.$unknown;
+      return Enum$SortDirection.$unknown;
   }
 }
 
@@ -24930,6 +22091,11 @@ enum Enum$ServiceRequestType {
   graphQlQueryUserCompanies,
   graphQlQueryUserGroupMembers,
   graphQlQueryUserGroups,
+  graphQlQueryFindCountries,
+  graphQlQueryFindExpertises,
+  graphQlQueryFindIndustries,
+  graphQlQueryFindOptions,
+  unset,
   graphQlMutationRunDataGenerator,
   graphQlMutationExecuteAdminTask,
   graphQlMutationSignUpOAuthUser,
@@ -24992,7 +22158,6 @@ enum Enum$ServiceRequestType {
   graphQlQueryGetMultiStepActionProgress,
   graphQlQueryLatestUserDevice,
   graphQlQueryUserUserDevices,
-  unset,
   $unknown
 }
 
@@ -25061,6 +22226,16 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryUserGroupMembers';
     case Enum$ServiceRequestType.graphQlQueryUserGroups:
       return r'graphQlQueryUserGroups';
+    case Enum$ServiceRequestType.graphQlQueryFindCountries:
+      return r'graphQlQueryFindCountries';
+    case Enum$ServiceRequestType.graphQlQueryFindExpertises:
+      return r'graphQlQueryFindExpertises';
+    case Enum$ServiceRequestType.graphQlQueryFindIndustries:
+      return r'graphQlQueryFindIndustries';
+    case Enum$ServiceRequestType.graphQlQueryFindOptions:
+      return r'graphQlQueryFindOptions';
+    case Enum$ServiceRequestType.unset:
+      return r'unset';
     case Enum$ServiceRequestType.graphQlMutationRunDataGenerator:
       return r'graphQlMutationRunDataGenerator';
     case Enum$ServiceRequestType.graphQlMutationExecuteAdminTask:
@@ -25185,8 +22360,6 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryLatestUserDevice';
     case Enum$ServiceRequestType.graphQlQueryUserUserDevices:
       return r'graphQlQueryUserUserDevices';
-    case Enum$ServiceRequestType.unset:
-      return r'unset';
     case Enum$ServiceRequestType.$unknown:
       return r'$unknown';
   }
@@ -25258,6 +22431,16 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryUserGroupMembers;
     case r'graphQlQueryUserGroups':
       return Enum$ServiceRequestType.graphQlQueryUserGroups;
+    case r'graphQlQueryFindCountries':
+      return Enum$ServiceRequestType.graphQlQueryFindCountries;
+    case r'graphQlQueryFindExpertises':
+      return Enum$ServiceRequestType.graphQlQueryFindExpertises;
+    case r'graphQlQueryFindIndustries':
+      return Enum$ServiceRequestType.graphQlQueryFindIndustries;
+    case r'graphQlQueryFindOptions':
+      return Enum$ServiceRequestType.graphQlQueryFindOptions;
+    case r'unset':
+      return Enum$ServiceRequestType.unset;
     case r'graphQlMutationRunDataGenerator':
       return Enum$ServiceRequestType.graphQlMutationRunDataGenerator;
     case r'graphQlMutationExecuteAdminTask':
@@ -25383,8 +22566,6 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryLatestUserDevice;
     case r'graphQlQueryUserUserDevices':
       return Enum$ServiceRequestType.graphQlQueryUserUserDevices;
-    case r'unset':
-      return Enum$ServiceRequestType.unset;
     default:
       return Enum$ServiceRequestType.$unknown;
   }
@@ -25917,6 +23098,11 @@ enum Enum$Mm2ModelType {
   Conversation,
   Message,
   User,
+  MenteeExpertise,
+  MenteeWebsite,
+  MentorExpertise,
+  Profile,
+  SpokenLanguage,
   $unknown
 }
 
@@ -25932,6 +23118,16 @@ String toJson$Enum$Mm2ModelType(Enum$Mm2ModelType e) {
       return r'Message';
     case Enum$Mm2ModelType.User:
       return r'User';
+    case Enum$Mm2ModelType.MenteeExpertise:
+      return r'MenteeExpertise';
+    case Enum$Mm2ModelType.MenteeWebsite:
+      return r'MenteeWebsite';
+    case Enum$Mm2ModelType.MentorExpertise:
+      return r'MentorExpertise';
+    case Enum$Mm2ModelType.Profile:
+      return r'Profile';
+    case Enum$Mm2ModelType.SpokenLanguage:
+      return r'SpokenLanguage';
     case Enum$Mm2ModelType.$unknown:
       return r'$unknown';
   }
@@ -25949,6 +23145,16 @@ Enum$Mm2ModelType fromJson$Enum$Mm2ModelType(String value) {
       return Enum$Mm2ModelType.Message;
     case r'User':
       return Enum$Mm2ModelType.User;
+    case r'MenteeExpertise':
+      return Enum$Mm2ModelType.MenteeExpertise;
+    case r'MenteeWebsite':
+      return Enum$Mm2ModelType.MenteeWebsite;
+    case r'MentorExpertise':
+      return Enum$Mm2ModelType.MentorExpertise;
+    case r'Profile':
+      return Enum$Mm2ModelType.Profile;
+    case r'SpokenLanguage':
+      return Enum$Mm2ModelType.SpokenLanguage;
     default:
       return Enum$Mm2ModelType.$unknown;
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/firebase_notifications.dart';
 import 'package:mm_flutter_app/providers/channels_provider.dart';
+import 'package:mm_flutter_app/providers/content_provider.dart';
 import 'package:mm_flutter_app/providers/messages_provider.dart';
 import 'package:mm_flutter_app/providers/models/scaffold_model.dart';
 import 'package:mm_flutter_app/providers/explore_card_filters_provider.dart';
@@ -131,6 +132,9 @@ void main() async {
               ),
               ChangeNotifierProvider(
                 create: (context) => ExploreCardFiltersProvider(),
+              ),
+              ChangeNotifierProvider(
+                create: (context) => ContentProvider(client: client),
               ),
               Provider<RouteObserver<PageRoute>>.value(
                 value: RouteObserver<PageRoute>(),

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -1,12 +1,138 @@
-// import 'package:flutter/material.dart';
-// import 'package:graphql_flutter/graphql_flutter.dart';
-// import 'package:mm_flutter_app/__generated/schema/operations_content.graphql.dart';
-// import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations_content.graphql.dart';
 
-// import 'base/base_provider.dart';
-// import 'base/operation_result.dart';
+import 'base/base_provider.dart';
+import 'base/operation_result.dart';
 
-// class ContentProvider extends BaseProvider {
-//   ContentProvider({required super.client});
-//   // TODO: add queries for expertises, education levels, countries, company stages, company types, genders, industries, and languages
-// }
+typedef CompanyStage = Query$FindCompanyStages$findCompanyStages;
+typedef CompanyType = Query$FindCompanyTypes$findCompanyTypes;
+typedef Country = Query$FindCountries$findCountries;
+typedef EducationLevel = Query$FindEducationLevels$findEducationLevels;
+typedef Expertise = Query$FindExpertises$findExpertises;
+typedef Gender = Query$FindGenders$findGenders;
+typedef Industry = Query$FindIndustries$findIndustries;
+typedef Language = Query$FindLanguages$findLanguages;
+
+class ContentProvider extends BaseProvider {
+  List<CompanyStage>? _companyStages;
+  List<CompanyType>? _companyTypes;
+  List<Country>? _countries;
+  List<EducationLevel>? _educationLevels;
+  List<Expertise>? _expertises;
+  List<Gender>? _presetGenders;
+  List<Industry>? _industries;
+  List<Language>? _languages;
+
+  ContentProvider({required super.client});
+
+  void _setAllContentOptions({
+    List<CompanyStage>? companyStages,
+    List<CompanyType>? companyTypes,
+    List<Country>? countries,
+    List<EducationLevel>? educationLevels,
+    List<Expertise>? expertises,
+    List<Gender>? presetGenders,
+    List<Industry>? industries,
+    List<Language>? languages,
+  }) {
+    if (companyStages != null) {
+      _companyStages = companyStages;
+    }
+    if (companyTypes != null) {
+      _companyTypes = companyTypes;
+    }
+    if (countries != null) {
+      _countries = countries;
+    }
+    if (educationLevels != null) {
+      _educationLevels = educationLevels;
+    }
+    if (expertises != null) {
+      _expertises = expertises;
+    }
+    if (presetGenders != null) {
+      _presetGenders = presetGenders;
+    }
+    if (industries != null) {
+      _industries = industries;
+    }
+    if (languages != null) {
+      _languages = languages;
+    }
+    debugPrint('Updated content provider values: ${toString()}');
+  }
+
+  // getters
+
+  List<CompanyStage>? get companyStageOptions {
+    return _companyStages;
+  }
+
+  List<CompanyType>? get companyTypeOptions {
+    return _companyTypes;
+  }
+
+  List<Country>? get countryOptions {
+    return _countries;
+  }
+
+  List<EducationLevel>? get educationLevelOptions {
+    return _educationLevels;
+  }
+
+  List<Expertise>? get expertiseOptions {
+    return _expertises;
+  }
+
+  List<Gender>? get presetGenderOptions {
+    return _presetGenders;
+  }
+
+  List<Industry>? get industryOptions {
+    return _industries;
+  }
+
+  List<Language>? get languageOptions {
+    return _languages;
+  }
+
+  // Queries
+  // TODO: add queries for all other variables
+  //    waiting until base provider is refactored to return Future<OperationResult>
+
+  Widget queryCountries({
+    required Widget Function(
+      OperationResult<List<Query$FindCountries$findCountries>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+    bool logFailures = true,
+  }) {
+    return runQuery(
+      document: documentNodeQueryFindCountries,
+      onData: (queryResult, {refetch, fetchMore}) {
+        final OperationResult<List<Query$FindCountries$findCountries>> result =
+            OperationResult(
+          gqlQueryResult: queryResult,
+          response: queryResult.data != null
+              ? Query$FindCountries.fromJson(
+                  queryResult.data!,
+                ).findCountries
+              : null,
+        );
+        if (result.response != null) {
+          _setAllContentOptions(countries: result.response!);
+        } else {
+          debugPrint("Error: no countries found");
+        }
+        return onData(result, refetch: refetch, fetchMore: fetchMore);
+      },
+      onLoading: onLoading,
+      onError: onError,
+      logFailures: logFailures,
+    );
+  }
+}

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/operations_content.graphql.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+
+import 'base/base_provider.dart';
+import 'base/operation_result.dart';
+
+class ContentProvider extends BaseProvider {
+  ContentProvider({required super.client});
+  // TODO: add queries for expertises, education levels, countries, company stages, company types, genders, industries, and languages
+}

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -1,12 +1,12 @@
-import 'package:flutter/material.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:mm_flutter_app/__generated/schema/operations_content.graphql.dart';
-import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+// import 'package:flutter/material.dart';
+// import 'package:graphql_flutter/graphql_flutter.dart';
+// import 'package:mm_flutter_app/__generated/schema/operations_content.graphql.dart';
+// import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
 
-import 'base/base_provider.dart';
-import 'base/operation_result.dart';
+// import 'base/base_provider.dart';
+// import 'base/operation_result.dart';
 
-class ContentProvider extends BaseProvider {
-  ContentProvider({required super.client});
-  // TODO: add queries for expertises, education levels, countries, company stages, company types, genders, industries, and languages
-}
+// class ContentProvider extends BaseProvider {
+//   ContentProvider({required super.client});
+//   // TODO: add queries for expertises, education levels, countries, company stages, company types, genders, industries, and languages
+// }

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -25,7 +25,9 @@ class ContentProvider extends BaseProvider {
   List<Industry>? _industries;
   List<Language>? _languages;
 
-  ContentProvider({required super.client});
+  ContentProvider({required super.client}) {
+    debugPrint('ContentProvider initialized');
+  }
 
   // one setter for all content options
   void _setAllContentOptions({
@@ -65,6 +67,49 @@ class ContentProvider extends BaseProvider {
     debugPrint('Updated content provider values: ${toString()}');
   }
 
+  // separate setters for each content option
+
+  void _setCompanyStageOptions(List<CompanyStage> companyStages) {
+    _companyStages = companyStages;
+    debugPrint('Updated content provider company stage values: ${toString()}');
+  }
+
+  void _setCompanyTypeOptions(List<CompanyType> companyTypes) {
+    _companyTypes = companyTypes;
+    debugPrint('Updated content provider company type values: ${toString()}');
+  }
+
+  void _setCountryOptions(List<Country> countries) {
+    _countries = countries;
+    debugPrint('Updated content provider country values: ${toString()}');
+  }
+
+  void _setEducationLevelOptions(List<EducationLevel> educationLevels) {
+    _educationLevels = educationLevels;
+    debugPrint(
+        'Updated content provider education level values: ${toString()}');
+  }
+
+  void _setExpertiseOptions(List<Expertise> expertises) {
+    _expertises = expertises;
+    debugPrint('Updated content provider expertise values: ${toString()}');
+  }
+
+  void _setPresetGenderOptions(List<PresetGender> presetGenders) {
+    _presetGenders = presetGenders;
+    debugPrint('Updated content provider preset gender values: ${toString()}');
+  }
+
+  void _setIndustryOptions(List<Industry> industries) {
+    _industries = industries;
+    debugPrint('Updated content provider industry values: ${toString()}');
+  }
+
+  void _setLanguageOptions(List<Language> languages) {
+    _languages = languages;
+    debugPrint('Updated content provider language values: ${toString()}');
+  }
+
   // separate getters for each content option
 
   List<CompanyStage>? get companyStageOptions {
@@ -99,65 +144,16 @@ class ContentProvider extends BaseProvider {
     return _languages;
   }
 
-  // use a query as the primary method for fetching content options
-  Future updateContentOptions({
-    bool fetchFromNetworkOnly = false,
-  }) async {
-    // final List<Future> futures = [
-    //   findCompanyStages(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findCompanyTypes(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findCountries(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findExpertises(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findIndustries(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findLanguages(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findEducationLevels(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    //   findPresetGenders(fetchFromNetworkOnly: fetchFromNetworkOnly),
-    // ];
-    // // await all these at once to avoid multiple blocking calls
-    // final List results = await Future.wait(futures);
-    // _setAllContentOptions(
-    //   companyStages: results[0].response,
-    //   companyTypes: results[1].response,
-    //   countries: results[2].response,
-    //   expertises: results[3].response,
-    //   industries: results[4].response,
-    //   languages: results[5].response,
-    //   educationLevels: results[6].response,
-    //   presetGenders: results[7].response,
-    // );
-
-    // same effect as the above Dart code, but with one GraphQL request instead of 8
-    // casts one type to another, but it's safe because they're all coming from identical graphql queries in operations_content.graphql
-    final data =
-        await findAllOptionsByType(fetchFromNetworkOnly: fetchFromNetworkOnly);
-
-    _setAllContentOptions(
-      companyStages: data.response?.findCompanyStages as List<CompanyStage>?,
-      companyTypes: data.response?.findCompanyTypes as List<CompanyType>?,
-      countries: data.response?.findCountries as List<Country>?,
-      expertises: data.response?.findExpertises as List<Expertise>?,
-      industries: data.response?.findIndustries as List<Industry>?,
-      languages: data.response?.findLanguages as List<Language>?,
-      educationLevels:
-          data.response?.findEducationLevels as List<EducationLevel>?,
-      presetGenders: data.response?.findGenders as List<PresetGender>?,
-    );
-  }
-
   // Queries
 
-  Future<OperationResult<List<Country>>> findCountries({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<Country>>> findCountries() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindCountries,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindCountries.fromJson(
@@ -165,20 +161,18 @@ class ContentProvider extends BaseProvider {
             ).findCountries
           : null,
     );
+    if (result.response != null) _setCountryOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<Expertise>>> findExpertises({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<Expertise>>> findExpertises() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindExpertises,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindExpertises.fromJson(
@@ -186,20 +180,18 @@ class ContentProvider extends BaseProvider {
             ).findExpertises
           : null,
     );
+    if (result.response != null) _setExpertiseOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<Industry>>> findIndustries({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<Industry>>> findIndustries() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindIndustries,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindIndustries.fromJson(
@@ -207,20 +199,18 @@ class ContentProvider extends BaseProvider {
             ).findIndustries
           : null,
     );
+    if (result.response != null) _setIndustryOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<Language>>> findLanguages({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<Language>>> findLanguages() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindLanguages,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindLanguages.fromJson(
@@ -228,20 +218,18 @@ class ContentProvider extends BaseProvider {
             ).findLanguages
           : null,
     );
+    if (result.response != null) _setLanguageOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<CompanyType>>> findCompanyTypes({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<CompanyType>>> findCompanyTypes() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindCompanyTypes,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindCompanyTypes.fromJson(
@@ -249,20 +237,18 @@ class ContentProvider extends BaseProvider {
             ).findCompanyTypes
           : null,
     );
+    if (result.response != null) _setCompanyTypeOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<CompanyStage>>> findCompanyStages({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<CompanyStage>>> findCompanyStages() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindCompanyStages,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindCompanyStages.fromJson(
@@ -270,20 +256,18 @@ class ContentProvider extends BaseProvider {
             ).findCompanyStages
           : null,
     );
+    if (result.response != null) _setCompanyStageOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<EducationLevel>>> findEducationLevels({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<EducationLevel>>> findEducationLevels() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindEducationLevels,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindEducationLevels.fromJson(
@@ -291,20 +275,18 @@ class ContentProvider extends BaseProvider {
             ).findEducationLevels
           : null,
     );
+    if (result.response != null) _setEducationLevelOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<List<PresetGender>>> findPresetGenders({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<List<PresetGender>>> findPresetGenders() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
         document: documentNodeQueryFindGenders,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindGenders.fromJson(
@@ -312,20 +294,19 @@ class ContentProvider extends BaseProvider {
             ).findGenders
           : null,
     );
+    if (result.response != null) _setPresetGenderOptions(result.response!);
+    return result;
   }
 
-  Future<OperationResult<Query$FindAllOptionsByType>> findAllOptionsByType({
-    bool fetchFromNetworkOnly = false,
-  }) async {
+  Future<OperationResult<Query$FindAllOptionsByType>>
+      findAllOptionsByType() async {
     final QueryResult queryResult = await asyncQuery(
       queryOptions: QueryOptions(
-        document: documentNodeQueryFindCountries,
-        fetchPolicy: fetchFromNetworkOnly
-            ? FetchPolicy.networkOnly
-            : FetchPolicy.cacheFirst,
+        document: documentNodeQueryFindAllOptionsByType,
+        fetchPolicy: FetchPolicy.cacheFirst,
       ),
     );
-    return OperationResult(
+    final result = OperationResult(
       gqlQueryResult: queryResult,
       response: queryResult.data != null
           ? Query$FindAllOptionsByType.fromJson(
@@ -333,5 +314,39 @@ class ContentProvider extends BaseProvider {
             )
           : null,
     );
+    if (result.response != null) {
+      _setAllContentOptions(
+        companyStages: result.response?.findCompanyStages
+            .map((e) =>
+                Query$FindCompanyStages$findCompanyStages.fromJson(e.toJson()))
+            .toList(),
+        companyTypes: result.response?.findCompanyTypes
+            .map((e) =>
+                Query$FindCompanyTypes$findCompanyTypes.fromJson(e.toJson()))
+            .toList(),
+        countries: result.response?.findCountries
+            .map((e) => Query$FindCountries$findCountries.fromJson(e.toJson()))
+            .toList(),
+        expertises: result.response?.findExpertises
+            .map(
+                (e) => Query$FindExpertises$findExpertises.fromJson(e.toJson()))
+            .toList(),
+        industries: result.response?.findIndustries
+            .map(
+                (e) => Query$FindIndustries$findIndustries.fromJson(e.toJson()))
+            .toList(),
+        languages: result.response?.findLanguages
+            .map((e) => Query$FindLanguages$findLanguages.fromJson(e.toJson()))
+            .toList(),
+        educationLevels: result.response?.findEducationLevels
+            .map((e) => Query$FindEducationLevels$findEducationLevels.fromJson(
+                e.toJson()))
+            .toList(),
+        presetGenders: result.response?.findGenders
+            .map((e) => Query$FindGenders$findGenders.fromJson(e.toJson()))
+            .toList(),
+      );
+    }
+    return result;
   }
 }

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -157,6 +157,92 @@ class UserProvider extends BaseProvider {
     );
   }
 
+  Widget findMenteeUsers({
+    required Input$FindObjectsOptions optionsInput,
+    required Input$UserListFilter filterInput,
+    required Input$UserInput matchInput,
+    required Widget Function(
+      OperationResult<List<Query$FindMenteeUsers$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return runQuery(
+      document: documentNodeQueryFindMenteeUsers,
+      variables: Variables$Query$FindMenteeUsers(
+              filter: filterInput, options: optionsInput, match: matchInput)
+          .toJson(),
+      onData: (queryResult, {refetch, fetchMore}) {
+        final OperationResult<List<Query$FindMenteeUsers$findUsers>> result =
+            OperationResult(
+          gqlQueryResult: queryResult,
+          response: queryResult.data == null
+              ? null
+              : Query$FindMenteeUsers.fromJson(
+                  queryResult.data!,
+                ).findUsers.map((element) {
+                  if (element.avatarUrl == "") {
+                    return element.copyWith(avatarUrl: null);
+                  }
+                  return element;
+                }).toList(),
+        );
+        return onData(
+          result,
+          refetch: refetch,
+          fetchMore: fetchMore,
+        );
+      },
+      onLoading: onLoading,
+      onError: onError,
+    );
+  }
+
+  Widget findMentorUsers({
+    required Input$FindObjectsOptions optionsInput,
+    required Input$UserListFilter filterInput,
+    required Input$UserInput matchInput,
+    required Widget Function(
+      OperationResult<List<Query$FindMentorUsers$findUsers>> data, {
+      void Function()? refetch,
+      void Function(FetchMoreOptions)? fetchMore,
+    }) onData,
+    Widget Function()? onLoading,
+    Widget Function(String error, {void Function()? refetch})? onError,
+  }) {
+    return runQuery(
+      document: documentNodeQueryFindMentorUsers,
+      variables: Variables$Query$FindMentorUsers(
+              filter: filterInput, options: optionsInput, match: matchInput)
+          .toJson(),
+      onData: (queryResult, {refetch, fetchMore}) {
+        final OperationResult<List<Query$FindMentorUsers$findUsers>> result =
+            OperationResult(
+          gqlQueryResult: queryResult,
+          response: queryResult.data == null
+              ? null
+              : Query$FindMentorUsers.fromJson(
+                  queryResult.data!,
+                ).findUsers.map((element) {
+                  if (element.avatarUrl == "") {
+                    return element.copyWith(avatarUrl: null);
+                  }
+                  return element;
+                }).toList(),
+        );
+        return onData(
+          result,
+          refetch: refetch,
+          fetchMore: fetchMore,
+        );
+      },
+      onLoading: onLoading,
+      onError: onError,
+    );
+  }
+
   // Mutations
   Future<OperationResult<Mutation$SignUpUser$signUpUser>> signUpUser({
     required Input$UserSignUpInput input,

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -10,6 +10,9 @@ import 'base/operation_result.dart';
 
 typedef AuthenticatedUser = Query$GetAuthenticatedUser$getAuthenticatedUser;
 
+typedef MenteeUser = Query$FindMenteeUsers$findUsers;
+typedef MentorUser = Query$FindMentorUsers$findUsers;
+
 class UserProvider extends BaseProvider {
   AuthenticatedUser? _user;
 
@@ -157,89 +160,57 @@ class UserProvider extends BaseProvider {
     );
   }
 
-  Widget findMenteeUsers({
+  Future<OperationResult<List<MenteeUser>>> findMenteeUsers({
     required Input$FindObjectsOptions optionsInput,
     required Input$UserListFilter filterInput,
     required Input$UserInput matchInput,
-    required Widget Function(
-      OperationResult<List<Query$FindMenteeUsers$findUsers>> data, {
-      void Function()? refetch,
-      void Function(FetchMoreOptions)? fetchMore,
-    }) onData,
-    Widget Function()? onLoading,
-    Widget Function(String error, {void Function()? refetch})? onError,
-  }) {
-    return runQuery(
-      document: documentNodeQueryFindMenteeUsers,
-      variables: Variables$Query$FindMenteeUsers(
-              filter: filterInput, options: optionsInput, match: matchInput)
-          .toJson(),
-      onData: (queryResult, {refetch, fetchMore}) {
-        final OperationResult<List<Query$FindMenteeUsers$findUsers>> result =
-            OperationResult(
-          gqlQueryResult: queryResult,
-          response: queryResult.data == null
-              ? null
-              : Query$FindMenteeUsers.fromJson(
-                  queryResult.data!,
-                ).findUsers.map((element) {
-                  if (element.avatarUrl == "") {
-                    return element.copyWith(avatarUrl: null);
-                  }
-                  return element;
-                }).toList(),
-        );
-        return onData(
-          result,
-          refetch: refetch,
-          fetchMore: fetchMore,
-        );
-      },
-      onLoading: onLoading,
-      onError: onError,
+    bool fetchFromNetworkOnly = false,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindMenteeUsers,
+        fetchPolicy: fetchFromNetworkOnly
+            ? FetchPolicy.networkOnly
+            : FetchPolicy.cacheFirst,
+        variables: Variables$Query$FindMenteeUsers(
+                filter: filterInput, options: optionsInput, match: matchInput)
+            .toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindMenteeUsers.fromJson(
+              queryResult.data!,
+            ).findUsers
+          : null,
     );
   }
 
-  Widget findMentorUsers({
+  Future<OperationResult<List<MentorUser>>> findMentorUsers({
     required Input$FindObjectsOptions optionsInput,
     required Input$UserListFilter filterInput,
     required Input$UserInput matchInput,
-    required Widget Function(
-      OperationResult<List<Query$FindMentorUsers$findUsers>> data, {
-      void Function()? refetch,
-      void Function(FetchMoreOptions)? fetchMore,
-    }) onData,
-    Widget Function()? onLoading,
-    Widget Function(String error, {void Function()? refetch})? onError,
-  }) {
-    return runQuery(
-      document: documentNodeQueryFindMentorUsers,
-      variables: Variables$Query$FindMentorUsers(
-              filter: filterInput, options: optionsInput, match: matchInput)
-          .toJson(),
-      onData: (queryResult, {refetch, fetchMore}) {
-        final OperationResult<List<Query$FindMentorUsers$findUsers>> result =
-            OperationResult(
-          gqlQueryResult: queryResult,
-          response: queryResult.data == null
-              ? null
-              : Query$FindMentorUsers.fromJson(
-                  queryResult.data!,
-                ).findUsers.map((element) {
-                  if (element.avatarUrl == "") {
-                    return element.copyWith(avatarUrl: null);
-                  }
-                  return element;
-                }).toList(),
-        );
-        return onData(
-          result,
-          refetch: refetch,
-          fetchMore: fetchMore,
-        );
-      },
-      onLoading: onLoading,
-      onError: onError,
+    bool fetchFromNetworkOnly = false,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindMentorUsers,
+        fetchPolicy: fetchFromNetworkOnly
+            ? FetchPolicy.networkOnly
+            : FetchPolicy.cacheFirst,
+        variables: Variables$Query$FindMentorUsers(
+                filter: filterInput, options: optionsInput, match: matchInput)
+            .toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindMentorUsers.fromJson(
+              queryResult.data!,
+            ).findUsers
+          : null,
     );
   }
 

--- a/lib/schema/operations_content.graphql
+++ b/lib/schema/operations_content.graphql
@@ -1,3 +1,42 @@
+query FindAllOptionsByType {
+  findCompanyStages {
+    textId
+    translatedValue
+  }
+  findCompanyTypes {
+    textId
+    translatedValue
+  }
+  findCountries {
+    alpha2Key
+    textId
+    translatedValue
+  }
+  findEducationLevels {
+    textId
+    translatedValue
+  }
+  findExpertises {
+    textId
+    translatedValue
+  }
+  findIndustries {
+    textId
+    translatedValue
+  }
+  findGenders {
+    textId
+    translatedValue
+  }
+  findLanguages {
+    textId
+    translatedValue
+    isUiLanguage
+    shortLangCode
+    longLangCode
+  }
+}
+
 query FindCompanyStages {
   findCompanyStages {
     textId

--- a/lib/schema/operations_content.graphql
+++ b/lib/schema/operations_content.graphql
@@ -1,0 +1,75 @@
+query FindCompanyStages {
+  findCompanyStages {
+    textId
+    translatedValue
+  }
+}
+
+query FindCompanyStages {
+  findCompanyTypes {
+    textId
+    translatedValue
+  }
+}
+
+query FindCountries {
+  findCountries {
+    alpha2Key
+    textId
+    translatedValue
+  }
+}
+
+query FindCountriesInLanguage($uiLanguage: UiLanguage) {
+  findCountries(uiLanguage: $uiLanguage) {
+    alpha2Key
+    textId
+    translatedValue
+  }
+}
+
+query FindEducationLevels {
+  findEducationLevels {
+    textId
+    translatedValue
+  }
+}
+
+query FindExpertises {
+  findExpertises {
+    textId
+    translatedValue
+  }
+}
+
+query FindIndustries {
+  findIndustries {
+    textId
+    translatedValue
+  }
+}
+
+query FindGenders {
+  findGenders {
+    textId
+    translatedValue
+  }
+}
+
+query FindLanguages {
+  findLanguages {
+    textId
+    translatedValue
+    isUiLanguage
+    shortLangCode
+    longLangCode
+  }
+}
+
+query FindAllOptions() {
+  findOptions() {
+    textId
+    translatedValue
+    optionType
+  }
+}

--- a/lib/schema/operations_content.graphql
+++ b/lib/schema/operations_content.graphql
@@ -5,7 +5,7 @@ query FindCompanyStages {
   }
 }
 
-query FindCompanyStages {
+query FindCompanyTypes {
   findCompanyTypes {
     textId
     translatedValue

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -14,16 +14,20 @@ query FindAllUsers ($filter: UserListFilter) {
     findUsers(filter: $filter) {
         id
         email
+        firstName
+        lastName
         fullName
         avatarUrl
         userHandle
     }
 }
 
-query FindMenteeUsers($options: FindObjectsOptions, $filter2: UserListFilter, $match2: UserInput) {
-    findUsers(options: $options, filter: $filter2, match: $match2) {
+query FindMenteeUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
+    findUsers(options: $options, filter: $filter, match: $match) {
         id
         email
+        firstName
+        lastName
         fullName
         avatarUrl
         userHandle
@@ -53,10 +57,12 @@ query FindMenteeUsers($options: FindObjectsOptions, $filter2: UserListFilter, $m
 
 query FindMentorUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
     findUsers(options: $options, filter: $filter, match: $match) {
+        id
+        email
         firstName
         lastName
         fullName
-        email
+        avatarUrl
         userHandle
         cityOfResidence
         regionOfResidence

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -34,21 +34,25 @@ query FindMenteeUsers($options: FindObjectsOptions, $filter: UserListFilter, $ma
         cityOfResidence
         regionOfResidence
         countryOfResidence {
+            textId
             translatedValue
         }
         jobTitle
         groupMemberships {
             ... on MenteesGroupMembership {
                 soughtExpertises {
+                    textId
                     translatedValue
                 }
                 industry {
+                    textId
                     translatedValue
                 }
             }
         }
         companies {
             companyStage {
+                textId
                 translatedValue
             }
         }
@@ -67,6 +71,7 @@ query FindMentorUsers($options: FindObjectsOptions, $filter: UserListFilter, $ma
         cityOfResidence
         regionOfResidence
         countryOfResidence {
+            textId
             translatedValue
         }
         jobTitle
@@ -74,9 +79,11 @@ query FindMentorUsers($options: FindObjectsOptions, $filter: UserListFilter, $ma
             groupId
             ... on MentorsGroupMembership {
                 expertises {
+                    textId
                     translatedValue
                 }
                 industries {
+                    textId
                     translatedValue
                 }
                 endorsements

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -20,6 +20,65 @@ query FindAllUsers ($filter: UserListFilter) {
     }
 }
 
+query FindMenteeUsers($options: FindObjectsOptions, $filter2: UserListFilter, $match2: UserInput) {
+    findUsers(options: $options, filter: $filter2, match: $match2) {
+        id
+        email
+        fullName
+        avatarUrl
+        userHandle
+        cityOfResidence
+        regionOfResidence
+        countryOfResidence {
+            translatedValue
+        }
+        jobTitle
+        groupMemberships {
+            ... on MenteesGroupMembership {
+                soughtExpertises {
+                    translatedValue
+                }
+                industry {
+                    translatedValue
+                }
+            }
+        }
+        companies {
+            companyStage {
+                translatedValue
+            }
+        }
+    }
+}
+
+query FindMentorUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
+    findUsers(options: $options, filter: $filter, match: $match) {
+        firstName
+        lastName
+        fullName
+        email
+        userHandle
+        cityOfResidence
+        regionOfResidence
+        countryOfResidence {
+            translatedValue
+        }
+        jobTitle
+        groupMemberships {
+            groupId
+            ... on MentorsGroupMembership {
+                expertises {
+                    translatedValue
+                }
+                industries {
+                    translatedValue
+                }
+                endorsements
+            }
+        }
+    }
+}
+
 query FindUsersWithFilter ($filter: UserListFilter) {
     findUsers(filter: $filter) {
         id

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -1059,7 +1059,7 @@ input UserInput {
 }
 
 input ModelEventInput {
-  time: DateTime! = "2023-07-31T21:39:59.808Z"
+  time: DateTime! = "2023-08-01T15:27:38.856Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -13,9 +13,14 @@ type GroupMembership implements IGroupMembership {
   groupIdent: String!
   userId: ID!
   roles: [GroupMembershipRole!]!
+  expertises: [Expertise!]!
+  industries: [Industry!]!
+  industry: Industry
+  soughtExpertises: [Expertise!]!
 }
 
 interface IGroupMembership {
+  id: ID!
   groupId: ID!
   groupIdent: String!
   userId: ID!
@@ -50,6 +55,120 @@ interface BaseModelMetadata {
   updatedAt: DateTime
 }
 
+type Expertise {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
+enum OptionType {
+  educationLevel
+  expertise
+  industry
+  companyStage
+  companyType
+  country
+  gender
+  language
+  unset
+}
+
+enum UiLanguage {
+  ar
+  en
+  es
+  id
+  ru
+  so
+}
+
+type Option {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
+type Industry {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
 type MenteesGroupMembership implements IGroupMembership {
   id: ID!
   adminNotes: String
@@ -65,8 +184,16 @@ type MenteesGroupMembership implements IGroupMembership {
   groupIdent: String!
   userId: ID!
   roles: [GroupMembershipRole!]!
-  soughtExpertises: [String!]!
-  industry: String
+  expertises: [Expertise!]!
+  industries: [Industry!]!
+  industry: Industry
+  soughtExpertises: [Expertise!]!
+
+  """Must match expertise ids or textIds."""
+  soughtExpertisesTextIds: [String!]
+
+  """Must match industry ids or textIds."""
+  industryTextId: String
   actionsTaken: String
   currentChallenges: String
   futureGoals: String
@@ -88,12 +215,20 @@ type MentorsGroupMembership implements IGroupMembership {
   groupIdent: String!
   userId: ID!
   roles: [GroupMembershipRole!]!
-  expertises: [String!]!
-  industries: [String!]!
-  website: String
+  expertises: [Expertise!]!
+  industries: [Industry!]!
+  industry: Industry
+  soughtExpertises: [Expertise!]!
+
+  """Must match expertise ids or textIds."""
+  expertisesTextIds: [String!]
+
+  """Must match industry ids or textIds."""
+  industriesTextIds: [String!]
   helpICanOffer: String
   expectationsForMentees: String
   menteePreparationInstructions: String
+  endorsements: Int
 }
 
 type UserMetadata implements BaseModelMetadata {
@@ -119,6 +254,7 @@ type Query {
   findUsers(options: FindObjectsOptions, match: UserInput, filter: UserListFilter): [User!]!
   getAvailableUserHandleField(startValue: String!): User!
   getAuthenticatedUser: User!
+  getMyUser: User!
   findUserDeviceById(id: String!): UserDevice!
   findUserDevices(options: FindObjectsOptions, match: UserDeviceInput, filter: SidUserDeviceListFilter): [UserDevice!]!
   findChannelInvitationById(id: String!): ChannelInvitation!
@@ -130,8 +266,15 @@ type Query {
   findChannelMessageById(id: String!): ChannelMessage!
   findChannelMessages(options: FindObjectsOptions, match: ChannelMessageInput, filter: ChannelMessageListFilter): [ChannelMessage!]!
   findChannelParticipantById(id: String!): ChannelParticipant!
-  findOptions(parentTextId: String, optionType: OptionType): [Option!]!
-  findOptionValues(language: Language, parentTextId: String, optionType: OptionType): [String!]!
+  findOptions(uiLanguage: UiLanguage, isParent: Boolean, parentTextId: String, optionType: OptionType!): [Option!]!
+  findCompanyStages(uiLanguage: UiLanguage): [CompanyStage!]!
+  findCompanyTypes(uiLanguage: UiLanguage): [CompanyType!]!
+  findCountries(uiLanguage: UiLanguage): [Country!]!
+  findEducationLevels(uiLanguage: UiLanguage): [EducationLevel!]!
+  findExpertises(uiLanguage: UiLanguage, isParent: Boolean, parentTextId: String): [Expertise!]!
+  findGenders(uiLanguage: UiLanguage): [Gender!]!
+  findIndustries(uiLanguage: UiLanguage): [Industry!]!
+  findLanguages(uiLanguage: UiLanguage): [Language!]!
   apiVersion: String!
   healthReport: SystemHealthReport!
   findGroupMembershipById(id: String!): GroupMembership!
@@ -237,7 +380,7 @@ type User {
   gender: String
   cityOfResidence: String
   regionOfResidence: String
-  countryOfResidence: String
+  countryOfResidenceTextId: String
   postalCode: String
   avatarUrl: String
   jobTitle: String
@@ -245,8 +388,8 @@ type User {
   authType: AuthType
   tfaBackupCodes: String
   passwordUpdatedAt: DateTime
-  preferredLanguage: String!
-  uiLanguage: String!
+  preferredLanguage: UiLanguage
+  uiLanguage: UiLanguage
   spokenLanguages: [String!]!
   roles: [UserRole!]!
   appFeatures: [AppFeature!]
@@ -270,12 +413,11 @@ type User {
   birthYear: Int
   genderSelfDescribed: String
   ethnicity: String
-  educationLevel: EducationLevel
+  educationLevelTextId: String
   professionalBackground: String
   yearsManagementExperience: Int
   yearsOwnershipExperience: Int
   ssoIdp: String
-  profileCompletionPercentage: Int
 
   """This attribute is only used by the MM2 synchronizer."""
   mm2Id: String
@@ -285,6 +427,11 @@ type User {
 
   """This is the MM2 password hash."""
   mm2PasswordHash: String
+
+  """
+  Users can enter a short description to be prominently displayed along with their name and other info.
+  """
+  oneLiner: String
   user: User!
   latestUserDevice: UserDevice!
   unreadInAppMessages: [Notification!]!
@@ -292,15 +439,18 @@ type User {
   channelInvitations: [ChannelInvitation!]!
   channelParticipants: [ChannelParticipant!]!
   companies: [Company!]!
+  countryOfResidence: Country
   groupMembers: [GroupMembership!]!
   groups: [Group!]!
   inbox: [UserInbox!]!
+  profileCompletionPercentage: Int!
   userSearches: [UserSearch!]!
 }
 
 type LabeledStringValue {
   label: String
   value: String!
+  tags: [String!]
 }
 
 enum AuthType {
@@ -383,14 +533,7 @@ type UserDevice {
   oAuthRefreshToken: String!
   pushNotificationToken: String!
   trustedAt: DateTime
-  uiLanguage: String!
-}
-
-enum EducationLevel {
-  doctorate
-  undergraduate
-  secondary
-  primary
+  uiLanguage: UiLanguage
 }
 
 type Notification {
@@ -622,9 +765,9 @@ type Company {
   name: String!
   description: String
   foundedAt: DateTime
-  companyType: CompanyType
-  companyStage: CompanyStage
-  website: String
+  companyTypeTextId: String
+  companyStageTextId: String
+  websites: [LabeledStringValue!]
   industries: [String!]
   isOperational: Boolean
   isFundraising: Boolean
@@ -640,20 +783,42 @@ type Company {
   If a Company was created from the imported from MM2, mm2CompanyRole is either "mentor" or "mentee". This attribute is only used by the MM2 synchronizer.
   """
   mm2CompanyRole: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
 }
 
-enum CompanyType {
-  forProfit
-  nonProfit
-  socialEnterprise
-  unsure
-}
+type Country {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
 
-enum CompanyStage {
-  idea
-  operational
-  earning
-  profitable
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+  alpha2Key: String!
+  alpha3Key: String!
 }
 
 type Group {
@@ -799,7 +964,7 @@ enum UserIdentType {
 
 input FindObjectsOptions {
   limit: Int
-  sort: String
+  sort: [SortItem!]
   skip: Int
   timeout: Boolean
   tailable: Boolean
@@ -813,6 +978,16 @@ input FindObjectsOptions {
   allowPartialResults: Boolean
   showRecordId: Boolean
   includeDeleted: Boolean
+}
+
+input SortItem {
+  field: String! = ""
+  direction: SortDirection = asc
+}
+
+enum SortDirection {
+  asc
+  desc
 }
 
 input UserInput {
@@ -839,7 +1014,7 @@ input UserInput {
   gender: String
   cityOfResidence: String
   regionOfResidence: String
-  countryOfResidence: String
+  countryOfResidenceTextId: String
   postalCode: String
   avatarUrl: String
   jobTitle: String
@@ -849,8 +1024,8 @@ input UserInput {
   newPassword: String
   tfaBackupCodes: String
   passwordUpdatedAt: String
-  preferredLanguage: String
-  uiLanguage: String
+  preferredLanguage: UiLanguage
+  uiLanguage: UiLanguage
   spokenLanguages: [String!]! = []
   roles: [UserRole!]! = []
   appFeatures: [AppFeature!]
@@ -871,15 +1046,20 @@ input UserInput {
   birthYear: Int
   genderSelfDescribed: String
   ethnicity: String
-  educationLevel: EducationLevel
+  educationLevelTextId: String
   professionalBackground: String
   yearsManagementExperience: Int
   yearsOwnershipExperience: Int
   ssoIdp: String
+
+  """
+  Users can enter a short description to be prominently displayed along with their name and other info.
+  """
+  oneLiner: String
 }
 
 input ModelEventInput {
-  time: DateTime! = "2023-06-26T19:59:47.783Z"
+  time: DateTime! = "2023-07-31T21:39:59.808Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -891,6 +1071,7 @@ input BaseModelMetadataInput {
 input LabeledStringValueInput {
   label: String
   value: String
+  tags: [String!]
 }
 
 input UserPreferencesInput {
@@ -918,7 +1099,7 @@ input UserListFilter {
   createdAtUntil: String
   updatedAtFrom: String
   updatedAtUntil: String
-  roles: [UserRole!]
+  rolesIn: [UserRole!]
   companyId: ID
   syncedWithMm2: Boolean
 }
@@ -966,7 +1147,7 @@ input UserDeviceInput {
   oAuthRefreshToken: String
   pushNotificationToken: String
   trustedAt: String
-  uiLanguage: String
+  uiLanguage: UiLanguage
 }
 
 input SidUserDeviceListFilter {
@@ -1004,6 +1185,12 @@ input ChannelInput {
   archivedAt: String
   archivedBy: ID
   assumedMentorId: ID
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: String
 }
 
 input ChannelListFilter {
@@ -1065,7 +1252,7 @@ input ChannelMessageListFilter {
   seen: Boolean
 }
 
-type Option {
+type CompanyStage {
   id: ID!
   adminNotes: String
   events: [ModelEvent!]
@@ -1082,26 +1269,149 @@ type Option {
   optionType: OptionType!
   value: String!
   translatedValue: String
+  language: UiLanguage
 
   """This attribute is only used by the MM2 synchronizer."""
   mm2Id: String
+  mm2Value: String
 
   """This attribute is only used by the MM2 synchronizer."""
   syncedWithMm2At: DateTime
-  childOptions: [Option!]!
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
 }
 
-enum OptionType {
-  expertise
-  industry
-  gender
-  unset
+type CompanyType {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
 }
 
-enum Language {
-  en
-  es
-  id
+type EducationLevel {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
+type Gender {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
+type Language {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+  isUiLanguage: Boolean!
+
+  """ISO 639-1, 2 letter language code. e.g. "en" for English."""
+  shortLangCode: String
+
+  """ISO 639-2, 3 letter language code. e.g. "eng" for English."""
+  longLangCode: String
 }
 
 """Server health report"""
@@ -1434,7 +1744,6 @@ type Mutation {
   createChannelParticipant(input: ChannelParticipantInput!): ChannelParticipant!
   deleteChannelParticipant(deletePhysically: Boolean!, channelParticipantId: String!): String!
   updateChannelParticipant(input: ChannelParticipantInput!): String!
-  runDataGenerator(input: GenRequest!): Boolean!
   createGroupMembership(input: GroupMembershipInput!): ServiceRequest!
   createMenteesGroupMembership(input: MenteesGroupMembershipInput!): ServiceRequest!
   createMentorsGroupMembership(input: MentorsGroupMembershipInput!): ServiceRequest!
@@ -1569,108 +1878,6 @@ input ChannelParticipantInput {
   role: ChannelParticipantRole
 }
 
-input GenRequest {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  clearDb: Boolean! = false
-  conversationCount: Int! = 0
-  messageCount: Int! = 0
-  users: GenUserInput! = {count: 0, emailDomain: "micromentor.org"}
-  groups: GenGroupsInput! = {count: 0, specificGroups: []}
-  publishAppEvents: Boolean! = false
-}
-
-input GenUserInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  count: Int! = 0
-  dualRoleCount: Int
-  emailDomain: String! = "micromentor.org"
-  emailPrefix: String
-  mentorCount: Int
-  menteeCount: Int
-  mentorRatio: Float
-}
-
-input GenGroupsInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  count: Int! = 0
-  specificGroups: [GenSpecificGroupInput!]!
-}
-
-input GenSpecificGroupInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  name: String! = ""
-  mentorCount: Int
-  menteeCount: Int
-  groupRules: [GenGroupRuleInput!]
-  matchingEngine: GenMatchingEngineInput
-}
-
-input GenGroupRuleInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  someGroupRule: Boolean! = false
-  someOtherGroupRule: Boolean! = false
-}
-
-input GenMatchingEngineInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  someMatchingRule: Boolean! = false
-  someOtherMatchingRule: Boolean! = false
-}
-
 type ServiceRequest {
   id: ID!
   serviceRequestType: ServiceRequestType!
@@ -1725,6 +1932,11 @@ enum ServiceRequestType {
   graphQlQueryUserCompanies
   graphQlQueryUserGroupMembers
   graphQlQueryUserGroups
+  graphQlQueryFindCountries
+  graphQlQueryFindExpertises
+  graphQlQueryFindIndustries
+  graphQlQueryFindOptions
+  unset
   graphQlMutationRunDataGenerator
   graphQlMutationExecuteAdminTask
   graphQlMutationSignUpOAuthUser
@@ -1787,7 +1999,6 @@ enum ServiceRequestType {
   graphQlQueryGetMultiStepActionProgress
   graphQlQueryLatestUserDevice
   graphQlQueryUserUserDevices
-  unset
 }
 
 enum ModelType {
@@ -1896,8 +2107,12 @@ input MenteesGroupMembershipInput {
   groupId: ID
   userId: ID
   roles: [GroupMembershipRole!]! = []
-  soughtExpertises: [String!]! = []
-  industry: String
+
+  """Must match expertise ids or textIds."""
+  soughtExpertisesTextIds: [String!]! = []
+
+  """Must match industry id or textId."""
+  industryTextId: String
   actionsTaken: String
   currentChallenges: String
   futureGoals: String
@@ -1918,12 +2133,16 @@ input MentorsGroupMembershipInput {
   groupId: ID
   userId: ID
   roles: [GroupMembershipRole!]! = []
-  expertises: [String!]! = []
-  industries: [String!]! = []
-  website: String
+
+  """Must match expertise ids or textIds."""
+  expertisesTextIds: [String!]! = []
+
+  """Must match industry ids or textIds."""
+  industriesTextIds: [String!]! = []
   helpICanOffer: String
   expectationsForMentees: String
   menteePreparationInstructions: String
+  endorsements: Int
 }
 
 input NotificationInput {
@@ -2110,6 +2329,11 @@ enum Mm2ModelType {
   Conversation
   Message
   User
+  MenteeExpertise
+  MenteeWebsite
+  MentorExpertise
+  Profile
+  SpokenLanguage
 }
 
 enum Mm2SynchronizationMode {
@@ -2123,6 +2347,7 @@ type Mm2SynchronizationResult {
   createdCount: Int!
   deletedCount: Int!
   updatedCount: Int!
+  skippedCount: Int!
   errorCount: Int!
   error: String
 }

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -786,6 +786,70 @@ type Company {
 
   """This attribute is only used by the MM2 synchronizer."""
   syncedWithMm2At: DateTime
+  companyStage: CompanyStage
+  companyType: CompanyType
+}
+
+type CompanyStage {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
+}
+
+type CompanyType {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTime!
+  createdBy: ID
+  updatedAt: DateTime
+  updatedBy: ID
+  deletedAt: DateTime
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTime
+  childOptions: [Option!]
+  parentOption: [Option!]
+  childExpertises: [Expertise!]
+  parentExpertise: Expertise
 }
 
 type Country {
@@ -1059,7 +1123,7 @@ input UserInput {
 }
 
 input ModelEventInput {
-  time: DateTime! = "2023-08-01T15:27:38.856Z"
+  time: DateTime! = "2023-08-02T20:56:51.049Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -1250,68 +1314,6 @@ input ChannelMessageListFilter {
   includeChannelMessageType: [ChannelMessageType!]
   received: Boolean
   seen: Boolean
-}
-
-type CompanyStage {
-  id: ID!
-  adminNotes: String
-  events: [ModelEvent!]
-  metadata: BaseModelMetadata
-  createdAt: DateTime!
-  createdBy: ID
-  updatedAt: DateTime
-  updatedBy: ID
-  deletedAt: DateTime
-  deletedBy: ID
-  textId: String!
-  parentTextId: String
-  isParent: Boolean
-  optionType: OptionType!
-  value: String!
-  translatedValue: String
-  language: UiLanguage
-
-  """This attribute is only used by the MM2 synchronizer."""
-  mm2Id: String
-  mm2Value: String
-
-  """This attribute is only used by the MM2 synchronizer."""
-  syncedWithMm2At: DateTime
-  childOptions: [Option!]
-  parentOption: [Option!]
-  childExpertises: [Expertise!]
-  parentExpertise: Expertise
-}
-
-type CompanyType {
-  id: ID!
-  adminNotes: String
-  events: [ModelEvent!]
-  metadata: BaseModelMetadata
-  createdAt: DateTime!
-  createdBy: ID
-  updatedAt: DateTime
-  updatedBy: ID
-  deletedAt: DateTime
-  deletedBy: ID
-  textId: String!
-  parentTextId: String
-  isParent: Boolean
-  optionType: OptionType!
-  value: String!
-  translatedValue: String
-  language: UiLanguage
-
-  """This attribute is only used by the MM2 synchronizer."""
-  mm2Id: String
-  mm2Value: String
-
-  """This attribute is only used by the MM2 synchronizer."""
-  syncedWithMm2At: DateTime
-  childOptions: [Option!]
-  parentOption: [Option!]
-  childExpertises: [Expertise!]
-  parentExpertise: Expertise
 }
 
 type EducationLevel {
@@ -1720,6 +1722,9 @@ type SidMultiStepActionProgress {
 }
 
 type Mutation {
+  createCompany(input: CompanyInput!): Company!
+  deleteCompany(deletePhysically: Boolean!, companyId: String!): ServiceRequest!
+  updateCompany(input: CompanyInput!): ServiceRequest!
   signInUser(input: UserSignInInput!): UserAuthResponse!
   signMeOut: String!
   signUpUser(input: UserSignUpInput!): UserAuthResponse!
@@ -1782,25 +1787,7 @@ type Mutation {
   verifyMultiStepActionToken(input: VerifyMultiStepActionTokenInput!): SidMultiStepActionProgress!
 }
 
-"""API response to userSignIn/userSignOut"""
-type UserAuthResponse {
-  userId: String!
-  deviceId: String!
-  deviceUuid: String!
-  authToken: String!
-  authTokenExpiresAt: DateTime
-}
-
-"""User sign in input data"""
-input UserSignInInput {
-  ident: String
-  identType: UserIdentType
-  deviceUuid: String
-  password: String
-}
-
-"""User sign up input data"""
-input UserSignUpInput {
+input CompanyInput {
   id: ID
   adminNotes: String
   events: [ModelEventInput!]
@@ -1811,71 +1798,18 @@ input UserSignUpInput {
   updatedBy: ID
   deletedAt: String
   deletedBy: ID
-  firstName: String
-  lastName: String
-  fullName: String
-  userHandle: String
-  email: String
-  phoneNumber: String
-  password: String
-  source: String
-  deviceUuid: String! = ""
-  timezone: String
-  pushNotificationToken: String
-  checkAvailable: Boolean! = true
-}
-
-input ChannelInvitationInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  channelId: ID
-  senderId: ID
-  recipientId: ID
-  channelName: String
-  channelTopic: String
-  messageText: String
-  dismissedFromInboxBySenderAt: String
-  dismissedFromInboxByRecipientAt: String
-  status: ChannelInvitationStatus
-}
-
-input BgAddChannelMessageEventInput {
-  channelId: ID! = ""
-  messageIds: [ID!]! = []
-  recipientId: ID! = ""
-  event: ChannelMessageEvent! = unset
-}
-
-enum ChannelMessageEvent {
-  received
-  seen
-  unset
-}
-
-input ChannelParticipantInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: String
-  createdBy: ID
-  updatedAt: String
-  updatedBy: ID
-  deletedAt: String
-  deletedBy: ID
-  channelId: ID
-  userId: ID
-  invitedBy: ID
-  channelName: String
-  role: ChannelParticipantRole
+  name: String
+  description: String
+  companyTypeTextId: String
+  companyStageTextId: String
+  foundedAt: String
+  websites: [LabeledStringValueInput!]
+  industries: [String!]
+  isOperational: Boolean
+  isFundraising: Boolean
+  annualRevenue: Int
+  employeeCount: Int
+  addUserIds: [String!]
 }
 
 type ServiceRequest {
@@ -1903,6 +1837,9 @@ type ServiceRequest {
 enum ServiceRequestType {
   graphQlQueryUserInbox
   graphQlQueryUserUserSearches
+  graphQlMutationCreateCompany
+  graphQlMutationDeleteCompany
+  graphQlMutationUpdateCompany
   graphQlMutationAddChannelMessageEvent
   graphQlMutationCreateChannel
   graphQlMutationCreateChannelInvitation
@@ -2093,6 +2030,102 @@ enum ErrorCode {
   authTokenNoMatch
 }
 
+"""API response to userSignIn/userSignOut"""
+type UserAuthResponse {
+  userId: String!
+  deviceId: String!
+  deviceUuid: String!
+  authToken: String!
+  authTokenExpiresAt: DateTime
+}
+
+"""User sign in input data"""
+input UserSignInInput {
+  ident: String
+  identType: UserIdentType
+  deviceUuid: String
+  password: String
+}
+
+"""User sign up input data"""
+input UserSignUpInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: String
+  createdBy: ID
+  updatedAt: String
+  updatedBy: ID
+  deletedAt: String
+  deletedBy: ID
+  firstName: String
+  lastName: String
+  fullName: String
+  userHandle: String
+  email: String
+  phoneNumber: String
+  password: String
+  source: String
+  deviceUuid: String! = ""
+  timezone: String
+  pushNotificationToken: String
+  checkAvailable: Boolean! = true
+}
+
+input ChannelInvitationInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: String
+  createdBy: ID
+  updatedAt: String
+  updatedBy: ID
+  deletedAt: String
+  deletedBy: ID
+  channelId: ID
+  senderId: ID
+  recipientId: ID
+  channelName: String
+  channelTopic: String
+  messageText: String
+  dismissedFromInboxBySenderAt: String
+  dismissedFromInboxByRecipientAt: String
+  status: ChannelInvitationStatus
+}
+
+input BgAddChannelMessageEventInput {
+  channelId: ID! = ""
+  messageIds: [ID!]! = []
+  recipientId: ID! = ""
+  event: ChannelMessageEvent! = unset
+}
+
+enum ChannelMessageEvent {
+  received
+  seen
+  unset
+}
+
+input ChannelParticipantInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: String
+  createdBy: ID
+  updatedAt: String
+  updatedBy: ID
+  deletedAt: String
+  deletedBy: ID
+  channelId: ID
+  userId: ID
+  invitedBy: ID
+  channelName: String
+  role: ChannelParticipantRole
+}
+
 input MenteesGroupMembershipInput {
   id: ID
   adminNotes: String
@@ -2142,7 +2175,6 @@ input MentorsGroupMembershipInput {
   helpICanOffer: String
   expectationsForMentees: String
   menteePreparationInstructions: String
-  endorsements: Int
 }
 
 input NotificationInput {

--- a/lib/widgets/atoms/reminder_banner.dart
+++ b/lib/widgets/atoms/reminder_banner.dart
@@ -106,7 +106,7 @@ class MaybeReminderBanner extends StatelessWidget {
       return const SizedBox(width: 0.0, height: 0.0);
     }, onData: (data, {refetch, fetchMore}) {
       int profileCompletionPercentage =
-          data.response!.profileCompletionPercentage ?? 0;
+          data.response!.profileCompletionPercentage;
       DateTime updatedAt = data.response!.updatedAt!;
       if (profileCompletionPercentage < 50) {
         return ReminderBanner(

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -3,6 +3,7 @@ import * as generators from "./util/generators";
 
 export function mockMutations(serverState: MockServerState) {
     return {
+        // users
         deleteUser: () => {
             serverState.loggedIn= false;
         },
@@ -16,6 +17,7 @@ export function mockMutations(serverState: MockServerState) {
             serverState.loggedIn = false;
             return "ok";
         },
+        // channels, channel invitations and channel messages
         createChannel: () => {
             const channel = generators.generateChannel([serverState.loggedInUser, serverState.otherUsers[1]])
             serverState.channels.push(channel);
@@ -29,7 +31,7 @@ export function mockMutations(serverState: MockServerState) {
         createChannelMessage: (_: any, args: { input: { channelId: string, messageText: string , replyToMessageId: string | null}}) => {
             const message = generators.generateChannelMessage(
                 args.input.messageText,
-                args.input.channelId,
+                serverState.channels.find((element) => element.id == args.input.channelId),
                 serverState.loggedInUser,
                 new Date(),
                 true,

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -1,19 +1,10 @@
 import { MockServerState } from "./util/state";
+import * as constants from "./util/constants";
 import * as generators from "./util/generators";
 
 export function mockQueries(serverState: MockServerState) {
     return {
-        findChannelById: () => {
-            var channel = serverState.channels[0];
-            channel.latestMessage = serverState.channelMessages[serverState.channelMessages.length-1];
-            return channel;
-        },
-        findChannelMessages: () => {
-            return serverState.channelMessages;
-        },
-        findChannelsForUser: () => {
-            return serverState.channels;
-        },
+        // users
         findUsers: () => {
             return serverState.otherUsers.concat([serverState.loggedInUser]);
         },
@@ -22,6 +13,18 @@ export function mockQueries(serverState: MockServerState) {
                 return null;
             }
             return serverState.loggedInUser;
+        },
+        // channels, channel invitations and channel messages
+        findChannelById: () => {
+            var channel = serverState.channels[0];
+            channel.latestMessage = serverState.channelMessages[serverState.channelMessages.length - 1];
+            return channel;
+        },
+        findChannelMessages: () => {
+            return serverState.channelMessages;
+        },
+        findChannelsForUser: () => {
+            return serverState.channels;
         },
         myInbox: () => {
             return {
@@ -34,11 +37,40 @@ export function mockQueries(serverState: MockServerState) {
                         serverState.channelInboxItemInvitations[1],
                     ],
                     unseenMessages: [
-                        generators.generateChannelInboxItemMessage(serverState.channels[0].id, serverState.loggedInUser),
-                        generators.generateChannelInboxItemMessage(serverState.channels[0].id, serverState.otherUsers[0]),
+                        generators.generateChannelInboxItemMessage(serverState.channels[0], serverState.loggedInUser),
+                        generators.generateChannelInboxItemMessage(serverState.channels[0], serverState.otherUsers[0]),
                     ],
                 }
             }
+        },
+        // content service
+        findCompanyStages: () => {
+            return constants.companyStages;
+        },
+        findCompanyTypes: () => {
+            return constants.companyTypes;
+        },
+        findCountries: () => {
+            return constants.countries;
+        },
+        findEducationLevels: () => {
+            return constants.educationLevels;
+        },
+        findExpertises: () => {
+            return constants.expertises;
+        },
+        findGenders: () => {
+            return constants.genders;
+        },
+        findIndustries: () => {
+            return constants.industries;
+        },
+        findLanguages: () => {
+            return constants.languages;
+        },
+        // groups
+        findGroups: () => {
+            return serverState.groups;
         },
     }
 }

--- a/mm-mock-server/src/mocks/util/constants.ts
+++ b/mm-mock-server/src/mocks/util/constants.ts
@@ -1,0 +1,568 @@
+// some values from the backend, copy-pasted/hard coded as constants here.
+// we could make this list smaller if this file is too long. it was easy to copy-paste the entire lists of values.
+
+// expertises
+
+export const expertises = [
+  {
+    textId: 'accountingAndFinance', mm2Id: 'ACCOUNTING_AND_FINANCE',
+    value: 'Accounting and Finance',
+    translatedValue: 'Accounting and Finance',
+  },
+  {
+    textId: 'humanResources', mm2Id: 'HUMAN_RESOURCES',
+    value: 'Human Resources',
+    translatedValue: 'Human Resources',
+  },
+  {
+    textId: 'international', mm2Id: 'INTERNATIONAL',
+    value: 'International',
+    translatedValue: 'International',
+  },
+  {
+    textId: 'lawAndLegal', mm2Id: 'LAW_AND_LEGAL',
+    value: 'Law and Legal',
+    translatedValue: 'Law and Legal',
+  },
+  {
+    textId: 'management', mm2Id: 'MANAGEMENT',
+    value: 'Management',
+    translatedValue: 'Management',
+  },
+  {
+    textId: 'marketing', mm2Id: 'MARKETING',
+    value: 'Marketing',
+    translatedValue: 'Marketing',
+  },
+  {
+    textId: 'operations', mm2Id: 'OPERATIONS',
+    value: 'Operations',
+    translatedValue: 'Operations',
+  },
+  {
+    textId: 'sales', mm2Id: 'SALES',
+    value: 'Sales',
+    translatedValue: 'Sales',
+  },
+  {
+    textId: 'startingUp', mm2Id: 'STARTING_UP',
+    value: 'Starting Up',
+    translatedValue: 'Starting Up',
+  },
+  {
+    textId: 'sustainability', mm2Id: 'SUSTAINABILITY',
+    value: 'Sustainability',
+    translatedValue: 'Sustainability',
+  },
+  {
+    textId: 'technologyAndInternet', mm2Id: 'TECHNOLOGY_AND_INTERNET',
+    value: 'Technology and Internet',
+    translatedValue: 'Technology and Internet',
+  },
+];
+
+// industries
+
+export const industries = [{
+  textId: 'accountingAndTaxServices',
+  mm2Id: 'ACCOUNTING_AND_TAX_SERVICES',
+  value: 'Accounting and Tax Services',
+  translatedValue: 'Accounting and Tax Services',
+},
+{
+  textId: 'agriculture',
+  mm2Id: 'AGRICULTURE',
+  value: 'Agriculture',
+  translatedValue: 'Agriculture',
+},
+{
+  textId: 'animalsAndPets',
+  mm2Id: 'ANIMALS_AND_PETS',
+  value: 'Animals and Pets',
+  translatedValue: 'Animals and Pets',
+},
+{
+  textId: 'architectureAndEngineering',
+  mm2Id: 'ARCHITECTURE_AND_ENGINEERING',
+  value: 'Architecture and Engineering',
+  translatedValue: 'Architecture and Engineering',
+},
+{
+  textId: 'artisanAndCraftWork',
+  mm2Id: 'ARTISAN_AND_CRAFT_WORK',
+  value: 'Artisan and Craft Work',
+  translatedValue: 'Artisan and Craft Work',
+},
+{
+  textId: 'autoAndBikeMechanic',
+  mm2Id: 'AUTO_AND_BIKE_MECHANIC',
+  value: 'Auto and Bike Mechanic',
+  translatedValue: 'Auto and Bike Mechanic',
+},
+{
+  textId: 'beauty',
+  mm2Id: 'BEAUTY',
+  value: 'Beauty',
+  translatedValue: 'Beauty',
+},
+{
+  textId: 'bookstore',
+  mm2Id: 'BOOKSTORE',
+  value: 'Bookstore',
+  translatedValue: 'Bookstore',
+},
+{
+  textId: 'businessConsultingAndCoaching',
+  mm2Id: 'BUSINESS_CONSULTING_AND_COACHING',
+  value: 'Business Consulting and Coaching',
+  translatedValue: 'Business Consulting and Coaching',
+},
+{
+  textId: 'childcare',
+  mm2Id: 'CHILDCARE',
+  value: 'Childcare',
+  translatedValue: 'Childcare',
+},
+{
+  textId: 'cleaningServices',
+  mm2Id: 'CLEANING_SERVICES',
+  value: 'Cleaning Services',
+  translatedValue: 'Cleaning Services',
+},
+{
+  textId: 'constructionAndContracting',
+  mm2Id: 'CONSTRUCTION_AND_CONTRACTING',
+  value: 'Construction and Contracting',
+  translatedValue: 'Construction and Contracting',
+},
+{
+  textId: 'counselingAndMentalHealth',
+  mm2Id: 'COUNSELING_AND_MENTAL_HEALTH',
+  value: 'Counseling and Mental Health',
+  translatedValue: 'Counseling and Mental Health',
+},
+{
+  textId: 'digitalMarketingAndSocialMedia',
+  mm2Id: 'DIGITAL_MARKETING_AND_SOCIAL_MEDIA',
+  value: 'Digital Marketing and Social Media',
+  translatedValue: 'Digital Marketing and Social Media',
+},
+{
+  textId: 'disabilityServices',
+  mm2Id: 'DISABILITY_SERVICES',
+  value: 'Disability Services',
+  translatedValue: 'Disability Services',
+},
+{
+  textId: 'distributionAndLogistics',
+  mm2Id: 'DISTRIBUTION_AND_LOGISTICS',
+  value: 'Distribution and Logistics',
+  translatedValue: 'Distribution and Logistics',
+},
+{
+  textId: 'eCommerce',
+  mm2Id: 'E_COMMERCE',
+  value: 'E-Commerce',
+  translatedValue: 'E-Commerce',
+},
+{
+  textId: 'education',
+  mm2Id: 'EDUCATION',
+  value: 'Education',
+  translatedValue: 'Education',
+},
+{
+  textId: 'elderAndHomeHealthCare',
+  mm2Id: 'ELDER_AND_HOME_HEALTH_CARE',
+  value: 'Elder and Home Health Care',
+  translatedValue: 'Elder and Home Health Care',
+},
+{
+  textId: 'entertainmentAndEvents',
+  mm2Id: 'ENTERTAINMENT_AND_EVENTS',
+  value: 'Entertainment and Events',
+  translatedValue: 'Entertainment and Events',
+},
+{
+  textId: 'exportAndImport',
+  mm2Id: 'EXPORT_AND_IMPORT',
+  value: 'Export and Import',
+  translatedValue: 'Export and Import',
+},
+{
+  textId: 'fashion',
+  mm2Id: 'FASHION',
+  value: 'Fashion',
+  translatedValue: 'Fashion',
+},
+{
+  textId: 'financialServicesAndInsurance',
+  mm2Id: 'FINANCIAL_SERVICES_AND_INSURANCE',
+  value: 'Financial Services and Insurance',
+  translatedValue: 'Financial Services and Insurance',
+},
+{
+  textId: 'flowersAndGifts',
+  mm2Id: 'FLOWERS_AND_GIFTS',
+  value: 'Flowers and Gifts',
+  translatedValue: 'Flowers and Gifts',
+},
+{
+  textId: 'foodAndGrocery',
+  mm2Id: 'FOOD_AND_GROCERY',
+  value: 'Food and Grocery',
+  translatedValue: 'Food and Grocery',
+},
+{
+  textId: 'forestry',
+  mm2Id: 'FORESTRY',
+  value: 'Forestry',
+  translatedValue: 'Forestry',
+},
+{
+  textId: 'furniture',
+  mm2Id: 'FURNITURE',
+  value: 'Furniture',
+  translatedValue: 'Furniture',
+},
+{
+  textId: 'graphicAndWebDesign',
+  mm2Id: 'GRAPHIC_AND_WEB_DESIGN',
+  value: 'Graphic and Web Design',
+  translatedValue: 'Graphic and Web Design',
+},
+{
+  textId: 'healthAndWellness',
+  mm2Id: 'HEALTH_AND_WELLNESS',
+  value: 'Health and Wellness',
+  translatedValue: 'Health and Wellness',
+},
+{
+  textId: 'informationTechnologyServices',
+  mm2Id: 'INFORMATION_TECHNOLOGY_SERVICES',
+  value: 'Information Technology Services',
+  translatedValue: 'Information Technology Services',
+},
+{
+  textId: 'jewelryAndLuxuryGoods',
+  mm2Id: 'JEWELRY_AND_LUXURY_GOODS',
+  value: 'Jewelry and Luxury Goods',
+  translatedValue: 'Jewelry and Luxury Goods',
+},
+{
+  textId: 'landscaping',
+  mm2Id: 'LANDSCAPING',
+  value: 'Landscaping',
+  translatedValue: 'Landscaping',
+},
+{
+  textId: 'laundryAndTailoring',
+  mm2Id: 'LAUNDRY_AND_TAILORING',
+  value: 'Laundry and Tailoring',
+  translatedValue: 'Laundry and Tailoring',
+},
+{
+  textId: 'legalServices',
+  mm2Id: 'LEGAL_SERVICES',
+  value: 'Legal Services',
+  translatedValue: 'Legal Services',
+},
+{
+  textId: 'manufacturing',
+  mm2Id: 'MANUFACTURING',
+  value: 'Manufacturing',
+  translatedValue: 'Manufacturing',
+},
+{
+  textId: 'marketingAndAdvertising',
+  mm2Id: 'MARKETING_AND_ADVERTISING',
+  value: 'Marketing and Advertising',
+  translatedValue: 'Marketing and Advertising',
+},
+{
+  textId: 'mediaAndPublishing',
+  mm2Id: 'MEDIA_AND_PUBLISHING',
+  value: 'Media and Publishing',
+  translatedValue: 'Media and Publishing',
+},
+{
+  textId: 'nonprofitAndSocialEnterprise',
+  mm2Id: 'NONPROFIT_AND_SOCIAL_ENTERPRISE',
+  value: 'Nonprofit and Social Enterprise',
+  translatedValue: 'Nonprofit and Social Enterprise',
+},
+{
+  textId: 'performingArts',
+  mm2Id: 'PERFORMING_ARTS',
+  value: 'Performing Arts',
+  translatedValue: 'Performing Arts',
+},
+{
+  textId: 'personalAndExecutiveAssistance',
+  mm2Id: 'PERSONAL_AND_EXECUTIVE_ASSISTANCE',
+  value: 'Personal and Executive Assistance',
+  translatedValue: 'Personal and Executive Assistance',
+},
+{
+  textId: 'photographyAndAvServices',
+  mm2Id: 'PHOTOGRAPHY_AND_AV_SERVICES',
+  value: 'Photography and A/V Services',
+  translatedValue: 'Photography and A/V Services',
+},
+{
+  textId: 'publicRelations',
+  mm2Id: 'PUBLIC_RELATIONS',
+  value: 'Public Relations',
+  translatedValue: 'Public Relations',
+},
+{
+  textId: 'realEstate',
+  mm2Id: 'REAL_ESTATE',
+  value: 'Real Estate',
+  translatedValue: 'Real Estate',
+},
+{
+  textId: 'recreationAndOutdoorFitness',
+  mm2Id: 'RECREATION_AND_OUTDOOR_FITNESS',
+  value: 'Recreation and Outdoor Fitness',
+  translatedValue: 'Recreation and Outdoor Fitness',
+},
+{
+  textId: 'recruitingAndStaffing',
+  mm2Id: 'RECRUITING_AND_STAFFING',
+  value: 'Recruiting and Staffing',
+  translatedValue: 'Recruiting and Staffing',
+},
+{
+  textId: 'restaurantAndCatering',
+  mm2Id: 'RESTAURANT_AND_CATERING',
+  value: 'Restaurant and Catering',
+  translatedValue: 'Restaurant and Catering',
+},
+{
+  textId: 'retail',
+  mm2Id: 'RETAIL',
+  value: 'Retail',
+  translatedValue: 'Retail',
+},
+{
+  textId: 'sustainability',
+  mm2Id: 'SUSTAINABILITY',
+  value: 'Sustainability',
+  translatedValue: 'Sustainability',
+},
+{
+  textId: 'taxiAndLimoServices',
+  mm2Id: 'TAXI_AND_LIMO_SERVICES',
+  value: 'Taxi and Limo Services',
+  translatedValue: 'Taxi and Limo Services',
+},
+{
+  textId: 'translationAndLocalization',
+  mm2Id: 'TRANSLATION_AND_LOCALIZATION',
+  value: 'Translation and Localization',
+  translatedValue: 'Translation and Localization',
+},
+{
+  textId: 'travelAndHospitality',
+  mm2Id: 'TRAVEL_AND_HOSPITALITY',
+  value: 'Travel and Hospitality',
+  translatedValue: 'Travel and Hospitality',
+},
+{
+  textId: 'veterinary',
+  mm2Id: 'VETERINARY',
+  value: 'Veterinary',
+  translatedValue: 'Veterinary',
+},
+{
+  textId: 'webAndTechnology',
+  mm2Id: 'WEB_AND_TECHNOLOGY',
+  value: 'Web and Technology',
+  translatedValue: 'Web and Technology',
+},
+{
+  textId: 'wineAndSpirits',
+  mm2Id: 'WINE_AND_SPIRITS',
+  value: 'Wine and Spirits',
+  translatedValue: 'Wine and Spirits',
+},
+{
+  textId: 'writingAndEditing',
+  mm2Id: 'WRITING_AND_EDITING',
+  value: 'Writing and Editing',
+  translatedValue: 'Writing and Editing',
+},
+];
+
+// languages
+
+export const languages = [
+  { 'mm2Value': 'ara', 'textId': 'ar', 'shortLangCode': 'ar', 'longLangCode': 'ara', 'value': 'Arabic', 'translatedValue': 'Arabic', 'isUiLanguage': true },
+  { 'mm2Value': 'ben', 'textId': 'bn', 'shortLangCode': 'bn', 'longLangCode': 'ben', 'value': 'Bengali', 'translatedValue': 'Bengali' },
+  { 'mm2Value': 'mya', 'textId': 'my', 'shortLangCode': 'my', 'longLangCode': 'mya', 'value': 'Burmese', 'translatedValue': 'Burmese' },
+  { 'mm2Value': 'yue', 'textId': 'zh', 'shortLangCode': 'zh', 'longLangCode': 'yue', 'value': 'Cantonese', 'translatedValue': 'Cantonese' },
+  { 'mm2Value': 'eng', 'textId': 'en', 'shortLangCode': 'en', 'longLangCode': 'eng', 'value': 'English', 'translatedValue': 'English', 'isUiLanguage': true },
+  { 'mm2Value': 'fra', 'textId': 'fr', 'shortLangCode': 'fr', 'longLangCode': 'fra', 'value': 'French', 'translatedValue': 'French' },
+  { 'mm2Value': 'deu', 'textId': 'de', 'shortLangCode': 'de', 'longLangCode': 'deu', 'value': 'German', 'translatedValue': 'German' },
+  { 'mm2Value': 'hin', 'textId': 'hi', 'shortLangCode': 'hi', 'longLangCode': 'hin', 'value': 'Hindi', 'translatedValue': 'Hindi' },
+  { 'mm2Value': 'hat', 'textId': 'ht', 'shortLangCode': 'ht', 'longLangCode': 'hat', 'value': 'Haitian', 'translatedValue': 'Haitian' },
+  { 'mm2Value': 'ind', 'textId': 'id', 'shortLangCode': 'id', 'longLangCode': 'ind', 'value': 'Bahasa Indonesia', 'translatedValue': 'Bahasa Indonesia', 'isUiLanguage': true },
+  { 'mm2Value': 'jpn', 'textId': 'ja', 'shortLangCode': 'ja', 'longLangCode': 'jpn', 'value': 'Japanese', 'translatedValue': 'Japanese' },
+  { 'mm2Value': 'kor', 'textId': 'ko', 'shortLangCode': 'ko', 'longLangCode': 'kor', 'value': 'Korean', 'translatedValue': 'Korean' },
+  { 'mm2Value': 'cmn', 'textId': 'zh', 'shortLangCode': 'zh', 'longLangCode': 'cmn', 'value': 'Mandarin', 'translatedValue': 'Mandarin' },
+  { 'mm2Value': 'por', 'textId': 'pt', 'shortLangCode': 'pt', 'longLangCode': 'por', 'value': 'Portuguese', 'translatedValue': 'Portuguese' },
+  { 'mm2Value': 'rus', 'textId': 'ru', 'shortLangCode': 'ru', 'longLangCode': 'rus', 'value': 'Russian', 'translatedValue': 'Russian', 'isUiLanguage': true },
+  { 'mm2Value': 'slk', 'textId': 'sk', 'shortLangCode': 'sk', 'longLangCode': 'slk', 'value': 'Slovak', 'translatedValue': 'Slovak' },
+  { 'mm2Value': 'som', 'textId': 'so', 'shortLangCode': 'so', 'longLangCode': 'som', 'value': 'Somali', 'translatedValue': 'Somali', 'isUiLanguage': true },
+  { 'mm2Value': 'spa', 'textId': 'es', 'shortLangCode': 'es', 'longLangCode': 'spa', 'value': 'Spanish', 'translatedValue': 'Spanish', 'isUiLanguage': true },
+  { 'mm2Value': 'tgl', 'textId': 'tl', 'shortLangCode': 'tl', 'longLangCode': 'tgl', 'value': 'Tagalog', 'translatedValue': 'Tagalog' },
+  { 'mm2Value': 'tha', 'textId': 'th', 'shortLangCode': 'th', 'longLangCode': 'tha', 'value': 'Thai', 'translatedValue': 'Thai' },
+  { 'mm2Value': 'urd', 'textId': 'ur', 'shortLangCode': 'ur', 'longLangCode': 'urd', 'value': 'Urdu', 'translatedValue': 'Urdu' },
+  { 'mm2Value': 'vie', 'textId': 'vi', 'shortLangCode': 'vi', 'longLangCode': 'vie', 'value': 'Vietnamese', 'translatedValue': 'Vietnamese' },
+]
+
+// company stages
+
+export const companyStages = [
+  {
+    textId: 'idea',
+    value: 'Idea',
+    translatedValue: 'Idea',
+    mm2Value: 'idea',
+  },
+  {
+    textId: 'operational',
+    value: 'Operational',
+    translatedValue: 'Operational',
+    mm2Value: 'operational',
+  },
+  {
+    textId: 'earning',
+    value: 'Earning',
+    translatedValue: 'Earning',
+    mm2Value: 'earning',
+  },
+  {
+    textId: 'profitable',
+    value: 'Profitable',
+    translatedValue: 'Profitable',
+    mm2Value: 'profitable',
+  },
+]
+
+// company types
+
+export const companyTypes = [
+  {
+    textId: 'forProfit',
+    value: 'For-profit venture',
+    translatedValue: 'For-profit venture',
+    mm2Value: 'for-profit',
+  },
+  {
+    textId: 'nonProfit',
+    value: 'Non-profit organization',
+    translatedValue: 'Non-profit organization',
+    mm2Value: 'non-profit',
+  },
+  {
+    textId: 'socialEnterprise',
+    value: 'Social enterprise',
+    translatedValue: 'Social enterprise',
+    mm2Value: 'social_enterprise',
+  },
+  {
+    textId: 'unsure',
+    value: 'Unsure',
+    translatedValue: 'Unsure',
+    mm2Value: 'unsure',
+  },
+]
+
+// education levels
+
+export const educationLevels = [
+  {
+    textId: 'doctorate',
+    value: 'Doctorate - PhD',
+    translatedValue: 'Doctorate - PhD',
+    mm2Value: 'Doctorate - PhD',
+  },
+  {
+    textId: 'postgraduate',
+    value: 'Postgraduate - Master\'s Degree/Honors Degree/J.D.',
+    translatedValue: 'Postgraduate - Master\'s Degree/Honors Degree/J.D.',
+    mm2Value: 'Postgraduate - Master\'s Degree/Honors Degree/J.D.',
+  },
+  {
+    textId: 'undergraduate',
+    value: 'Undergraduate - Bachelor\'s Degree',
+    translatedValue: 'Undergraduate - Bachelor\'s Degree',
+    mm2Value: 'Undergraduate - Bachelor\'s Degree',
+  },
+  {
+    textId: 'postSecondary',
+    value: 'Post-Secondary - Technical or Vocational Degree',
+    translatedValue: 'Post-Secondary - Technical or Vocational Degree',
+    mm2Value: 'Post-Secondary - Technical or Vocational Degree',
+  },
+  {
+    textId: 'highSchool',
+    value: 'Secondary - High School',
+    translatedValue: 'Secondary - High School',
+    mm2Value: 'Secondary - High School',
+  },
+  {
+    textId: 'middleSchool',
+    value: 'Secondary - Middle School or Junior High',
+    translatedValue: 'Secondary - Middle School or Junior High',
+    mm2Value: 'Secondary - Middle School or Junior High',
+  },
+  {
+    textId: 'primary',
+    value: 'Primary - Elementary School',
+    translatedValue: 'Primary - Elementary School',
+    mm2Value: 'Primary - Elementary School',
+  },
+];
+
+// countries
+
+export const countries = [{ "alpha2Key": "AF", "alpha3Key": "AFG", "value": "Afghanistan", "translatedValue": "Afghanistan", "textId": "AF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AL", "alpha3Key": "ALB", "value": "Albania", "translatedValue": "Albania", "textId": "AL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DZ", "alpha3Key": "DZA", "value": "Algeria", "translatedValue": "Algeria", "textId": "DZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AS", "alpha3Key": "ASM", "value": "American Samoa", "translatedValue": "American Samoa", "textId": "AS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AD", "alpha3Key": "AND", "value": "Andorra", "translatedValue": "Andorra", "textId": "AD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AO", "alpha3Key": "AGO", "value": "Angola", "translatedValue": "Angola", "textId": "AO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AI", "alpha3Key": "AIA", "value": "Anguilla", "translatedValue": "Anguilla", "textId": "AI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AQ", "alpha3Key": "ATA", "value": "Antarctica", "translatedValue": "Antarctica", "textId": "AQ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AG", "alpha3Key": "ATG", "value": "Antigua and Barbuda", "translatedValue": "Antigua and Barbuda", "textId": "AG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AR", "alpha3Key": "ARG", "value": "Argentina", "translatedValue": "Argentina", "textId": "AR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AM", "alpha3Key": "ARM", "value": "Armenia", "translatedValue": "Armenia", "textId": "AM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AW", "alpha3Key": "ABW", "value": "Aruba", "translatedValue": "Aruba", "textId": "AW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AU", "alpha3Key": "AUS", "value": "Australia", "translatedValue": "Australia", "textId": "AU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AT", "alpha3Key": "AUT", "value": "Austria", "translatedValue": "Austria", "textId": "AT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AZ", "alpha3Key": "AZE", "value": "Azerbaijan", "translatedValue": "Azerbaijan", "textId": "AZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BS", "alpha3Key": "BHS", "value": "Bahamas", "translatedValue": "Bahamas", "textId": "BS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BH", "alpha3Key": "BHR", "value": "Bahrain", "translatedValue": "Bahrain", "textId": "BH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BD", "alpha3Key": "BGD", "value": "Bangladesh", "translatedValue": "Bangladesh", "textId": "BD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BB", "alpha3Key": "BRB", "value": "Barbados", "translatedValue": "Barbados", "textId": "BB", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BY", "alpha3Key": "BLR", "value": "Belarus", "translatedValue": "Belarus", "textId": "BY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BE", "alpha3Key": "BEL", "value": "Belgium", "translatedValue": "Belgium", "textId": "BE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BZ", "alpha3Key": "BLZ", "value": "Belize", "translatedValue": "Belize", "textId": "BZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BJ", "alpha3Key": "BEN", "value": "Benin", "translatedValue": "Benin", "textId": "BJ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BM", "alpha3Key": "BMU", "value": "Bermuda", "translatedValue": "Bermuda", "textId": "BM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BT", "alpha3Key": "BTN", "value": "Bhutan", "translatedValue": "Bhutan", "textId": "BT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BO", "alpha3Key": "BOL", "value": "Bolivia", "translatedValue": "Bolivia", "textId": "BO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BA", "alpha3Key": "BIH", "value": "Bosnia and Herzegovina", "translatedValue": "Bosnia and Herzegovina", "textId": "BA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BW", "alpha3Key": "BWA", "value": "Botswana", "translatedValue": "Botswana", "textId": "BW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BV", "alpha3Key": "BVT", "value": "Bouvet Island", "translatedValue": "Bouvet Island", "textId": "BV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BR", "alpha3Key": "BRA", "value": "Brazil", "translatedValue": "Brazil", "textId": "BR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IO", "alpha3Key": "IOT", "value": "British Indian Ocean Territory", "translatedValue": "British Indian Ocean Territory", "textId": "IO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BN", "alpha3Key": "BRN", "value": "Brunei Darussalam", "translatedValue": "Brunei Darussalam", "textId": "BN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BG", "alpha3Key": "BGR", "value": "Bulgaria", "translatedValue": "Bulgaria", "textId": "BG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BF", "alpha3Key": "BFA", "value": "Burkina Faso", "translatedValue": "Burkina Faso", "textId": "BF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BI", "alpha3Key": "BDI", "value": "Burundi", "translatedValue": "Burundi", "textId": "BI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KH", "alpha3Key": "KHM", "value": "Cambodia", "translatedValue": "Cambodia", "textId": "KH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CM", "alpha3Key": "CMR", "value": "Cameroon", "translatedValue": "Cameroon", "textId": "CM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CA", "alpha3Key": "CAN", "value": "Canada", "translatedValue": "Canada", "textId": "CA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CV", "alpha3Key": "CPV", "value": "Cape Verde", "translatedValue": "Cape Verde", "textId": "CV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KY", "alpha3Key": "CYM", "value": "Cayman Islands", "translatedValue": "Cayman Islands", "textId": "KY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CF", "alpha3Key": "CAF", "value": "Central African Republic", "translatedValue": "Central African Republic", "textId": "CF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TD", "alpha3Key": "TCD", "value": "Chad", "translatedValue": "Chad", "textId": "TD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CL", "alpha3Key": "CHL", "value": "Chile", "translatedValue": "Chile", "textId": "CL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CN", "alpha3Key": "CHN", "value": "People's Republic of China", "translatedValue": "People's Republic of China", "textId": "CN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CX", "alpha3Key": "CXR", "value": "Christmas Island", "translatedValue": "Christmas Island", "textId": "CX", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CC", "alpha3Key": "CCK", "value": "Cocos (Keeling) Islands", "translatedValue": "Cocos (Keeling) Islands", "textId": "CC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CO", "alpha3Key": "COL", "value": "Colombia", "translatedValue": "Colombia", "textId": "CO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KM", "alpha3Key": "COM", "value": "Comoros", "translatedValue": "Comoros", "textId": "KM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CG", "alpha3Key": "COG", "value": "Republic of the Congo", "translatedValue": "Republic of the Congo", "textId": "CG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CD", "alpha3Key": "COD", "value": "Democratic Republic of the Congo", "translatedValue": "Democratic Republic of the Congo", "textId": "CD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CK", "alpha3Key": "COK", "value": "Cook Islands", "translatedValue": "Cook Islands", "textId": "CK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CR", "alpha3Key": "CRI", "value": "Costa Rica", "translatedValue": "Costa Rica", "textId": "CR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CI", "alpha3Key": "CIV", "value": "Cote D'Ivoire", "translatedValue": "Cote D'Ivoire", "textId": "CI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HR", "alpha3Key": "HRV", "value": "Croatia", "translatedValue": "Croatia", "textId": "HR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CU", "alpha3Key": "CUB", "value": "Cuba", "translatedValue": "Cuba", "textId": "CU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CY", "alpha3Key": "CYP", "value": "Cyprus", "translatedValue": "Cyprus", "textId": "CY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CZ", "alpha3Key": "CZE", "value": "Czech Republic", "translatedValue": "Czech Republic", "textId": "CZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DK", "alpha3Key": "DNK", "value": "Denmark", "translatedValue": "Denmark", "textId": "DK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DJ", "alpha3Key": "DJI", "value": "Djibouti", "translatedValue": "Djibouti", "textId": "DJ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DM", "alpha3Key": "DMA", "value": "Dominica", "translatedValue": "Dominica", "textId": "DM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DO", "alpha3Key": "DOM", "value": "Dominican Republic", "translatedValue": "Dominican Republic", "textId": "DO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "EC", "alpha3Key": "ECU", "value": "Ecuador", "translatedValue": "Ecuador", "textId": "EC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "EG", "alpha3Key": "EGY", "value": "Egypt", "translatedValue": "Egypt", "textId": "EG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SV", "alpha3Key": "SLV", "value": "El Salvador", "translatedValue": "El Salvador", "textId": "SV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GQ", "alpha3Key": "GNQ", "value": "Equatorial Guinea", "translatedValue": "Equatorial Guinea", "textId": "GQ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ER", "alpha3Key": "ERI", "value": "Eritrea", "translatedValue": "Eritrea", "textId": "ER", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "EE", "alpha3Key": "EST", "value": "Estonia", "translatedValue": "Estonia", "textId": "EE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ET", "alpha3Key": "ETH", "value": "Ethiopia", "translatedValue": "Ethiopia", "textId": "ET", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FK", "alpha3Key": "FLK", "value": "Falkland Islands (Malvinas)", "translatedValue": "Falkland Islands (Malvinas)", "textId": "FK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FO", "alpha3Key": "FRO", "value": "Faroe Islands", "translatedValue": "Faroe Islands", "textId": "FO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FJ", "alpha3Key": "FJI", "value": "Fiji", "translatedValue": "Fiji", "textId": "FJ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FI", "alpha3Key": "FIN", "value": "Finland", "translatedValue": "Finland", "textId": "FI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FR", "alpha3Key": "FRA", "value": "France", "translatedValue": "France", "textId": "FR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GF", "alpha3Key": "GUF", "value": "French Guiana", "translatedValue": "French Guiana", "textId": "GF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PF", "alpha3Key": "PYF", "value": "French Polynesia", "translatedValue": "French Polynesia", "textId": "PF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TF", "alpha3Key": "ATF", "value": "French Southern Territories", "translatedValue": "French Southern Territories", "textId": "TF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GA", "alpha3Key": "GAB", "value": "Gabon", "translatedValue": "Gabon", "textId": "GA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GM", "alpha3Key": "GMB", "value": "Republic of The Gambia", "translatedValue": "Republic of The Gambia", "textId": "GM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GE", "alpha3Key": "GEO", "value": "Georgia", "translatedValue": "Georgia", "textId": "GE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "DE", "alpha3Key": "DEU", "value": "Germany", "translatedValue": "Germany", "textId": "DE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GH", "alpha3Key": "GHA", "value": "Ghana", "translatedValue": "Ghana", "textId": "GH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GI", "alpha3Key": "GIB", "value": "Gibraltar", "translatedValue": "Gibraltar", "textId": "GI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GR", "alpha3Key": "GRC", "value": "Greece", "translatedValue": "Greece", "textId": "GR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GL", "alpha3Key": "GRL", "value": "Greenland", "translatedValue": "Greenland", "textId": "GL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GD", "alpha3Key": "GRD", "value": "Grenada", "translatedValue": "Grenada", "textId": "GD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GP", "alpha3Key": "GLP", "value": "Guadeloupe", "translatedValue": "Guadeloupe", "textId": "GP", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GU", "alpha3Key": "GUM", "value": "Guam", "translatedValue": "Guam", "textId": "GU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GT", "alpha3Key": "GTM", "value": "Guatemala", "translatedValue": "Guatemala", "textId": "GT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GN", "alpha3Key": "GIN", "value": "Guinea", "translatedValue": "Guinea", "textId": "GN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GW", "alpha3Key": "GNB", "value": "Guinea-Bissau", "translatedValue": "Guinea-Bissau", "textId": "GW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GY", "alpha3Key": "GUY", "value": "Guyana", "translatedValue": "Guyana", "textId": "GY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HT", "alpha3Key": "HTI", "value": "Haiti", "translatedValue": "Haiti", "textId": "HT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HM", "alpha3Key": "HMD", "value": "Heard Island and McDonald Islands", "translatedValue": "Heard Island and McDonald Islands", "textId": "HM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VA", "alpha3Key": "VAT", "value": "Holy See (Vatican City State)", "translatedValue": "Holy See (Vatican City State)", "textId": "VA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HN", "alpha3Key": "HND", "value": "Honduras", "translatedValue": "Honduras", "textId": "HN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HK", "alpha3Key": "HKG", "value": "Hong Kong", "translatedValue": "Hong Kong", "textId": "HK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "HU", "alpha3Key": "HUN", "value": "Hungary", "translatedValue": "Hungary", "textId": "HU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IS", "alpha3Key": "ISL", "value": "Iceland", "translatedValue": "Iceland", "textId": "IS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IN", "alpha3Key": "IND", "value": "India", "translatedValue": "India", "textId": "IN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ID", "alpha3Key": "IDN", "value": "Indonesia", "translatedValue": "Indonesia", "textId": "ID", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IR", "alpha3Key": "IRN", "value": "Islamic Republic of Iran", "translatedValue": "Islamic Republic of Iran", "textId": "IR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IQ", "alpha3Key": "IRQ", "value": "Iraq", "translatedValue": "Iraq", "textId": "IQ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IE", "alpha3Key": "IRL", "value": "Ireland", "translatedValue": "Ireland", "textId": "IE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IL", "alpha3Key": "ISR", "value": "Israel", "translatedValue": "Israel", "textId": "IL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IT", "alpha3Key": "ITA", "value": "Italy", "translatedValue": "Italy", "textId": "IT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "JM", "alpha3Key": "JAM", "value": "Jamaica", "translatedValue": "Jamaica", "textId": "JM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "JP", "alpha3Key": "JPN", "value": "Japan", "translatedValue": "Japan", "textId": "JP", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "JO", "alpha3Key": "JOR", "value": "Jordan", "translatedValue": "Jordan", "textId": "JO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KZ", "alpha3Key": "KAZ", "value": "Kazakhstan", "translatedValue": "Kazakhstan", "textId": "KZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KE", "alpha3Key": "KEN", "value": "Kenya", "translatedValue": "Kenya", "textId": "KE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KI", "alpha3Key": "KIR", "value": "Kiribati", "translatedValue": "Kiribati", "textId": "KI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KP", "alpha3Key": "PRK", "value": "North Korea", "translatedValue": "North Korea", "textId": "KP", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KR", "alpha3Key": "KOR", "value": "South Korea", "translatedValue": "South Korea", "textId": "KR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KW", "alpha3Key": "KWT", "value": "Kuwait", "translatedValue": "Kuwait", "textId": "KW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KG", "alpha3Key": "KGZ", "value": "Kyrgyzstan", "translatedValue": "Kyrgyzstan", "textId": "KG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LA", "alpha3Key": "LAO", "value": "Lao People's Democratic Republic", "translatedValue": "Lao People's Democratic Republic", "textId": "LA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LV", "alpha3Key": "LVA", "value": "Latvia", "translatedValue": "Latvia", "textId": "LV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LB", "alpha3Key": "LBN", "value": "Lebanon", "translatedValue": "Lebanon", "textId": "LB", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LS", "alpha3Key": "LSO", "value": "Lesotho", "translatedValue": "Lesotho", "textId": "LS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LR", "alpha3Key": "LBR", "value": "Liberia", "translatedValue": "Liberia", "textId": "LR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LY", "alpha3Key": "LBY", "value": "Libya", "translatedValue": "Libya", "textId": "LY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LI", "alpha3Key": "LIE", "value": "Liechtenstein", "translatedValue": "Liechtenstein", "textId": "LI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LT", "alpha3Key": "LTU", "value": "Lithuania", "translatedValue": "Lithuania", "textId": "LT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LU", "alpha3Key": "LUX", "value": "Luxembourg", "translatedValue": "Luxembourg", "textId": "LU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MO", "alpha3Key": "MAC", "value": "Macao", "translatedValue": "Macao", "textId": "MO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MG", "alpha3Key": "MDG", "value": "Madagascar", "translatedValue": "Madagascar", "textId": "MG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MW", "alpha3Key": "MWI", "value": "Malawi", "translatedValue": "Malawi", "textId": "MW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MY", "alpha3Key": "MYS", "value": "Malaysia", "translatedValue": "Malaysia", "textId": "MY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MV", "alpha3Key": "MDV", "value": "Maldives", "translatedValue": "Maldives", "textId": "MV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ML", "alpha3Key": "MLI", "value": "Mali", "translatedValue": "Mali", "textId": "ML", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MT", "alpha3Key": "MLT", "value": "Malta", "translatedValue": "Malta", "textId": "MT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MH", "alpha3Key": "MHL", "value": "Marshall Islands", "translatedValue": "Marshall Islands", "textId": "MH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MQ", "alpha3Key": "MTQ", "value": "Martinique", "translatedValue": "Martinique", "textId": "MQ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MR", "alpha3Key": "MRT", "value": "Mauritania", "translatedValue": "Mauritania", "textId": "MR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MU", "alpha3Key": "MUS", "value": "Mauritius", "translatedValue": "Mauritius", "textId": "MU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "YT", "alpha3Key": "MYT", "value": "Mayotte", "translatedValue": "Mayotte", "textId": "YT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MX", "alpha3Key": "MEX", "value": "Mexico", "translatedValue": "Mexico", "textId": "MX", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "FM", "alpha3Key": "FSM", "value": "Micronesia, Federated States of", "translatedValue": "Micronesia, Federated States of", "textId": "FM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MD", "alpha3Key": "MDA", "value": "Moldova, Republic of", "translatedValue": "Moldova, Republic of", "textId": "MD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MC", "alpha3Key": "MCO", "value": "Monaco", "translatedValue": "Monaco", "textId": "MC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MN", "alpha3Key": "MNG", "value": "Mongolia", "translatedValue": "Mongolia", "textId": "MN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MS", "alpha3Key": "MSR", "value": "Montserrat", "translatedValue": "Montserrat", "textId": "MS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MA", "alpha3Key": "MAR", "value": "Morocco", "translatedValue": "Morocco", "textId": "MA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MZ", "alpha3Key": "MOZ", "value": "Mozambique", "translatedValue": "Mozambique", "textId": "MZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MM", "alpha3Key": "MMR", "value": "Myanmar", "translatedValue": "Myanmar", "textId": "MM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NA", "alpha3Key": "NAM", "value": "Namibia", "translatedValue": "Namibia", "textId": "NA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NR", "alpha3Key": "NRU", "value": "Nauru", "translatedValue": "Nauru", "textId": "NR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NP", "alpha3Key": "NPL", "value": "Nepal", "translatedValue": "Nepal", "textId": "NP", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NL", "alpha3Key": "NLD", "value": "Netherlands", "translatedValue": "Netherlands", "textId": "NL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NC", "alpha3Key": "NCL", "value": "New Caledonia", "translatedValue": "New Caledonia", "textId": "NC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NZ", "alpha3Key": "NZL", "value": "New Zealand", "translatedValue": "New Zealand", "textId": "NZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NI", "alpha3Key": "NIC", "value": "Nicaragua", "translatedValue": "Nicaragua", "textId": "NI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NE", "alpha3Key": "NER", "value": "Niger", "translatedValue": "Niger", "textId": "NE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NG", "alpha3Key": "NGA", "value": "Nigeria", "translatedValue": "Nigeria", "textId": "NG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NU", "alpha3Key": "NIU", "value": "Niue", "translatedValue": "Niue", "textId": "NU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NF", "alpha3Key": "NFK", "value": "Norfolk Island", "translatedValue": "Norfolk Island", "textId": "NF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MK", "alpha3Key": "MKD", "value": "The Republic of North Macedonia", "translatedValue": "The Republic of North Macedonia", "textId": "MK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MP", "alpha3Key": "MNP", "value": "Northern Mariana Islands", "translatedValue": "Northern Mariana Islands", "textId": "MP", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "NO", "alpha3Key": "NOR", "value": "Norway", "translatedValue": "Norway", "textId": "NO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "OM", "alpha3Key": "OMN", "value": "Oman", "translatedValue": "Oman", "textId": "OM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PK", "alpha3Key": "PAK", "value": "Pakistan", "translatedValue": "Pakistan", "textId": "PK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PW", "alpha3Key": "PLW", "value": "Palau", "translatedValue": "Palau", "textId": "PW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PS", "alpha3Key": "PSE", "value": "State of Palestine", "translatedValue": "State of Palestine", "textId": "PS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PA", "alpha3Key": "PAN", "value": "Panama", "translatedValue": "Panama", "textId": "PA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PG", "alpha3Key": "PNG", "value": "Papua New Guinea", "translatedValue": "Papua New Guinea", "textId": "PG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PY", "alpha3Key": "PRY", "value": "Paraguay", "translatedValue": "Paraguay", "textId": "PY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PE", "alpha3Key": "PER", "value": "Peru", "translatedValue": "Peru", "textId": "PE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PH", "alpha3Key": "PHL", "value": "Philippines", "translatedValue": "Philippines", "textId": "PH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PN", "alpha3Key": "PCN", "value": "Pitcairn", "translatedValue": "Pitcairn", "textId": "PN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PL", "alpha3Key": "POL", "value": "Poland", "translatedValue": "Poland", "textId": "PL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PT", "alpha3Key": "PRT", "value": "Portugal", "translatedValue": "Portugal", "textId": "PT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PR", "alpha3Key": "PRI", "value": "Puerto Rico", "translatedValue": "Puerto Rico", "textId": "PR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "QA", "alpha3Key": "QAT", "value": "Qatar", "translatedValue": "Qatar", "textId": "QA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "RE", "alpha3Key": "REU", "value": "Reunion", "translatedValue": "Reunion", "textId": "RE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "RO", "alpha3Key": "ROU", "value": "Romania", "translatedValue": "Romania", "textId": "RO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "RU", "alpha3Key": "RUS", "value": "Russian Federation", "translatedValue": "Russian Federation", "textId": "RU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "RW", "alpha3Key": "RWA", "value": "Rwanda", "translatedValue": "Rwanda", "textId": "RW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SH", "alpha3Key": "SHN", "value": "Saint Helena", "translatedValue": "Saint Helena", "textId": "SH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "KN", "alpha3Key": "KNA", "value": "Saint Kitts and Nevis", "translatedValue": "Saint Kitts and Nevis", "textId": "KN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LC", "alpha3Key": "LCA", "value": "Saint Lucia", "translatedValue": "Saint Lucia", "textId": "LC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "PM", "alpha3Key": "SPM", "value": "Saint Pierre and Miquelon", "translatedValue": "Saint Pierre and Miquelon", "textId": "PM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VC", "alpha3Key": "VCT", "value": "Saint Vincent and the Grenadines", "translatedValue": "Saint Vincent and the Grenadines", "textId": "VC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "WS", "alpha3Key": "WSM", "value": "Samoa", "translatedValue": "Samoa", "textId": "WS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SM", "alpha3Key": "SMR", "value": "San Marino", "translatedValue": "San Marino", "textId": "SM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ST", "alpha3Key": "STP", "value": "Sao Tome and Principe", "translatedValue": "Sao Tome and Principe", "textId": "ST", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SA", "alpha3Key": "SAU", "value": "Saudi Arabia", "translatedValue": "Saudi Arabia", "textId": "SA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SN", "alpha3Key": "SEN", "value": "Senegal", "translatedValue": "Senegal", "textId": "SN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SC", "alpha3Key": "SYC", "value": "Seychelles", "translatedValue": "Seychelles", "textId": "SC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SL", "alpha3Key": "SLE", "value": "Sierra Leone", "translatedValue": "Sierra Leone", "textId": "SL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SG", "alpha3Key": "SGP", "value": "Singapore", "translatedValue": "Singapore", "textId": "SG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SK", "alpha3Key": "SVK", "value": "Slovakia", "translatedValue": "Slovakia", "textId": "SK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SI", "alpha3Key": "SVN", "value": "Slovenia", "translatedValue": "Slovenia", "textId": "SI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SB", "alpha3Key": "SLB", "value": "Solomon Islands", "translatedValue": "Solomon Islands", "textId": "SB", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SO", "alpha3Key": "SOM", "value": "Somalia", "translatedValue": "Somalia", "textId": "SO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ZA", "alpha3Key": "ZAF", "value": "South Africa", "translatedValue": "South Africa", "textId": "ZA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GS", "alpha3Key": "SGS", "value": "South Georgia and the South Sandwich Islands", "translatedValue": "South Georgia and the South Sandwich Islands", "textId": "GS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ES", "alpha3Key": "ESP", "value": "Spain", "translatedValue": "Spain", "textId": "ES", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "LK", "alpha3Key": "LKA", "value": "Sri Lanka", "translatedValue": "Sri Lanka", "textId": "LK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SD", "alpha3Key": "SDN", "value": "Sudan", "translatedValue": "Sudan", "textId": "SD", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SR", "alpha3Key": "SUR", "value": "Suriname", "translatedValue": "Suriname", "textId": "SR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SJ", "alpha3Key": "SJM", "value": "Svalbard and Jan Mayen", "translatedValue": "Svalbard and Jan Mayen", "textId": "SJ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SZ", "alpha3Key": "SWZ", "value": "Eswatini", "translatedValue": "Eswatini", "textId": "SZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SE", "alpha3Key": "SWE", "value": "Sweden", "translatedValue": "Sweden", "textId": "SE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CH", "alpha3Key": "CHE", "value": "Switzerland", "translatedValue": "Switzerland", "textId": "CH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SY", "alpha3Key": "SYR", "value": "Syrian Arab Republic", "translatedValue": "Syrian Arab Republic", "textId": "SY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TW", "alpha3Key": "TWN", "value": "Taiwan, Province of China", "translatedValue": "Taiwan, Province of China", "textId": "TW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TJ", "alpha3Key": "TJK", "value": "Tajikistan", "translatedValue": "Tajikistan", "textId": "TJ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TZ", "alpha3Key": "TZA", "value": "United Republic of Tanzania", "translatedValue": "United Republic of Tanzania", "textId": "TZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TH", "alpha3Key": "THA", "value": "Thailand", "translatedValue": "Thailand", "textId": "TH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TL", "alpha3Key": "TLS", "value": "Timor-Leste", "translatedValue": "Timor-Leste", "textId": "TL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TG", "alpha3Key": "TGO", "value": "Togo", "translatedValue": "Togo", "textId": "TG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TK", "alpha3Key": "TKL", "value": "Tokelau", "translatedValue": "Tokelau", "textId": "TK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TO", "alpha3Key": "TON", "value": "Tonga", "translatedValue": "Tonga", "textId": "TO", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TT", "alpha3Key": "TTO", "value": "Trinidad and Tobago", "translatedValue": "Trinidad and Tobago", "textId": "TT", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TN", "alpha3Key": "TUN", "value": "Tunisia", "translatedValue": "Tunisia", "textId": "TN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TR", "alpha3Key": "TUR", "value": "Türkiye", "translatedValue": "Türkiye", "textId": "TR", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TM", "alpha3Key": "TKM", "value": "Turkmenistan", "translatedValue": "Turkmenistan", "textId": "TM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TC", "alpha3Key": "TCA", "value": "Turks and Caicos Islands", "translatedValue": "Turks and Caicos Islands", "textId": "TC", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "TV", "alpha3Key": "TUV", "value": "Tuvalu", "translatedValue": "Tuvalu", "textId": "TV", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "UG", "alpha3Key": "UGA", "value": "Uganda", "translatedValue": "Uganda", "textId": "UG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "UA", "alpha3Key": "UKR", "value": "Ukraine", "translatedValue": "Ukraine", "textId": "UA", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AE", "alpha3Key": "ARE", "value": "United Arab Emirates", "translatedValue": "United Arab Emirates", "textId": "AE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GB", "alpha3Key": "GBR", "value": "United Kingdom", "translatedValue": "United Kingdom", "textId": "GB", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "US", "alpha3Key": "USA", "value": "United States of America", "translatedValue": "United States of America", "textId": "US", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "UM", "alpha3Key": "UMI", "value": "United States Minor Outlying Islands", "translatedValue": "United States Minor Outlying Islands", "textId": "UM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "UY", "alpha3Key": "URY", "value": "Uruguay", "translatedValue": "Uruguay", "textId": "UY", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "UZ", "alpha3Key": "UZB", "value": "Uzbekistan", "translatedValue": "Uzbekistan", "textId": "UZ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VU", "alpha3Key": "VUT", "value": "Vanuatu", "translatedValue": "Vanuatu", "textId": "VU", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VE", "alpha3Key": "VEN", "value": "Venezuela", "translatedValue": "Venezuela", "textId": "VE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VN", "alpha3Key": "VNM", "value": "Vietnam", "translatedValue": "Vietnam", "textId": "VN", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VG", "alpha3Key": "VGB", "value": "Virgin Islands, British", "translatedValue": "Virgin Islands, British", "textId": "VG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "VI", "alpha3Key": "VIR", "value": "Virgin Islands, U.S.", "translatedValue": "Virgin Islands, U.S.", "textId": "VI", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "WF", "alpha3Key": "WLF", "value": "Wallis and Futuna", "translatedValue": "Wallis and Futuna", "textId": "WF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "EH", "alpha3Key": "ESH", "value": "Western Sahara", "translatedValue": "Western Sahara", "textId": "EH", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "YE", "alpha3Key": "YEM", "value": "Yemen", "translatedValue": "Yemen", "textId": "YE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ZM", "alpha3Key": "ZMB", "value": "Zambia", "translatedValue": "Zambia", "textId": "ZM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ZW", "alpha3Key": "ZWE", "value": "Zimbabwe", "translatedValue": "Zimbabwe", "textId": "ZW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "AX", "alpha3Key": "ALA", "value": "Åland Islands", "translatedValue": "Åland Islands", "textId": "AX", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BQ", "alpha3Key": "BES", "value": "Bonaire, Sint Eustatius and Saba", "translatedValue": "Bonaire, Sint Eustatius and Saba", "textId": "BQ", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "CW", "alpha3Key": "CUW", "value": "Curaçao", "translatedValue": "Curaçao", "textId": "CW", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "GG", "alpha3Key": "GGY", "value": "Guernsey", "translatedValue": "Guernsey", "textId": "GG", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "IM", "alpha3Key": "IMN", "value": "Isle of Man", "translatedValue": "Isle of Man", "textId": "IM", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "JE", "alpha3Key": "JEY", "value": "Jersey", "translatedValue": "Jersey", "textId": "JE", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "ME", "alpha3Key": "MNE", "value": "Montenegro", "translatedValue": "Montenegro", "textId": "ME", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "BL", "alpha3Key": "BLM", "value": "Saint Barthélemy", "translatedValue": "Saint Barthélemy", "textId": "BL", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "MF", "alpha3Key": "MAF", "value": "Saint Martin (French part)", "translatedValue": "Saint Martin (French part)", "textId": "MF", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "RS", "alpha3Key": "SRB", "value": "Serbia", "translatedValue": "Serbia", "textId": "RS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SX", "alpha3Key": "SXM", "value": "Sint Maarten (Dutch part)", "translatedValue": "Sint Maarten (Dutch part)", "textId": "SX", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "SS", "alpha3Key": "SSD", "value": "South Sudan", "translatedValue": "South Sudan", "textId": "SS", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }, { "alpha2Key": "XK", "alpha3Key": "XKX", "value": "Kosovo", "translatedValue": "Kosovo", "textId": "XK", "language": "en", "id": "647620845098f5861461f0ed", "optionType": "country" }];
+
+
+// genders
+
+export const genders = [
+  {
+    textId: 'm',
+    value: 'Male',
+    translatedValue: 'Male',
+  },
+  {
+    textId: 'f',
+    value: 'Female',
+    translatedValue: 'Female',
+  },
+  {
+    textId: 'x',
+    value: 'Prefer to self-describe',
+    translatedValue: 'Prefer to self-describe',
+  },
+  {
+    textId: '-',
+    value: 'I prefer not to share',
+    translatedValue: 'I prefer not to share',
+  },
+]
+
+// website types taken from Micromentor's django app (subject to change)
+
+export const websiteTypes = [
+  "facebook",
+  "twitter",
+  "venture",
+  "linkedin",
+  "other"
+]

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -1,3 +1,5 @@
+import { faker } from "@faker-js/faker";
+
 import * as generators from './generators';
 
 export class MockServerState {
@@ -8,16 +10,19 @@ export class MockServerState {
     channelInvitations: any[];
     channelInboxItemInvitations: any[];
     channelMessages: any[];
+    groups: any[];
 
     constructor() {
+        this.groups = generators.generateCoreGroups()
+            .concat(generators.generateGroup());
         this.loggedIn = false;
-        this.loggedInUser = generators.generateUser();
+        this.loggedInUser = generators.generateUser(this.groups.filter(g => g.groupIdent === "mentees"));
         // 4 users, one for each channel and one who hasn't communicated with the logged in user
         this.otherUsers = [
-            generators.generateUser(),
-            generators.generateUser(),
-            generators.generateUser(),
-            generators.generateUser(),
+            generators.generateUser(this.groups.filter(g => g.groupIdent === "mentors")),
+            generators.generateUser(faker.helpers.arrayElements(this.groups, 1)),
+            generators.generateUser(faker.helpers.arrayElements(this.groups, 2)),
+            generators.generateUser(faker.helpers.arrayElements(this.groups, 2)),
         ];
         this.channels = [
             generators.generateChannel([this.loggedInUser, this.otherUsers[0]]),
@@ -33,22 +38,22 @@ export class MockServerState {
             // generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]], false, true),
         ];
         this.channelInboxItemInvitations = [
-            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[0], true, false),
-            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[1], false, false),
-            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[2], false, true),
-            generators.generateChannelInboxItemInvitation(this.channels[0].id, this.otherUsers[3], false, false),
+            generators.generateChannelInboxItemInvitation(this.channels[0], this.otherUsers[0], true, false),
+            generators.generateChannelInboxItemInvitation(this.channels[0], this.otherUsers[1], false, false),
+            generators.generateChannelInboxItemInvitation(this.channels[0], this.otherUsers[2], false, true),
+            generators.generateChannelInboxItemInvitation(this.channels[0], this.otherUsers[3], false, false),
         ];
-        const message0 = generators.generateChannelMessage('Hello!', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
-        const message1 = generators.generateChannelMessage('👋', this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true, false, false);
-        const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?',this.channels[0].id, this.loggedInUser, new Date('2023-07-26T12:35:01-07:00'), true);
-        const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true);
-        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, false, true, message2.id);
-        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
-        const message6 = generators.generateChannelMessage('👍', this.channels[0].id, this.otherUsers[0], new Date('2023-07-27T08:24:01-07:00'), true);
-        const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, true);
-        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0].id, this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, true, false, message5.id);
-        const message9 = generators.generateChannelMessage('You got it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
-        const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0].id, this.otherUsers[0], new Date('2023-07-28T20:01:01-07:00'), false);
+        const message0 = generators.generateChannelMessage('Hello!', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
+        const message1 = generators.generateChannelMessage('👋', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true, false, false);
+        const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:35:01-07:00'), true);
+        const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true);
+        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, false, true, message2.id);
+        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
+        const message6 = generators.generateChannelMessage('👍', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:24:01-07:00'), true);
+        const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, true);
+        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, true, false, message5.id);
+        const message9 = generators.generateChannelMessage('You got it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
+        const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:01:01-07:00'), false);
         this.channelMessages = [
             message0,
             message1,


### PR DESCRIPTION
This PR contains the following edits:

- Updated graphql schema to include some random updates from last few weeks, including pagination, sorting, and other options. See this PR in the backend for more context on those options: https://github.com/micromentor-team/mmdata/pull/239 
- Updates to mock server to keep up with the above schema changes, already reviewed in #84
- Added content provider, which includes static options like Countries, Languages, Company Stages, Company Types, Expertises, Industries, some preset options for Genders, and "Education Levels". Later, it may provide additional options. Countries may be broken out into a separate Location provider once we determine how States/Cities are going to work.
- Added 2 queries to the User provider which return fields specific to Mentors or Mentees. Those queries still need appropriate filters if they are to be expected to return only mentor or only mentee users.

Example for how to fetch mentees:
```dart
final menteeUsers = userProvider.findMenteeUsers(
  optionsInput: Input$FindObjectsOptions(
    limit: 10, // only return 10 users
    skip:
      10, // return users after the first 10 (e.g. for the 2nd page of a search)
    sort: [
      Input$SortItem(
        direction: Enum$SortDirection.desc, field: "createdAt")
    ], // sort by createdAt descending
  ),
  filterInput: Input$UserListFilter(
    ids: null,
    searchText:
      "" // some non-empty field seems to be required by our user search at the moment, buggy but works
    ),
  matchInput: Input$UserInput(seeksHelp: true // mentee users
    ));

menteeUsers.then((value) => debugPrint(
  // log all attributes from each user
  value.response!.map((e) => e!.toJson()).toList().toString(),
));
```

And to fetch countries:
```dart
final contentProvider = Provider.of<ContentProvider>(context);
final content = contentProvider.findCountries();

// log content
content.then((value) => debugPrint(
    value.response!.map((e) => e!.toJson()).toList().toString()));
```

Unless only one of the types is needed from the Content provider, it's probably better to use `findAllOptionsByType()` rather than the individual queries like `findCountries`.

<details>
  <summary>Hidden graphql for the above dart code for mentees</summary>
  
 ```graphql
query FindMenteeUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
    findUsers(options: $options, filter: $filter, match: $match) {
        id
        email
        firstName
        lastName
        fullName
        avatarUrl
        userHandle
        cityOfResidence
        regionOfResidence
        countryOfResidence {
            translatedValue
        }
        jobTitle
        groupMemberships {
            ... on MenteesGroupMembership {
                soughtExpertises {
                    translatedValue
                }
                industry {
                    translatedValue
                }
            }
        }
        companies {
            companyStage {
                translatedValue
            }
        }
    }
}
```

Variables JSON:
```json
{
  "filter": {
    "ids": null,
    "searchText": ""
  },
  "match": {
    "seeksHelp": true
  },
  "options": {
    "limit": 500,
    "skip": 0,
    "sort": [
      {
        "direction": "desc",
        "field": "createdAt"
      }
    ]
  }
}
```
</details>

