### PR TITLE
Add support for subscriptions to mock server

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -84,7 +84,7 @@ class _StartScreenState extends State<StartScreen> {
               return SignInScreen(nextRouteName: widget.nextRouteName);
             }
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              context.go(widget.nextRouteName);
+              context.goNamed(widget.nextRouteName);
             });
             return const LoadingScreen();
           },

--- a/mm-mock-server/package-lock.json
+++ b/mm-mock-server/package-lock.json
@@ -9,13 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "firebase-admin": "^11.10.1"
+        "cors": "^2.8.5",
+        "firebase-admin": "^11.10.1",
+        "graphql-subscriptions": "^2.0.0",
+        "graphql-ws": "^5.14.0",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
         "@apollo/server": "^4.7.1",
         "@faker-js/faker": "^8.0.1",
         "@graphql-tools/mock": "^9.0.0",
         "@graphql-tools/schema": "^10.0.0",
+        "@types/cors": "^2.8.13",
+        "@types/ws": "^8.5.5",
         "apollo-server-core": "^3.12.0",
         "fs": "^0.0.1-security",
         "path": "^0.12.7",
@@ -812,6 +818,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -941,6 +956,15 @@
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "dependencies": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1779,7 +1803,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2448,10 +2471,20 @@
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-subscriptions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==",
+      "dependencies": {
+        "iterall": "^1.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -2467,6 +2500,17 @@
       },
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/gtoken": {
@@ -2685,6 +2729,11 @@
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
       "optional": true
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "node_modules/jose": {
       "version": "4.14.4",
@@ -3140,7 +3189,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3985,7 +4033,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4067,6 +4114,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/mm-mock-server/package.json
+++ b/mm-mock-server/package.json
@@ -14,6 +14,8 @@
     "@faker-js/faker": "^8.0.1",
     "@graphql-tools/mock": "^9.0.0",
     "@graphql-tools/schema": "^10.0.0",
+    "@types/cors": "^2.8.13",
+    "@types/ws": "^8.5.5",
     "apollo-server-core": "^3.12.0",
     "fs": "^0.0.1-security",
     "path": "^0.12.7",
@@ -21,6 +23,10 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "firebase-admin": "^11.10.1"
+    "cors": "^2.8.5",
+    "firebase-admin": "^11.10.1",
+    "graphql-subscriptions": "^2.0.0",
+    "graphql-ws": "^5.14.0",
+    "ws": "^8.13.0"
   }
 }

--- a/mm-mock-server/src/mocks/subscriptions.ts
+++ b/mm-mock-server/src/mocks/subscriptions.ts
@@ -1,0 +1,30 @@
+import { withFilter } from 'graphql-subscriptions';
+import { MockServerState } from "./util/state";
+
+export const PUBSUB_OBJECT_CHANGED = 'PUBSUB_OBJECT_CHANGED';
+export const PUBSUB_CHANNEL_CHANGED = 'PUBSUB_CHANNEL_CHANGED';
+
+export function mockSubscriptions(serverState: MockServerState) {
+    return {
+        objectChanged: {
+            subscribe: withFilter(
+                () => serverState.pubsub.asyncIterator([PUBSUB_OBJECT_CHANGED]),
+                (payload, args) => {
+                    return (
+                        payload.objectChanged.objectId == args.objectId
+                    );
+                },
+            ),
+        },
+        channelChanged: {
+            subscribe: withFilter(
+                () => serverState.pubsub.asyncIterator([PUBSUB_CHANNEL_CHANGED]),
+                (payload, args) => {
+                    return (
+                        payload.channelChanged.channelId == args.channelId
+                    );
+                },
+            ),
+        },
+    }
+}

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -1,8 +1,10 @@
+import { PubSub } from 'graphql-subscriptions';
 import { faker } from "@faker-js/faker";
 
 import * as generators from './generators';
 
 export class MockServerState {
+    pubsub: PubSub;
     loggedIn: boolean;
     loggedInUser: any;
     otherUsers: any[];
@@ -13,6 +15,7 @@ export class MockServerState {
     groups: any[];
 
     constructor() {
+        this.pubsub = new PubSub();
         this.groups = generators.generateCoreGroups()
             .concat(generators.generateGroup());
         this.loggedIn = false;


### PR DESCRIPTION
There is no out-of-the-box mock for subscriptions in the Apollo packages, so these were implemented using the WebSockets and an in-memory PubSub, as described in the [Apollo Server docs](https://www.apollographql.com/docs/apollo-server/data/subscriptions).

Tested with several operations on the Inbox chats.