### PR TITLE
First hardcoded iteration of the profile page scaffolding and profile page bar

### DIFF
--- a/lib/widgets/molecules/profile_page_header.dart
+++ b/lib/widgets/molecules/profile_page_header.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+
+class ProfilePageHeader extends StatelessWidget {
+  const ProfilePageHeader({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Container(
+        color: theme.colorScheme.secondaryContainer,
+        height: 68.0,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(Insets.paddingLarge),
+              child: Icon(
+                Icons.keyboard_backspace_outlined,
+                color: theme.colorScheme.secondary,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                right: (Insets.paddingLarge),
+              ),
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  minimumSize: Dimensions.bigButtonSize,
+                  backgroundColor: theme.colorScheme.surface,
+                  disabledBackgroundColor: theme.colorScheme.surface,
+                ),
+                onPressed: () {},
+                child: Row(
+                  children: [
+                    Text(
+                      "Invite Maria to Connect",
+                      style: theme.textTheme.labelLarge
+                          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                    ),
+                    const SizedBox(
+                      width: Insets.paddingSmall,
+                    ),
+                    Icon(
+                      Icons.send_outlined,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ));
+  }
+}

--- a/lib/widgets/screens/profile/profile.dart
+++ b/lib/widgets/screens/profile/profile.dart
@@ -1,9 +1,32 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/utilities/router.dart';
 import 'package:provider/provider.dart';
-
 import '../../../providers/models/scaffold_model.dart';
+import '../../molecules/profile_page_header.dart';
+
+class ProfileScreenScroll extends StatefulWidget {
+  const ProfileScreenScroll({Key? key}) : super(key: key);
+
+  @override
+  State<ProfileScreenScroll> createState() => _ProfileScreenScrollState();
+}
+
+class _ProfileScreenScrollState extends State<ProfileScreenScroll> {
+  @override
+  Widget build(BuildContext context) {
+    return const SafeArea(
+      child: Column(
+        children: [
+          ProfilePageHeader(),
+          //TO-DO(all): replace the placeholder with the elements of the profile page you're working on
+          Expanded(
+            child: Placeholder(),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -38,8 +61,6 @@ class _ProfileScreenState extends State<ProfileScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text(AppLocalizations.of(context)!.navProfileText),
-    );
+    return const ProfileScreenScroll();
   }
 }


### PR DESCRIPTION
Hello all,

To unblock folks working on the profile page, I have created the blank page along hardcoded profile page bar on the top [UI only].

I will make this profile page top bar functional as well in future commits. This is what it looks like at the moment:

<img width="501" alt="Screenshot 2023-08-01 at 2 48 00 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/63002494/3dbf81b5-1980-470e-adec-f0ad12de04ae">

I also want to give a shoutout to the UX team- Katy and Ujjaini for adding the necessary specs for the UI elements on the Figma file. 