### PR TITLE
Profile basic info section

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -61,6 +61,8 @@
     "navInboxText": "Inbox",
     "navProfileText": "Profile",
     "mentors": "Mentors",
+    "entrepreneurCapitalized": "ENTREPRENEUR",
+    "mentorCapitalized": "MENTOR",
     "entrepeneurs": "Entrepeneurs",
     "india": "India",
     "marketing": "Marketing",
@@ -144,5 +146,6 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "profileVacationBanner": "I am on vacation so my responses may be slow."
 }

--- a/lib/utilities/scaffold_utils/appbar_factory.dart
+++ b/lib/utilities/scaffold_utils/appbar_factory.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/utilities/errors/errors.dart';
+import 'package:mm_flutter_app/utilities/scaffold_utils/report_or_block_menu_button.dart';
 
 import '../../constants/app_constants.dart';
 import '../../widgets/atoms/notification_bubble.dart';
@@ -187,17 +188,7 @@ class AppBarFactory {
       ),
       centerTitle: false,
       actions: [
-        PopupMenuButton(
-          icon: const Icon(Icons.more_vert),
-          itemBuilder: (context) => [
-            PopupMenuItem(
-              child: Text(l10n.blockUser),
-            ),
-            PopupMenuItem(
-              child: Text(l10n.reportUser),
-            ),
-          ],
-        ),
+        ReportOrBlockMenuButton(l10n: l10n),
       ],
     );
   }

--- a/lib/utilities/scaffold_utils/report_or_block_menu_button.dart
+++ b/lib/utilities/scaffold_utils/report_or_block_menu_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class ReportOrBlockMenuButton extends StatelessWidget {
+  const ReportOrBlockMenuButton({
+    super.key,
+    required this.l10n,
+  });
+
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton(
+      icon: const Icon(Icons.more_vert),
+      itemBuilder: (context) => [
+        PopupMenuItem(
+          child: Text(l10n.blockUser),
+        ),
+        PopupMenuItem(
+          child: Text(l10n.reportUser),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/atoms/profile_chip.dart
+++ b/lib/widgets/atoms/profile_chip.dart
@@ -5,11 +5,13 @@ import '../../constants/app_constants.dart';
 class ProfileChip extends StatelessWidget {
   final String text;
   final IconData? icon;
+  final bool? usePrimaryColor;
 
   const ProfileChip({
     super.key,
     required this.text,
     this.icon,
+    this.usePrimaryColor,
   });
 
   @override
@@ -25,11 +27,15 @@ class ProfileChip extends StatelessWidget {
       label: Text(
         text,
         style: theme.textTheme.labelSmall?.copyWith(
-          color: theme.colorScheme.onSecondaryContainer,
+          color: (usePrimaryColor != null && usePrimaryColor!)
+              ? theme.colorScheme.onSurfaceVariant
+              : theme.colorScheme.onSecondaryContainer,
         ),
         overflow: TextOverflow.ellipsis,
       ),
-      backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+      backgroundColor: (usePrimaryColor != null && usePrimaryColor!)
+          ? theme.colorScheme.inversePrimary
+          : theme.colorScheme.secondaryContainer,
       side: BorderSide.none,
       visualDensity: const VisualDensity(
         horizontal: VisualDensity.minimumDensity,

--- a/lib/widgets/screens/profile/profile.dart
+++ b/lib/widgets/screens/profile/profile.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/providers/user_provider.dart';
 import 'package:mm_flutter_app/utilities/router.dart';
+import 'package:mm_flutter_app/widgets/screens/profile/profile_basic_info.dart';
 import 'package:provider/provider.dart';
 import '../../../providers/models/scaffold_model.dart';
 import '../../molecules/profile_page_header.dart';
@@ -19,14 +22,24 @@ class ProfileScreenScroll extends StatefulWidget {
 class _ProfileScreenScrollState extends State<ProfileScreenScroll> {
   @override
   Widget build(BuildContext context) {
+    final user = Provider.of<UserProvider>(context, listen: false).user!;
     return SafeArea(
       child: Column(
         children: [
           if (widget.showProfilePagerHeader)
             const ProfilePageHeader(requestReceived: true),
           //TO-DO(all): replace the placeholder with the elements of the profile page you're working on
-          const Expanded(
-            child: Placeholder(),
+          ProfileBasicInfo(
+            userType: UserType.entrepreneur,
+            fullName: user.fullName!,
+            avatarUrl: user.avatarUrl,
+            pronouns: "she/her",
+            affiliations: const ["Verizon Digital Ready"],
+            company: "SVK Group",
+            companyRole: "Director",
+            education: "Harvard University, MBA",
+            linkedinUrl: "https://www.linkedin.com/in/williamhgates/",
+            vacationMode: true,
           ),
         ],
       ),
@@ -67,8 +80,6 @@ class _ProfileScreenState extends State<ProfileScreen>
 
   @override
   Widget build(BuildContext context) {
-    return const ProfileScreenScroll(
-      showProfilePagerHeader: true,
-    );
+    return const ProfileScreenScroll(showProfilePagerHeader: true);
   }
 }

--- a/lib/widgets/screens/profile/profile_basic_info.dart
+++ b/lib/widgets/screens/profile/profile_basic_info.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/utilities/scaffold_utils/report_or_block_menu_button.dart';
+import 'package:mm_flutter_app/widgets/atoms/profile_chip.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const double _inlineIconSize = 16.0;
+
+Future<void> _launchUrl(Uri url) async {
+  if (!await launchUrl(url)) {
+    throw Exception('Could not launch $url');
+  }
+}
+
+Widget _createFooter(BuildContext context, String company, String? companyRole,
+    String? education, String? linkedinUrl) {
+  String companyAndRole = company;
+
+  final ThemeData theme = Theme.of(context);
+  if (companyRole != null) {
+    companyAndRole = "$companyRole, $company";
+  }
+
+  return Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+    Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          const Icon(
+            Icons.work_outline,
+            size: _inlineIconSize,
+          ),
+          const SizedBox(width: Insets.paddingExtraSmall),
+          Text(
+            companyAndRole,
+            style: theme.textTheme.labelSmall!
+                .copyWith(color: theme.colorScheme.secondary),
+          ),
+        ],
+      ),
+      if (education != null) const SizedBox(height: Insets.paddingExtraSmall),
+      if (education != null)
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            const Icon(
+              Icons.school_outlined,
+              size: _inlineIconSize,
+            ),
+            const SizedBox(width: Insets.paddingExtraSmall),
+            Text(
+              education,
+              style: theme.textTheme.labelSmall!
+                  .copyWith(color: theme.colorScheme.secondary),
+            ),
+          ],
+        ),
+    ]),
+    if (linkedinUrl != null)
+      Ink(
+        decoration: ShapeDecoration(
+          shape: RoundedRectangleBorder(
+              borderRadius:
+                  BorderRadius.circular(Radii.roundedRectRadiusSmall)),
+          color: theme.colorScheme.onInverseSurface,
+        ),
+        child: IconButton(
+          style: IconButton.styleFrom(
+              shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(Radii.roundedRectRadiusSmall),
+          )),
+          icon: const ColorFiltered(
+            colorFilter: ColorFilter.mode(
+              Colors.white,
+              BlendMode.saturation,
+            ),
+            child: SizedBox(
+              width: _inlineIconSize,
+              child: Image(
+                image: AssetImage(Assets.linkedInIcon),
+              ),
+            ),
+          ),
+          onPressed: () {
+            debugPrint(linkedinUrl);
+            _launchUrl(Uri.parse(linkedinUrl));
+          },
+        ),
+      ),
+  ]);
+}
+
+Widget _createNameAndBadges(BuildContext context, String fullName,
+    String? pronouns, UserType userType, List<String>? affiliations) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final ThemeData theme = Theme.of(context);
+
+  List<Widget> widgets = [
+    Text(
+      fullName,
+      style: theme.textTheme.titleMedium?.copyWith(
+        color: theme.colorScheme.onSurface,
+      ),
+    ),
+    if (pronouns != null)
+      Text(pronouns,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.secondary)),
+    if (userType == UserType.mentor)
+      ProfileChip(
+        text: l10n.mentorCapitalized,
+        usePrimaryColor: true,
+      ),
+    if (userType == UserType.entrepreneur)
+      ProfileChip(
+        text: l10n.entrepreneurCapitalized,
+        usePrimaryColor: true,
+      ),
+  ];
+
+  if (affiliations != null) {
+    for (String affiliation in affiliations) {
+      widgets.add(ProfileChip(
+        text: affiliation,
+        usePrimaryColor: true,
+      ));
+    }
+  }
+  return Expanded(
+      child: Stack(children: [
+    Align(
+        alignment: Alignment.topRight,
+        child: ReportOrBlockMenuButton(l10n: l10n)),
+    Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: widgets,
+    )
+  ]));
+}
+
+Widget _createVacationBanner(BuildContext context) {
+  final AppLocalizations l10n = AppLocalizations.of(context)!;
+  final ThemeData theme = Theme.of(context);
+  return Container(
+      color: theme.colorScheme.primaryContainer,
+      height: 48.0,
+      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            const Icon(
+              Icons.beach_access_outlined,
+              size: _inlineIconSize,
+            ),
+            const SizedBox(width: Insets.paddingExtraSmall),
+            Text(
+              l10n.profileVacationBanner,
+              style: theme.textTheme.labelSmall!
+                  .copyWith(color: theme.colorScheme.onPrimaryContainer),
+            ),
+          ],
+        ),
+      ]));
+}
+
+class ProfileBasicInfo extends StatelessWidget {
+  final UserType userType;
+  final String? avatarUrl;
+  final String fullName;
+  final String? pronouns;
+  final String company;
+  final String? companyRole;
+  final List<String>? affiliations;
+  final String? education;
+  final String? linkedinUrl;
+  final bool vacationMode;
+
+  const ProfileBasicInfo({
+    Key? key,
+    required this.userType,
+    this.avatarUrl,
+    this.pronouns,
+    this.affiliations,
+    required this.fullName,
+    required this.company,
+    this.companyRole,
+    this.education,
+    this.linkedinUrl,
+    required this.vacationMode,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (vacationMode) _createVacationBanner(context),
+        Padding(
+          padding: const EdgeInsets.all(Insets.paddingMedium),
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(
+                      Radii.roundedRectRadiusMedium,
+                    ),
+                    child: Image(
+                      image: avatarUrl != null
+                          ? NetworkImage(avatarUrl!) as ImageProvider<Object>
+                          : const AssetImage(Assets.blankAvatar),
+                      width: 88.0,
+                      height: 88.0, // Height of the avatar
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                  const SizedBox(width: Insets.paddingMedium),
+                  _createNameAndBadges(
+                      context, fullName, pronouns, userType, affiliations),
+                ],
+              ),
+              const SizedBox(height: Insets.paddingMedium),
+              _createFooter(
+                  context, company, companyRole, education, linkedinUrl),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/widgets/screens/profile/profile_basic_info.dart
+++ b/lib/widgets/screens/profile/profile_basic_info.dart
@@ -27,10 +27,8 @@ Widget _createFooter(BuildContext context, String company, String? companyRole,
       Wrap(
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
-          const Icon(
-            Icons.work_outline,
-            size: _inlineIconSize,
-          ),
+          Icon(Icons.work_outline,
+              size: _inlineIconSize, color: theme.colorScheme.secondary),
           const SizedBox(width: Insets.paddingExtraSmall),
           Text(
             companyAndRole,
@@ -44,9 +42,10 @@ Widget _createFooter(BuildContext context, String company, String? companyRole,
         Wrap(
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
-            const Icon(
+            Icon(
               Icons.school_outlined,
               size: _inlineIconSize,
+              color: theme.colorScheme.secondary,
             ),
             const SizedBox(width: Insets.paddingExtraSmall),
             Text(
@@ -104,7 +103,7 @@ Widget _createNameAndBadges(BuildContext context, String fullName,
       ),
     ),
     if (pronouns != null)
-      Text(pronouns,
+      Text("($pronouns)",
           style: theme.textTheme.bodySmall
               ?.copyWith(color: theme.colorScheme.secondary)),
     if (userType == UserType.mentor)
@@ -145,21 +144,25 @@ Widget _createVacationBanner(BuildContext context) {
   return Container(
       color: theme.colorScheme.primaryContainer,
       height: 48.0,
-      child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-        Wrap(
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            const Icon(
-              Icons.beach_access_outlined,
-              size: _inlineIconSize,
-            ),
-            const SizedBox(width: Insets.paddingExtraSmall),
-            Text(
-              l10n.profileVacationBanner,
-              style: theme.textTheme.labelSmall!
-                  .copyWith(color: theme.colorScheme.onPrimaryContainer),
-            ),
-          ],
+      child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Insets.paddingMedium),
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Icon(
+                Icons.beach_access_outlined,
+                size: _inlineIconSize,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+              const SizedBox(width: Insets.paddingExtraSmall),
+              Text(
+                l10n.profileVacationBanner,
+                style: theme.textTheme.labelSmall!
+                    .copyWith(color: theme.colorScheme.onPrimaryContainer),
+              ),
+            ],
+          ),
         ),
       ]));
 }


### PR DESCRIPTION
1. Profile basic info section; displays vacation banner, user type, affiliations, company, education, etc.
2. moved three dots menu for block/report user to a separate file for code reuse
3. extended profileChip class to have an option to use primary color

Note: 
The vacation banner color may seem odd with profile page header, as figma uses primary95, which is not in the color scheme, so I'm using the closest color primaryContainer instead. I will follow up with Katy on this.

---

https://github.com/micromentor-team/mm-flutter-app/assets/100324646/5a6c30f5-389e-4b5a-973b-579d2227d13f





All fields
----

<img width="500" alt="Screenshot 2023-08-02 at 5 04 51 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/100324646/69180d8b-13d2-4514-a538-68de929fdf48">
Only mandatory fields