### PR TITLE
Update ChannelsProvider to use async queries

### DIFF
--- a/lib/__generated/schema/operations_channel.graphql.dart
+++ b/lib/__generated/schema/operations_channel.graphql.dart
@@ -2000,6 +2000,625 @@ class _CopyWithStubImpl$Query$FindChannelById$findChannelById$participants$user<
       _res;
 }
 
+class Variables$Query$FindChannelLatestMessage {
+  factory Variables$Query$FindChannelLatestMessage(
+          {required String channelId}) =>
+      Variables$Query$FindChannelLatestMessage._({
+        r'channelId': channelId,
+      });
+
+  Variables$Query$FindChannelLatestMessage._(this._$data);
+
+  factory Variables$Query$FindChannelLatestMessage.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$channelId = data['channelId'];
+    result$data['channelId'] = (l$channelId as String);
+    return Variables$Query$FindChannelLatestMessage._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String get channelId => (_$data['channelId'] as String);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$channelId = channelId;
+    result$data['channelId'] = l$channelId;
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindChannelLatestMessage<
+          Variables$Query$FindChannelLatestMessage>
+      get copyWith => CopyWith$Variables$Query$FindChannelLatestMessage(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindChannelLatestMessage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$channelId = channelId;
+    final lOther$channelId = other.channelId;
+    if (l$channelId != lOther$channelId) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$channelId = channelId;
+    return Object.hashAll([l$channelId]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindChannelLatestMessage<TRes> {
+  factory CopyWith$Variables$Query$FindChannelLatestMessage(
+    Variables$Query$FindChannelLatestMessage instance,
+    TRes Function(Variables$Query$FindChannelLatestMessage) then,
+  ) = _CopyWithImpl$Variables$Query$FindChannelLatestMessage;
+
+  factory CopyWith$Variables$Query$FindChannelLatestMessage.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindChannelLatestMessage;
+
+  TRes call({String? channelId});
+}
+
+class _CopyWithImpl$Variables$Query$FindChannelLatestMessage<TRes>
+    implements CopyWith$Variables$Query$FindChannelLatestMessage<TRes> {
+  _CopyWithImpl$Variables$Query$FindChannelLatestMessage(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindChannelLatestMessage _instance;
+
+  final TRes Function(Variables$Query$FindChannelLatestMessage) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? channelId = _undefined}) =>
+      _then(Variables$Query$FindChannelLatestMessage._({
+        ..._instance._$data,
+        if (channelId != _undefined && channelId != null)
+          'channelId': (channelId as String),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindChannelLatestMessage<TRes>
+    implements CopyWith$Variables$Query$FindChannelLatestMessage<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindChannelLatestMessage(this._res);
+
+  TRes _res;
+
+  call({String? channelId}) => _res;
+}
+
+class Query$FindChannelLatestMessage {
+  Query$FindChannelLatestMessage({
+    required this.findChannelById,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindChannelLatestMessage.fromJson(Map<String, dynamic> json) {
+    final l$findChannelById = json['findChannelById'];
+    final l$$__typename = json['__typename'];
+    return Query$FindChannelLatestMessage(
+      findChannelById: Query$FindChannelLatestMessage$findChannelById.fromJson(
+          (l$findChannelById as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindChannelLatestMessage$findChannelById findChannelById;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findChannelById = findChannelById;
+    _resultData['findChannelById'] = l$findChannelById.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findChannelById = findChannelById;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$findChannelById,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindChannelLatestMessage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findChannelById = findChannelById;
+    final lOther$findChannelById = other.findChannelById;
+    if (l$findChannelById != lOther$findChannelById) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindChannelLatestMessage
+    on Query$FindChannelLatestMessage {
+  CopyWith$Query$FindChannelLatestMessage<Query$FindChannelLatestMessage>
+      get copyWith => CopyWith$Query$FindChannelLatestMessage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindChannelLatestMessage<TRes> {
+  factory CopyWith$Query$FindChannelLatestMessage(
+    Query$FindChannelLatestMessage instance,
+    TRes Function(Query$FindChannelLatestMessage) then,
+  ) = _CopyWithImpl$Query$FindChannelLatestMessage;
+
+  factory CopyWith$Query$FindChannelLatestMessage.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindChannelLatestMessage;
+
+  TRes call({
+    Query$FindChannelLatestMessage$findChannelById? findChannelById,
+    String? $__typename,
+  });
+  CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes>
+      get findChannelById;
+}
+
+class _CopyWithImpl$Query$FindChannelLatestMessage<TRes>
+    implements CopyWith$Query$FindChannelLatestMessage<TRes> {
+  _CopyWithImpl$Query$FindChannelLatestMessage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindChannelLatestMessage _instance;
+
+  final TRes Function(Query$FindChannelLatestMessage) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findChannelById = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindChannelLatestMessage(
+        findChannelById:
+            findChannelById == _undefined || findChannelById == null
+                ? _instance.findChannelById
+                : (findChannelById
+                    as Query$FindChannelLatestMessage$findChannelById),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes>
+      get findChannelById {
+    final local$findChannelById = _instance.findChannelById;
+    return CopyWith$Query$FindChannelLatestMessage$findChannelById(
+        local$findChannelById, (e) => call(findChannelById: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindChannelLatestMessage<TRes>
+    implements CopyWith$Query$FindChannelLatestMessage<TRes> {
+  _CopyWithStubImpl$Query$FindChannelLatestMessage(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindChannelLatestMessage$findChannelById? findChannelById,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes>
+      get findChannelById =>
+          CopyWith$Query$FindChannelLatestMessage$findChannelById.stub(_res);
+}
+
+const documentNodeQueryFindChannelLatestMessage = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindChannelLatestMessage'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'channelId')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findChannelById'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'id'),
+            value: VariableNode(name: NameNode(value: 'channelId')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'latestMessage'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'createdAt'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'messageText'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindChannelLatestMessage$findChannelById {
+  Query$FindChannelLatestMessage$findChannelById({
+    required this.latestMessage,
+    this.$__typename = 'Channel',
+  });
+
+  factory Query$FindChannelLatestMessage$findChannelById.fromJson(
+      Map<String, dynamic> json) {
+    final l$latestMessage = json['latestMessage'];
+    final l$$__typename = json['__typename'];
+    return Query$FindChannelLatestMessage$findChannelById(
+      latestMessage:
+          Query$FindChannelLatestMessage$findChannelById$latestMessage.fromJson(
+              (l$latestMessage as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindChannelLatestMessage$findChannelById$latestMessage
+      latestMessage;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$latestMessage = latestMessage;
+    _resultData['latestMessage'] = l$latestMessage.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$latestMessage = latestMessage;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$latestMessage,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindChannelLatestMessage$findChannelById) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$latestMessage = latestMessage;
+    final lOther$latestMessage = other.latestMessage;
+    if (l$latestMessage != lOther$latestMessage) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindChannelLatestMessage$findChannelById
+    on Query$FindChannelLatestMessage$findChannelById {
+  CopyWith$Query$FindChannelLatestMessage$findChannelById<
+          Query$FindChannelLatestMessage$findChannelById>
+      get copyWith => CopyWith$Query$FindChannelLatestMessage$findChannelById(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes> {
+  factory CopyWith$Query$FindChannelLatestMessage$findChannelById(
+    Query$FindChannelLatestMessage$findChannelById instance,
+    TRes Function(Query$FindChannelLatestMessage$findChannelById) then,
+  ) = _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById;
+
+  factory CopyWith$Query$FindChannelLatestMessage$findChannelById.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById;
+
+  TRes call({
+    Query$FindChannelLatestMessage$findChannelById$latestMessage? latestMessage,
+    String? $__typename,
+  });
+  CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<TRes>
+      get latestMessage;
+}
+
+class _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById<TRes>
+    implements CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes> {
+  _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindChannelLatestMessage$findChannelById _instance;
+
+  final TRes Function(Query$FindChannelLatestMessage$findChannelById) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? latestMessage = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindChannelLatestMessage$findChannelById(
+        latestMessage: latestMessage == _undefined || latestMessage == null
+            ? _instance.latestMessage
+            : (latestMessage
+                as Query$FindChannelLatestMessage$findChannelById$latestMessage),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<TRes>
+      get latestMessage {
+    final local$latestMessage = _instance.latestMessage;
+    return CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage(
+        local$latestMessage, (e) => call(latestMessage: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById<TRes>
+    implements CopyWith$Query$FindChannelLatestMessage$findChannelById<TRes> {
+  _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindChannelLatestMessage$findChannelById$latestMessage? latestMessage,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<TRes>
+      get latestMessage =>
+          CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage
+              .stub(_res);
+}
+
+class Query$FindChannelLatestMessage$findChannelById$latestMessage {
+  Query$FindChannelLatestMessage$findChannelById$latestMessage({
+    required this.createdAt,
+    this.messageText,
+    this.$__typename = 'ChannelMessage',
+  });
+
+  factory Query$FindChannelLatestMessage$findChannelById$latestMessage.fromJson(
+      Map<String, dynamic> json) {
+    final l$createdAt = json['createdAt'];
+    final l$messageText = json['messageText'];
+    final l$$__typename = json['__typename'];
+    return Query$FindChannelLatestMessage$findChannelById$latestMessage(
+      createdAt: DateTime.parse((l$createdAt as String)),
+      messageText: (l$messageText as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final DateTime createdAt;
+
+  final String? messageText;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$createdAt = createdAt;
+    _resultData['createdAt'] = l$createdAt.toIso8601String();
+    final l$messageText = messageText;
+    _resultData['messageText'] = l$messageText;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$createdAt = createdAt;
+    final l$messageText = messageText;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$createdAt,
+      l$messageText,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindChannelLatestMessage$findChannelById$latestMessage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$messageText = messageText;
+    final lOther$messageText = other.messageText;
+    if (l$messageText != lOther$messageText) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindChannelLatestMessage$findChannelById$latestMessage
+    on Query$FindChannelLatestMessage$findChannelById$latestMessage {
+  CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+          Query$FindChannelLatestMessage$findChannelById$latestMessage>
+      get copyWith =>
+          CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+    TRes> {
+  factory CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage(
+    Query$FindChannelLatestMessage$findChannelById$latestMessage instance,
+    TRes Function(Query$FindChannelLatestMessage$findChannelById$latestMessage)
+        then,
+  ) = _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage;
+
+  factory CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage;
+
+  TRes call({
+    DateTime? createdAt,
+    String? messageText,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+        TRes>
+    implements
+        CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+            TRes> {
+  _CopyWithImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindChannelLatestMessage$findChannelById$latestMessage _instance;
+
+  final TRes Function(
+      Query$FindChannelLatestMessage$findChannelById$latestMessage) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? createdAt = _undefined,
+    Object? messageText = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindChannelLatestMessage$findChannelById$latestMessage(
+        createdAt: createdAt == _undefined || createdAt == null
+            ? _instance.createdAt
+            : (createdAt as DateTime),
+        messageText: messageText == _undefined
+            ? _instance.messageText
+            : (messageText as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+        TRes>
+    implements
+        CopyWith$Query$FindChannelLatestMessage$findChannelById$latestMessage<
+            TRes> {
+  _CopyWithStubImpl$Query$FindChannelLatestMessage$findChannelById$latestMessage(
+      this._res);
+
+  TRes _res;
+
+  call({
+    DateTime? createdAt,
+    String? messageText,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
 class Query$GetChannelsList {
   Query$GetChannelsList({
     required this.findChannels,

--- a/lib/__generated/schema/operations_message.graphql.dart
+++ b/lib/__generated/schema/operations_message.graphql.dart
@@ -1978,34 +1978,6 @@ const documentNodeQueryInboxUnseenMessages = DocumentNode(definitions: [
                     selectionSet: null,
                   ),
                   FieldNode(
-                    name: NameNode(value: 'id'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'messageText'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'senderFullName'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'createdBy'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
                     name: NameNode(value: '__typename'),
                     alias: null,
                     arguments: [],
@@ -2353,40 +2325,20 @@ class _CopyWithStubImpl$Query$InboxUnseenMessages$myInbox$channels<TRes>
 class Query$InboxUnseenMessages$myInbox$channels$unseenMessages {
   Query$InboxUnseenMessages$myInbox$channels$unseenMessages({
     required this.channelId,
-    required this.id,
-    this.messageText,
-    this.senderFullName,
-    this.createdBy,
     this.$__typename = 'ChannelInboxItemMessage',
   });
 
   factory Query$InboxUnseenMessages$myInbox$channels$unseenMessages.fromJson(
       Map<String, dynamic> json) {
     final l$channelId = json['channelId'];
-    final l$id = json['id'];
-    final l$messageText = json['messageText'];
-    final l$senderFullName = json['senderFullName'];
-    final l$createdBy = json['createdBy'];
     final l$$__typename = json['__typename'];
     return Query$InboxUnseenMessages$myInbox$channels$unseenMessages(
       channelId: (l$channelId as String),
-      id: (l$id as String),
-      messageText: (l$messageText as String?),
-      senderFullName: (l$senderFullName as String?),
-      createdBy: (l$createdBy as String?),
       $__typename: (l$$__typename as String),
     );
   }
 
   final String channelId;
-
-  final String id;
-
-  final String? messageText;
-
-  final String? senderFullName;
-
-  final String? createdBy;
 
   final String $__typename;
 
@@ -2394,14 +2346,6 @@ class Query$InboxUnseenMessages$myInbox$channels$unseenMessages {
     final _resultData = <String, dynamic>{};
     final l$channelId = channelId;
     _resultData['channelId'] = l$channelId;
-    final l$id = id;
-    _resultData['id'] = l$id;
-    final l$messageText = messageText;
-    _resultData['messageText'] = l$messageText;
-    final l$senderFullName = senderFullName;
-    _resultData['senderFullName'] = l$senderFullName;
-    final l$createdBy = createdBy;
-    _resultData['createdBy'] = l$createdBy;
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -2410,17 +2354,9 @@ class Query$InboxUnseenMessages$myInbox$channels$unseenMessages {
   @override
   int get hashCode {
     final l$channelId = channelId;
-    final l$id = id;
-    final l$messageText = messageText;
-    final l$senderFullName = senderFullName;
-    final l$createdBy = createdBy;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$channelId,
-      l$id,
-      l$messageText,
-      l$senderFullName,
-      l$createdBy,
       l$$__typename,
     ]);
   }
@@ -2437,26 +2373,6 @@ class Query$InboxUnseenMessages$myInbox$channels$unseenMessages {
     final l$channelId = channelId;
     final lOther$channelId = other.channelId;
     if (l$channelId != lOther$channelId) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$messageText = messageText;
-    final lOther$messageText = other.messageText;
-    if (l$messageText != lOther$messageText) {
-      return false;
-    }
-    final l$senderFullName = senderFullName;
-    final lOther$senderFullName = other.senderFullName;
-    if (l$senderFullName != lOther$senderFullName) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (l$createdBy != lOther$createdBy) {
       return false;
     }
     final l$$__typename = $__typename;
@@ -2493,10 +2409,6 @@ abstract class CopyWith$Query$InboxUnseenMessages$myInbox$channels$unseenMessage
 
   TRes call({
     String? channelId,
-    String? id,
-    String? messageText,
-    String? senderFullName,
-    String? createdBy,
     String? $__typename,
   });
 }
@@ -2520,26 +2432,12 @@ class _CopyWithImpl$Query$InboxUnseenMessages$myInbox$channels$unseenMessages<
 
   TRes call({
     Object? channelId = _undefined,
-    Object? id = _undefined,
-    Object? messageText = _undefined,
-    Object? senderFullName = _undefined,
-    Object? createdBy = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$InboxUnseenMessages$myInbox$channels$unseenMessages(
         channelId: channelId == _undefined || channelId == null
             ? _instance.channelId
             : (channelId as String),
-        id: id == _undefined || id == null ? _instance.id : (id as String),
-        messageText: messageText == _undefined
-            ? _instance.messageText
-            : (messageText as String?),
-        senderFullName: senderFullName == _undefined
-            ? _instance.senderFullName
-            : (senderFullName as String?),
-        createdBy: createdBy == _undefined
-            ? _instance.createdBy
-            : (createdBy as String?),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
@@ -2558,10 +2456,6 @@ class _CopyWithStubImpl$Query$InboxUnseenMessages$myInbox$channels$unseenMessage
 
   call({
     String? channelId,
-    String? id,
-    String? messageText,
-    String? senderFullName,
-    String? createdBy,
     String? $__typename,
   }) =>
       _res;

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -25049,7 +25049,7 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
     case Enum$ServiceRequestType.graphQlQueryFindChannelParticipantById:
       return r'graphQlQueryFindChannelParticipantById';
     case Enum$ServiceRequestType
-          .graphQlQueryFindPendingChannelInvitationsForUser:
+        .graphQlQueryFindPendingChannelInvitationsForUser:
       return r'graphQlQueryFindPendingChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryMyInbox:
       return r'graphQlQueryMyInbox';

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -25049,7 +25049,7 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
     case Enum$ServiceRequestType.graphQlQueryFindChannelParticipantById:
       return r'graphQlQueryFindChannelParticipantById';
     case Enum$ServiceRequestType
-        .graphQlQueryFindPendingChannelInvitationsForUser:
+          .graphQlQueryFindPendingChannelInvitationsForUser:
       return r'graphQlQueryFindPendingChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryMyInbox:
       return r'graphQlQueryMyInbox';

--- a/lib/providers/channels_provider.dart
+++ b/lib/providers/channels_provider.dart
@@ -6,17 +6,17 @@ import '../__generated/schema/operations_channel.graphql.dart';
 import 'base/base_provider.dart';
 import 'base/operation_result.dart';
 
+typedef ChannelById = Query$FindChannelById$findChannelById;
 typedef ChannelForUser = Query$FindChannelsForUser$findChannelsForUser;
 typedef ChannelForUserParticipant
     = Query$FindChannelsForUser$findChannelsForUser$participants;
-typedef ChannelById = Query$FindChannelById$findChannelById;
 typedef ChannelParticipant = Query$FindChannelById$findChannelById$participants;
+typedef ChannelLatestMessage
+    = Query$FindChannelLatestMessage$findChannelById$latestMessage;
+typedef InvitationInbox = Query$GetInboxInvitations$myInbox;
 
 class ChannelsProvider extends BaseProvider {
-  ChannelsProvider({required super.client}) {
-    debugPrint('ChannelsProvider initialized');
-    // subscribeToChannels();
-  }
+  ChannelsProvider({required super.client});
 
   // Queries
   Future<OperationResult<List<ChannelForUser>>> queryUserChannels({
@@ -38,61 +38,61 @@ class ChannelsProvider extends BaseProvider {
     );
   }
 
-  Widget findChannelById({
+  Future<OperationResult<ChannelById>> findChannelById({
     required String channelId,
-    required Widget Function(
-      OperationResult<Query$FindChannelById$findChannelById> data, {
-      void Function()? refetch,
-      void Function(FetchMoreOptions)? fetchMore,
-    }) onData,
-    Widget Function()? onLoading,
-    Widget Function(String error, {void Function()? refetch})? onError,
-  }) {
-    return runQuery(
-      document: documentNodeQueryFindChannelById,
-      variables: Variables$Query$FindChannelById(channelId: channelId).toJson(),
-      onData: (queryResult, {refetch, fetchMore}) {
-        final OperationResult<Query$FindChannelById$findChannelById> result =
-            OperationResult(
-          gqlQueryResult: queryResult,
-          response: queryResult.data != null
-              ? Query$FindChannelById.fromJson(
-                  queryResult.data!,
-                ).findChannelById
-              : null,
-        );
-        return onData(result, refetch: refetch, fetchMore: fetchMore);
-      },
-      onLoading: onLoading,
-      onError: onError,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindChannelById,
+        variables:
+            Variables$Query$FindChannelById(channelId: channelId).toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindChannelById.fromJson(
+              queryResult.data!,
+            ).findChannelById
+          : null,
     );
   }
 
-  Widget getInboxInvitations({
-    required Widget Function(
-      OperationResult<Query$GetInboxInvitations$myInbox> data, {
-      void Function()? refetch,
-      void Function(FetchMoreOptions)? fetchMore,
-    }) onData,
-    Widget Function()? onLoading,
-    Widget Function(String error, {void Function()? refetch})? onError,
-  }) {
-    return runQuery(
-      document: documentNodeQueryGetInboxInvitations,
-      onData: (queryResult, {refetch, fetchMore}) {
-        final OperationResult<Query$GetInboxInvitations$myInbox> result =
-            OperationResult(
-          gqlQueryResult: queryResult,
-          response: queryResult.data != null
-              ? Query$GetInboxInvitations.fromJson(
-                  queryResult.data!,
-                ).myInbox
-              : null,
-        );
-        return onData(result, refetch: refetch, fetchMore: fetchMore);
-      },
-      onLoading: onLoading,
-      onError: onError,
+  Future<OperationResult<ChannelLatestMessage>> findChannelLatestMessage({
+    required String channelId,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindChannelLatestMessage,
+        fetchPolicy: FetchPolicy.noCache,
+        variables:
+            Variables$Query$FindChannelLatestMessage(channelId: channelId)
+                .toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindChannelLatestMessage.fromJson(
+              queryResult.data!,
+            ).findChannelById.latestMessage
+          : null,
+    );
+  }
+
+  Future<OperationResult<InvitationInbox>> getInboxInvitations() async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryGetInboxInvitations,
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$GetInboxInvitations.fromJson(
+              queryResult.data!,
+            ).myInbox
+          : null,
     );
   }
 

--- a/lib/providers/models/chat_model.dart
+++ b/lib/providers/models/chat_model.dart
@@ -10,7 +10,7 @@ import '../messages_provider.dart';
 
 class ChatModel extends ChangeNotifier {
   final String channelId;
-  final MessagesProvider messagesProvider;
+  final MessagesProvider _messagesProvider;
   List<ChannelMessage>? _channelMessages;
   StreamSubscription<QueryResult<Object?>>? _streamSubscription;
   AsyncState _state = AsyncState.loading;
@@ -21,14 +21,14 @@ class ChatModel extends ChangeNotifier {
   ChatModel({
     required BuildContext context,
     required this.channelId,
-  }) : messagesProvider = Provider.of<MessagesProvider>(
+  }) : _messagesProvider = Provider.of<MessagesProvider>(
           context,
           listen: false,
         );
 
   Future<void> refreshChannelMessages() async {
     _state = AsyncState.loading;
-    final result = await messagesProvider.findChannelMessages(
+    final result = await _messagesProvider.findChannelMessages(
       fetchFromNetworkOnly: true,
       input: Input$ChannelMessageListFilter(channelId: channelId),
     );
@@ -45,7 +45,7 @@ class ChatModel extends ChangeNotifier {
     if (_streamSubscription != null) {
       return;
     }
-    _streamSubscription = messagesProvider.subscribeToChannel(
+    _streamSubscription = _messagesProvider.subscribeToChannel(
       channelId: channelId,
       onSubscriptionEvent: () => refreshChannelMessages(),
     );

--- a/lib/providers/models/chat_model.dart
+++ b/lib/providers/models/chat_model.dart
@@ -11,11 +11,11 @@ import '../messages_provider.dart';
 class ChatModel extends ChangeNotifier {
   final String channelId;
   final MessagesProvider _messagesProvider;
-  List<ChannelMessage>? _channelMessages;
+  List<ChannelMessage> _channelMessages = [];
   StreamSubscription<QueryResult<Object?>>? _streamSubscription;
   AsyncState _state = AsyncState.loading;
 
-  List<ChannelMessage> get channelMessages => _channelMessages ?? [];
+  List<ChannelMessage> get channelMessages => _channelMessages;
   AsyncState get state => _state;
 
   ChatModel({

--- a/lib/schema/operations_channel.graphql
+++ b/lib/schema/operations_channel.graphql
@@ -34,6 +34,15 @@ query FindChannelById ($channelId: String!) {
     }
 }
 
+query FindChannelLatestMessage ($channelId: String!) {
+    findChannelById(id: $channelId) {
+        latestMessage {
+            createdAt
+            messageText
+        }
+    }
+}
+
 query GetChannelsList {
     findChannels {
         id

--- a/lib/schema/operations_message.graphql
+++ b/lib/schema/operations_message.graphql
@@ -36,10 +36,6 @@ query InboxUnseenMessages {
         channels {
             unseenMessages {
                 channelId
-                id
-                messageText
-                senderFullName
-                createdBy
             }
         }
     }

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -497,6 +497,7 @@ type Channel {
   syncedWithMm2At: DateTime
   creator: User!
   invitations: [ChannelInvitation!]!
+  latestMessage: ChannelMessage!
   messages: [ChannelMessage!]!
   participants: [ChannelParticipant!]!
   pendingInvitations: [ChannelInvitation!]!

--- a/lib/widgets/molecules/inbox_chat_list_tile.dart
+++ b/lib/widgets/molecules/inbox_chat_list_tile.dart
@@ -37,7 +37,7 @@ class _InboxChatListTileState extends State<InboxChatListTile> {
 
   @override
   void dispose() {
-    _inboxChatTileModel?.createChannelSubscription();
+    _inboxChatTileModel?.cancelChannelSubscription();
     super.dispose();
   }
 

--- a/lib/widgets/screens/channel_messages/channel_messages.dart
+++ b/lib/widgets/screens/channel_messages/channel_messages.dart
@@ -38,9 +38,9 @@ class ChannelMessagesScreen extends StatefulWidget {
 
 class _ChannelMessagesScreenState extends State<ChannelMessagesScreen>
     with RouteAwareMixin<ChannelMessagesScreen> {
-  ChannelsProvider? _channelsProvider;
-  Future<OperationResult<ChannelById>>? _channel;
-  AuthenticatedUser? _user;
+  late final ChannelsProvider _channelsProvider;
+  late final AuthenticatedUser? _user;
+  late Future<OperationResult<ChannelById>> _channel;
 
   @override
   void initState() {
@@ -52,7 +52,7 @@ class _ChannelMessagesScreenState extends State<ChannelMessagesScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _channel = _channelsProvider?.findChannelById(channelId: widget.channelId);
+    _channel = _channelsProvider.findChannelById(channelId: widget.channelId);
   }
 
   void _refreshScaffold(
@@ -135,8 +135,8 @@ class _ChannelChatState extends State<ChannelChat> {
   final TextEditingController messageTextController = TextEditingController();
   final ScrollController listScrollController = ScrollController();
   final Duration _animationDuration = const Duration(milliseconds: 250);
-  ChatModel? _chatModel;
-  MessagesProvider? _messagesProvider;
+  late final ChatModel _chatModel;
+  late final MessagesProvider _messagesProvider;
   int _messageCount = 0;
   bool _unreadMessages = false; // Non-local Message exists outside of viewport
   ChannelMessage? _focusedMessage; // Intended reply Message
@@ -147,25 +147,25 @@ class _ChannelChatState extends State<ChannelChat> {
     _chatModel = Provider.of<ChatModel>(context, listen: false);
     _messagesProvider = Provider.of<MessagesProvider>(context, listen: false);
     _markMessageRead();
-    _chatModel!.createChannelSubscription();
-    _messageCount = _chatModel!.channelMessages.length;
+    _chatModel.createChannelSubscription();
+    _messageCount = _chatModel.channelMessages.length;
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _chatModel!.refreshChannelMessages();
+    _chatModel.refreshChannelMessages();
   }
 
   _markMessageRead() {
-    _messagesProvider?.markMessageRead(channelId: widget.channel.id);
+    _messagesProvider.markMessageRead(channelId: widget.channel.id);
   }
 
   void _processNewMessages() {
-    if (_messageCount < _chatModel!.channelMessages.length) {
+    if (_messageCount < _chatModel.channelMessages.length) {
       _markMessageRead();
       if (_isCurrentUser(
-        userId: _chatModel!.channelMessages.last.createdBy,
+        userId: _chatModel.channelMessages.last.createdBy,
         context: context,
       )) {
         _scrollDown();
@@ -173,12 +173,12 @@ class _ChannelChatState extends State<ChannelChat> {
         _unreadMessages = true;
       }
     }
-    _messageCount = _chatModel!.channelMessages.length;
+    _messageCount = _chatModel.channelMessages.length;
   }
 
   @override
   void dispose() {
-    _chatModel?.cancelChannelSubscription();
+    _chatModel.cancelChannelSubscription();
     messageTextController.dispose();
     listScrollController.dispose();
     super.dispose();
@@ -186,7 +186,7 @@ class _ChannelChatState extends State<ChannelChat> {
 
   void _scrollDown() {
     if (listScrollController.hasClients &&
-        _chatModel!.channelMessages.isNotEmpty) {
+        _chatModel.channelMessages.isNotEmpty) {
       listScrollController.animateTo(
         listScrollController.position.minScrollExtent,
         duration: _animationDuration,
@@ -231,12 +231,11 @@ class _ChannelChatState extends State<ChannelChat> {
   Widget build(BuildContext context) {
     return Consumer<ChatModel>(
       builder: (context, chatModel, child) {
-        _chatModel = chatModel;
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _processNewMessages();
         });
         return AppUtility.widgetForAsyncState(
-          state: _chatModel!.state,
+          state: chatModel.state,
           onReady: () => Column(
             mainAxisAlignment: MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -260,7 +259,7 @@ class _ChannelChatState extends State<ChannelChat> {
                 replyingTo: _focusedMessage,
                 participants: widget.channel.participants,
                 onSubmit: (val, replyToMessageId) {
-                  _messagesProvider!.createMessage(
+                  _messagesProvider.createMessage(
                     input: Input$ChannelMessageInput(
                       channelId: widget.channel.id,
                       messageText: val,

--- a/lib/widgets/screens/inbox/inbox_chats.dart
+++ b/lib/widgets/screens/inbox/inbox_chats.dart
@@ -23,7 +23,7 @@ class InboxChatsScreen extends StatefulWidget {
 
 class _InboxChatsScreenState extends State<InboxChatsScreen>
     with RouteAwareMixin<InboxChatsScreen> {
-  AuthenticatedUser? _user;
+  late final AuthenticatedUser? _user;
   Future<OperationResult<List<ChannelForUser>>>? _userChannels;
 
   @override

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -4,7 +4,9 @@ import * as generators from "./util/generators";
 export function mockQueries(serverState: MockServerState) {
     return {
         findChannelById: () => {
-            return serverState.channels[0];
+            var channel = serverState.channels[0];
+            channel.latestMessage = serverState.channelMessages[serverState.channelMessages.length-1];
+            return channel;
         },
         findChannelMessages: () => {
             return serverState.channelMessages;


### PR DESCRIPTION
- Update the remaining queries inside ChannelsProvider to return Future instead of Widget
- Updated the query for the channels last message to use instead Channel.latestMessage
- Some miscellaneous house keeping in related classes

Note that I tried to also implement an improved version of the query for unseen messages, but it seems that the corresponding backend query is not working as expected. This will be revised later.