### PR TITLE
Miscellaneous fixes in the home page

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -89,6 +89,9 @@ class UserProvider extends BaseProvider {
   }) {
     return runQuery(
       document: documentNodeQueryFindAllUsers,
+      variables: Variables$Query$FindAllUsers(
+        filter: Input$UserListFilter(caseSensitive: false),
+      ).toJson(),
       onData: (queryResult, {refetch, fetchMore}) {
         final OperationResult<List<Query$FindAllUsers$findUsers>> result =
             OperationResult(

--- a/lib/widgets/atoms/mentor_card.dart
+++ b/lib/widgets/atoms/mentor_card.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class MentorCard extends StatelessWidget {
-  final String avatarUrl;
+  final String? avatarUrl;
   final String mentorName;
   final String mentorBio;
   final List<String> mentorSkill;
@@ -14,7 +14,7 @@ class MentorCard extends StatelessWidget {
 
   const MentorCard({
     Key? key,
-    required this.avatarUrl,
+    this.avatarUrl,
     required this.mentorName,
     required this.mentorBio,
     required this.mentorSkill,
@@ -30,7 +30,9 @@ class MentorCard extends StatelessWidget {
             radius: Radii.avatarRadiusLarge,
             child: CircleAvatar(
               radius: Radii.avatarRadiusMedium,
-              backgroundImage: NetworkImage(avatarUrl.toString()),
+              backgroundImage: avatarUrl != null
+                  ? NetworkImage(avatarUrl!) as ImageProvider<Object>
+                  : const AssetImage(Assets.blankAvatar),
             ),
           ),
         ),

--- a/lib/widgets/atoms/profile_header.dart
+++ b/lib/widgets/atoms/profile_header.dart
@@ -48,8 +48,8 @@ class ProfileHeader extends StatelessWidget {
               CircleAvatar(
                 radius: Radii.avatarRadiusSmall,
                 backgroundImage: avatarUrl != null
-                    ? NetworkImage(avatarUrl.toString())
-                    : null,
+                    ? NetworkImage(avatarUrl!) as ImageProvider<Object>
+                    : const AssetImage(Assets.blankAvatar),
               ),
             ],
           ),

--- a/lib/widgets/molecules/recommended_mentors_scroll.dart
+++ b/lib/widgets/molecules/recommended_mentors_scroll.dart
@@ -24,7 +24,7 @@ class RecommendedMentorsScroll extends StatelessWidget {
     for (i = 0; i < numberOfMentors; i++) {
       recommendedMentors.add(
         MentorCard(
-            avatarUrl: mentors[i].avatarUrl.toString(),
+            avatarUrl: mentors[i].avatarUrl,
             mentorName: mentors[i].fullName.toString(),
             //TODO: Once these fields come up in the mock server, replace these hardcoded values with the appropriate fields
             mentorBio: 'CEO, Levi Consulting',

--- a/lib/widgets/molecules/upcoming_section.dart
+++ b/lib/widgets/molecules/upcoming_section.dart
@@ -23,7 +23,9 @@ class UpcomingSection extends StatelessWidget {
           DateTime.now().add(const Duration(days: maxDaysDisplayed)))) {
         sessionTiles.add(
           ImageTile(
-            image: NetworkImage(sessions[i].avatarUrl),
+            image: sessions[i].avatarUrl != null
+                ? NetworkImage(sessions[i].avatarUrl!) as ImageProvider<Object>
+                : const AssetImage(Assets.blankAvatar),
             subtitle: dateFormat.format(sessions[i].dateTime),
             title: sessions[i].mentorName,
             isCircle: true,
@@ -90,11 +92,11 @@ class UpcomingSection extends StatelessWidget {
 class _UpcomingSession {
   final String mentorName;
   final DateTime dateTime;
-  final String avatarUrl;
+  final String? avatarUrl;
 
   const _UpcomingSession({
     required this.mentorName,
     required this.dateTime,
-    required this.avatarUrl,
+    this.avatarUrl,
   });
 }


### PR DESCRIPTION
Found a few bugs when testing with the real backend:

- The queryAllUsers call doesn't work without a 'filter' parameter. Added an inconsequential parameter just so that it won't crash and query all users.
- AvatarUrl in the Recommended Mentor tile was a required parameter, but in practice it can be null. Made it a nullable field.
- Added a default empty avatar image for header, recommended mentors, and upcoming sessions.