### PR TITLE
Quick fix to change the padding of the chips in the "How can I help" section

### DIFF
--- a/lib/widgets/screens/profile/how_can_i_help_section.dart
+++ b/lib/widgets/screens/profile/how_can_i_help_section.dart
@@ -83,7 +83,8 @@ class HowCanIHelpSection extends StatelessWidget {
             children: [
               for (var chip in chips)
                 Padding(
-                  padding: const EdgeInsets.all(Insets.paddingExtraSmall),
+                  padding:
+                      const EdgeInsets.only(right: Insets.paddingExtraSmall),
                   child: chip,
                 )
             ],

--- a/lib/widgets/screens/profile/how_can_i_help_section.dart
+++ b/lib/widgets/screens/profile/how_can_i_help_section.dart
@@ -84,7 +84,7 @@ class HowCanIHelpSection extends StatelessWidget {
               for (var chip in chips)
                 Padding(
                   padding: const EdgeInsetsDirectional.only(
-                      start: Insets.paddingExtraSmall),
+                      end: Insets.paddingExtraSmall),
                   child: chip,
                 )
             ],

--- a/lib/widgets/screens/profile/how_can_i_help_section.dart
+++ b/lib/widgets/screens/profile/how_can_i_help_section.dart
@@ -83,8 +83,8 @@ class HowCanIHelpSection extends StatelessWidget {
             children: [
               for (var chip in chips)
                 Padding(
-                  padding:
-                      const EdgeInsets.only(right: Insets.paddingExtraSmall),
+                  padding: const EdgeInsetsDirectional.only(
+                      start: Insets.paddingExtraSmall),
                   child: chip,
                 )
             ],

--- a/lib/widgets/screens/profile/profile_about_me.dart
+++ b/lib/widgets/screens/profile/profile_about_me.dart
@@ -24,7 +24,8 @@ class ProfileAboutMe extends StatelessWidget {
           children: [
             for (var chip in chips)
               Padding(
-                padding: const EdgeInsets.only(right: Insets.paddingExtraSmall),
+                padding: const EdgeInsetsDirectional.only(
+                    start: Insets.paddingExtraSmall),
                 child: chip,
               )
           ],

--- a/lib/widgets/screens/profile/profile_about_me.dart
+++ b/lib/widgets/screens/profile/profile_about_me.dart
@@ -25,7 +25,7 @@ class ProfileAboutMe extends StatelessWidget {
             for (var chip in chips)
               Padding(
                 padding: const EdgeInsetsDirectional.only(
-                    start: Insets.paddingExtraSmall),
+                    end: Insets.paddingExtraSmall),
                 child: chip,
               )
           ],


### PR DESCRIPTION
Hello,
This is a quick fix to the padding of the "How can I help" section of the profile. Here's what it looks like on an Android emulator. 
<img width="397" alt="Screenshot 2023-08-10 at 3 13 02 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/63002494/2bcece98-acd1-4dab-888f-84e2292ab4fe">
