### PR TITLE
Fix provider avatar, home page findAllUsers bugs

### DIFF
--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -148,7 +148,12 @@ class UserProvider extends BaseProvider with ChangeNotifier {
       response: queryResult.data != null
           ? Query$FindMenteeUsers.fromJson(
               queryResult.data!,
-            ).findUsers
+            ).findUsers.map((element) {
+              if (element.avatarUrl == "") {
+                return element.copyWith(avatarUrl: null);
+              }
+              return element;
+            }).toList()
           : null,
     );
   }
@@ -175,7 +180,12 @@ class UserProvider extends BaseProvider with ChangeNotifier {
       response: queryResult.data != null
           ? Query$FindMentorUsers.fromJson(
               queryResult.data!,
-            ).findUsers
+            ).findUsers.map((element) {
+              if (element.avatarUrl == "") {
+                return element.copyWith(avatarUrl: null);
+              }
+              return element;
+            }).toList()
           : null,
     );
   }

--- a/lib/widgets/molecules/recommended_mentors_scroll.dart
+++ b/lib/widgets/molecules/recommended_mentors_scroll.dart
@@ -6,11 +6,12 @@ import 'package:mm_flutter_app/utilities/utility.dart';
 import 'package:mm_flutter_app/widgets/atoms/mentor_card.dart';
 import 'package:provider/provider.dart';
 
+import '../../__generated/schema/schema.graphql.dart';
 import '../../providers/base/operation_result.dart';
 import '../../providers/user_provider.dart';
 
 class RecommendedMentorsScroll extends StatelessWidget {
-  final List<AllUsersResult> mentors;
+  final List<MentorUser> mentors;
 
   const RecommendedMentorsScroll({
     Key? key,
@@ -105,7 +106,7 @@ class RecommendedSection extends StatefulWidget {
 
 class _RecommendedSectionState extends State<RecommendedSection> {
   late final UserProvider _userProvider;
-  late Future<OperationResult<List<AllUsersResult>>> _allUsers;
+  late Future<OperationResult<List<MentorUser>>> _allUsers;
 
   @override
   void initState() {
@@ -116,7 +117,11 @@ class _RecommendedSectionState extends State<RecommendedSection> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _allUsers = _userProvider.findAllUsers();
+    _allUsers = _userProvider.findMentorUsers(
+      optionsInput: Input$FindObjectsOptions(limit: 10), // only return 10 users
+      filterInput: Input$UserListFilter(ids: null), // no filter/null filter
+      matchInput: Input$UserInput(), // empty input, won't restrict matches
+    );
   }
 
   @override
@@ -127,7 +132,7 @@ class _RecommendedSectionState extends State<RecommendedSection> {
         return AppUtility.widgetForAsyncSnapshot(
           snapshot: snapshot,
           onReady: () {
-            List<AllUsersResult> mentors = snapshot.data?.response != null
+            List<MentorUser> mentors = snapshot.data?.response != null
                 ? snapshot.data!.response!.reversed
                     .where(
                         (element) => element.id != widget.authenticatedUser.id)
@@ -141,7 +146,7 @@ class _RecommendedSectionState extends State<RecommendedSection> {
   }
 
   Column _createRecommendedMentorsWidget(
-      List<AllUsersResult> mentors, BuildContext context) {
+      List<MentorUser> mentors, BuildContext context) {
     return Column(
       children: [
         RecommendedMentorsScroll(mentors: mentors),


### PR DESCRIPTION
A couple changes which get the app into a more usable state when connected to the real backend.
 
1. ~~Hacky temp 'fix' on the provider avatar bug. The MMData backend doesn't provide URLs at this time for this field. As a more long term fix in the mmdata backend, we should provide a graphQL resolver for `avatarUrl` and rename the current field to `avatarPath` or something.~~ There is a [PR out](https://github.com/micromentor-team/mmdata/pull/286) in the backend which fixes this issue, not yet merged. This PR adds the fix for null avatar URLs used in `findAllUsers` to the `findMentorUsers` and `findMenteeUsers` queries.
2. Display only 10 Mentor users on the home page, rather than loading the entire users collection onto the app. The app is unusable when connected to the backend due to the amount of data returned.

The fix for 2 will eventually need to be refactored If I am a mentor, I'd probably want to see a list of mentees, not mentors. For that, we need to determine if we want to re-work the existing `RecommendedMentorsScroll` widget, maybe into a `RecommendedUsersScroll` that can contain either mentors, mentees, or a mix of both.