### PR TITLE
Create mock resolvers for replying, deleting, and updating messages

### DIFF
--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -31,6 +31,14 @@ export function mockMutations(serverState: MockServerState) {
             serverState.channelMessages.push(message);
             return message;
         },
+        deleteChannelMessage: (_: any, args: { channelMessageId: string, deletePhysically: boolean }) => {
+            var channelMessage = serverState.channelMessages.find((element) => element.id == args.channelMessageId);
+            const currentTime : string = new Date().toISOString();
+            channelMessage.deletedAt = currentTime;
+            channelMessage.updatedAt = currentTime;
+            channelMessage.deletedBy = channelMessage.createdBy;
+            return "ok";
+        },
         updateChannelInvitation: (_: any, args: { input: { status: string }}) => {
             const invitation = serverState.channelInvitations[0]
             if (args.input.status) {
@@ -43,6 +51,16 @@ export function mockMutations(serverState: MockServerState) {
                     invitation.status = "declined";
             }
             return invitation.id;
-        }
+        },
+        updateChannelMessage: (_: any, args: { input: { id: string | null, messageText: string | null, deletedAt: Date | null } }) => {
+            var channelMessage = serverState.channelMessages.find((element) => element.id == args.input.id);
+            if(args.input.deletedAt) {
+                channelMessage.deletedAt = args.input.deletedAt.toISOString();
+            } else {
+                channelMessage.deletedAt = null;
+            }
+            channelMessage.messageText = args.input.messageText ?? channelMessage.messageText;
+            return "ok";
+        },
     }
 }

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -26,8 +26,17 @@ export function mockMutations(serverState: MockServerState) {
             serverState.channelInvitations.push(invitation);
             return invitation;
         },
-        createChannelMessage: (_: any, args: { input: { messageText: string }}) => {
-            const message = generators.generateChannelMessage(args.input.messageText ,serverState.channels[0].id, serverState.loggedInUser, new Date(), true)
+        createChannelMessage: (_: any, args: { input: { messageText: string , replyToMessageId: string | null}}) => {
+            const message = generators.generateChannelMessage(
+                args.input.messageText,
+                serverState.channels[0].id,
+                serverState.loggedInUser,
+                new Date(),
+                true,
+                false,
+                false,
+                args.input.replyToMessageId,
+            );
             serverState.channelMessages.push(message);
             return message;
         },

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -45,7 +45,6 @@ export function mockMutations(serverState: MockServerState) {
             const currentTime : string = new Date().toISOString();
             channelMessage.deletedAt = currentTime;
             channelMessage.updatedAt = currentTime;
-            channelMessage.deletedBy = channelMessage.createdBy;
             return "ok";
         },
         markChannelMessagesAsSeenByMe: (_: any, args: { channelId: string }) => {
@@ -75,12 +74,17 @@ export function mockMutations(serverState: MockServerState) {
         },
         updateChannelMessage: (_: any, args: { input: { id: string | null, messageText: string | null, deletedAt: Date | null } }) => {
             var channelMessage = serverState.channelMessages.find((element) => element.id == args.input.id);
+            const currentTime : string = new Date().toISOString();
             if(args.input.deletedAt) {
                 channelMessage.deletedAt = args.input.deletedAt.toISOString();
             } else {
                 channelMessage.deletedAt = null;
             }
-            channelMessage.messageText = args.input.messageText ?? channelMessage.messageText;
+            if(args.input.messageText != channelMessage.messageText) {
+                channelMessage.messageText = args.input.messageText;
+                channelMessage.editedAt = currentTime;
+            }
+            channelMessage.updatedAt = currentTime;
             return "ok";
         },
     }

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -26,10 +26,10 @@ export function mockMutations(serverState: MockServerState) {
             serverState.channelInvitations.push(invitation);
             return invitation;
         },
-        createChannelMessage: (_: any, args: { input: { messageText: string , replyToMessageId: string | null}}) => {
+        createChannelMessage: (_: any, args: { input: { channelId: string, messageText: string , replyToMessageId: string | null}}) => {
             const message = generators.generateChannelMessage(
                 args.input.messageText,
-                serverState.channels[0].id,
+                args.input.channelId,
                 serverState.loggedInUser,
                 new Date(),
                 true,

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -48,6 +48,18 @@ export function mockMutations(serverState: MockServerState) {
             channelMessage.deletedBy = channelMessage.createdBy;
             return "ok";
         },
+        markChannelMessagesAsSeenByMe: (_: any, args: { channelId: string }) => {
+            var channelMessages = serverState.channelMessages.filter((element) => element.channelId == args.channelId);
+            channelMessages.forEach((element) => {
+                element.statuses = [
+                    {
+                        __typename: "ChannelMessageStatus",
+                        seenAt: new Date().toISOString(),
+                    }
+                ];
+            });
+            return "ok";
+        },
         updateChannelInvitation: (_: any, args: { input: { status: string }}) => {
             const invitation = serverState.channelInvitations[0]
             if (args.input.status) {


### PR DESCRIPTION
This allows deleting/undeleting, editing messages, creating replies, and marking messages as seen in the mock server. These changes persist as long as the server is running.

I need confirmation on the logic for the backend. I know these fields are all that is needed for the frontend, but I would like to know if there are side effects to running these operations that we need to be aware of. For example, does editing a message update the `editedAt` and `updatedAt` fields? Does deleting or undeleting a message update the `deletedAt` and `deletedBy` fields?

Also, is the backend able to tell the difference between a `deletedAt` field that is null because it wasn't set by the caller in the `updateChannelMessage` mutation, or because it was specifically set to null by the caller (to undelete the message)?