### PR TITLE
Rename ExploreCardFilterProvider to ExploreCardFilterModel

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,8 +11,8 @@ import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/firebase_notifications.dart';
 import 'package:mm_flutter_app/providers/channels_provider.dart';
 import 'package:mm_flutter_app/providers/messages_provider.dart';
+import 'package:mm_flutter_app/providers/models/explore_card_filters_model.dart';
 import 'package:mm_flutter_app/providers/models/scaffold_model.dart';
-import 'package:mm_flutter_app/providers/explore_card_filters_provider.dart';
 import 'package:mm_flutter_app/services/graphql/graphql.dart';
 import 'package:mm_flutter_app/utilities/errors/crash_handler.dart';
 import 'package:mm_flutter_app/utilities/router.dart';
@@ -130,7 +130,7 @@ void main() async {
                 create: (context) => ScaffoldModel(),
               ),
               ChangeNotifierProvider(
-                create: (context) => ExploreCardFiltersProvider(),
+                create: (context) => ExploreCardFiltersModel(),
               ),
               Provider<RouteObserver<PageRoute>>.value(
                 value: RouteObserver<PageRoute>(),

--- a/lib/providers/models/explore_card_filters_model.dart
+++ b/lib/providers/models/explore_card_filters_model.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class ExploreCardFiltersProvider extends ChangeNotifier {
+class ExploreCardFiltersModel extends ChangeNotifier {
   static const List<String> countries = ['USA'];
   static const List<String> languages = ['English', 'Urdu', 'Hindi'];
   static const List<String> skills = ['Marketing', 'Operations', 'StartingUp'];

--- a/lib/widgets/atoms/explore_filter.dart
+++ b/lib/widgets/atoms/explore_filter.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-import 'package:mm_flutter_app/providers/explore_card_filters_provider.dart';
+import 'package:mm_flutter_app/providers/models/explore_card_filters_model.dart';
 import 'package:provider/provider.dart';
 
 class ExploreFilter extends StatelessWidget {
@@ -120,7 +120,7 @@ class ExploreFilter extends StatelessWidget {
                 ],
               ),
               Expanded(
-                child: Consumer<ExploreCardFiltersProvider>(
+                child: Consumer<ExploreCardFiltersModel>(
                     builder: (context, filters, _) => Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [

--- a/lib/widgets/molecules/recommended_mentors_filters.dart
+++ b/lib/widgets/molecules/recommended_mentors_filters.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-import 'package:mm_flutter_app/providers/explore_card_filters_provider.dart';
+import 'package:mm_flutter_app/providers/models/explore_card_filters_model.dart';
 import 'package:mm_flutter_app/providers/models/scaffold_model.dart';
 import 'package:mm_flutter_app/utilities/router.dart';
 import 'package:mm_flutter_app/widgets/atoms/clear_apply_buttons.dart';
@@ -22,7 +22,7 @@ class _RecommendedMentorsFilters extends State<RecommendedMentorsFilters>
     with RouteAwareMixin<RecommendedMentorsFilters> {
   late final TextfieldTagsController _countriesController;
   late final TextfieldTagsController _languagesController;
-  late final ExploreCardFiltersProvider _filtersProvider;
+  late final ExploreCardFiltersModel _filtersModel;
   Set<String> _selectedSkills = {};
 
   @override
@@ -30,9 +30,9 @@ class _RecommendedMentorsFilters extends State<RecommendedMentorsFilters>
     super.initState();
     _countriesController = TextfieldTagsController();
     _languagesController = TextfieldTagsController();
-    _filtersProvider =
-        Provider.of<ExploreCardFiltersProvider>(context, listen: false);
-    _selectedSkills = _filtersProvider.selectedSkills;
+    _filtersModel =
+        Provider.of<ExploreCardFiltersModel>(context, listen: false);
+    _selectedSkills = _filtersModel.selectedSkills;
   }
 
   @override
@@ -78,16 +78,16 @@ class _RecommendedMentorsFilters extends State<RecommendedMentorsFilters>
             AutocompletePicker(
               fieldName: l10n.exploreSearchFilterHeadingLanguage,
               controller: _languagesController,
-              options: ExploreCardFiltersProvider.languages,
+              options: ExploreCardFiltersModel.languages,
               optionsTranslations: l10n.exploreSearchFilterLanguages,
-              selectedOptions: _filtersProvider.selectedLanguages,
+              selectedOptions: _filtersModel.selectedLanguages,
             ),
             AutocompletePicker(
               fieldName: l10n.exploreSearchFilterHeadingCountries,
               controller: _countriesController,
-              options: ExploreCardFiltersProvider.countries,
+              options: ExploreCardFiltersModel.countries,
               optionsTranslations: l10n.exploreSearchFilterCountries,
-              selectedOptions: _filtersProvider.selectedCountries,
+              selectedOptions: _filtersModel.selectedCountries,
             ),
           ]),
           Align(
@@ -105,7 +105,7 @@ class _RecommendedMentorsFilters extends State<RecommendedMentorsFilters>
               _selectedSkills.clear();
             }),
             onApply: () {
-              _filtersProvider.setFilters(
+              _filtersModel.setFilters(
                 selectedCountries: _countriesController.getTags?.toSet(),
                 selectedLanguages: _languagesController.getTags?.toSet(),
                 selectedSkills: _selectedSkills,
@@ -136,8 +136,8 @@ class _ExpertiseState extends State<_Expertise> {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     var skillButtons = [];
-    for (int i = 0; i < ExploreCardFiltersProvider.skills.length; i++) {
-      var skill = ExploreCardFiltersProvider.skills[i];
+    for (int i = 0; i < ExploreCardFiltersModel.skills.length; i++) {
+      var skill = ExploreCardFiltersModel.skills[i];
       var isSelected = widget.skills.contains(skill);
 
       skillButtons.add(OutlinedButton(
@@ -158,13 +158,13 @@ class _ExpertiseState extends State<_Expertise> {
         child: Text(l10n.exploreSearchFilterSkills(skill),
             style: TextStyle(color: theme.colorScheme.primary)),
       ));
-      if (i != ExploreCardFiltersProvider.skills.length - 1) {
+      if (i != ExploreCardFiltersModel.skills.length - 1) {
         skillButtons.add(const SizedBox(width: Insets.paddingExtraSmall));
       }
     }
 
     bool allSkillsSelected =
-        setEquals(widget.skills, ExploreCardFiltersProvider.skills.toSet());
+        setEquals(widget.skills, ExploreCardFiltersModel.skills.toSet());
 
     return Row(
       children: [
@@ -187,7 +187,7 @@ class _ExpertiseState extends State<_Expertise> {
                             } else {
                               widget.skills.clear();
                               widget.skills
-                                  .addAll(ExploreCardFiltersProvider.skills);
+                                  .addAll(ExploreCardFiltersModel.skills);
                             }
                           });
                         },

--- a/lib/widgets/molecules/recommended_mentors_filters_advanced.dart
+++ b/lib/widgets/molecules/recommended_mentors_filters_advanced.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-import 'package:mm_flutter_app/providers/explore_card_filters_provider.dart';
+import 'package:mm_flutter_app/providers/models/explore_card_filters_model.dart';
 import 'package:mm_flutter_app/providers/models/scaffold_model.dart';
 import 'package:mm_flutter_app/utilities/router.dart';
 import 'package:mm_flutter_app/widgets/atoms/clear_apply_buttons.dart';
 import 'package:mm_flutter_app/widgets/molecules/autocomplete_picker.dart';
+import 'package:provider/provider.dart';
 import 'package:textfield_tags/textfield_tags.dart';
 
 class RecommendedMentorsFiltersAdvanced extends StatefulWidget {
@@ -22,18 +22,18 @@ class _RecommendedMentorsFiltersAdvanced
     with RouteAwareMixin<RecommendedMentorsFiltersAdvanced> {
   String? _selectedIndustry;
   late final TextfieldTagsController _userTypesController;
-  late final ExploreCardFiltersProvider _filtersProvider;
+  late final ExploreCardFiltersModel _filtersModel;
   late final TextEditingController _keywordController;
 
   @override
   void initState() {
     super.initState();
     _userTypesController = TextfieldTagsController();
-    _filtersProvider =
-        Provider.of<ExploreCardFiltersProvider>(context, listen: false);
-    _selectedIndustry = _filtersProvider.selectedIndustry;
+    _filtersModel =
+        Provider.of<ExploreCardFiltersModel>(context, listen: false);
+    _selectedIndustry = _filtersModel.selectedIndustry;
     _keywordController =
-        TextEditingController(text: _filtersProvider.selectedKeyword);
+        TextEditingController(text: _filtersModel.selectedKeyword);
   }
 
   @override
@@ -85,7 +85,7 @@ class _RecommendedMentorsFiltersAdvanced
                     const SizedBox(height: Insets.paddingExtraSmall),
                     DropdownButton<String>(
                       isExpanded: true,
-                      items: ExploreCardFiltersProvider.industries
+                      items: ExploreCardFiltersModel.industries
                           .map((industry) => DropdownMenuItem(
                                 value: l10n
                                     .exploreSearchFilterIndustries(industry),
@@ -106,9 +106,9 @@ class _RecommendedMentorsFiltersAdvanced
           AutocompletePicker(
             fieldName: l10n.exploreSearchFilterUserType,
             controller: _userTypesController,
-            options: ExploreCardFiltersProvider.userTypes,
+            options: ExploreCardFiltersModel.userTypes,
             optionsTranslations: l10n.exploreSearchFilterUserTypes,
-            selectedOptions: _filtersProvider.selectedUserTypes,
+            selectedOptions: _filtersModel.selectedUserTypes,
           ),
           Row(
             children: [
@@ -143,7 +143,7 @@ class _RecommendedMentorsFiltersAdvanced
               _userTypesController.clearTags();
             }),
             onApply: () {
-              _filtersProvider.setAdvancedFilters(
+              _filtersModel.setAdvancedFilters(
                 selectedIndustry: _selectedIndustry,
                 selectedUserTypes: _userTypesController.getTags?.toSet(),
                 selectedKeyword: _keywordController.text,


### PR DESCRIPTION
We are using the convention that models are ChangeNotifiers for specific UI components, and the 'Providers' are GraphQL interfaces. Renaming and moving to 'models' folder to avoid confusion.