### PR TITLE
Fix GroupMemberships on mock server

### DIFF
--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -129,14 +129,14 @@ export function generateGroupMembership(user: any, group: any) {
         updatedAt: faker.date.recent(),
     }
 
-    if (group.groupIdent === "mentors") {
+    if (membership.groupIdent === "mentors") {
         membership.__typename = "MentorsGroupMembership";
         membership.expertises = faker.helpers.arrayElements(constants.expertises, 2);
         membership.industries = faker.helpers.arrayElements(constants.industries, 2);
         membership.endorsements = faker.number.int(5);
     }
 
-    if (group.groupIdent === "mentees") {
+    if (membership.groupIdent === "mentees") {
         membership.__typename = "MenteesGroupMembership";
         membership.soughtExpertises = faker.helpers.arrayElements(constants.expertises, 2);
         membership.industry = faker.helpers.arrayElement(constants.industries);

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -19,10 +19,10 @@ export class MockServerState {
         this.groups = generators.generateCoreGroups()
             .concat(generators.generateGroup());
         this.loggedIn = false;
-        this.loggedInUser = generators.generateUser(this.groups.filter(g => g.groupIdent === "mentees"));
+        this.loggedInUser = generators.generateUser(this.groups.filter(g => g.ident === "mentees"));
         // 4 users, one for each channel and one who hasn't communicated with the logged in user
         this.otherUsers = [
-            generators.generateUser(this.groups.filter(g => g.groupIdent === "mentors")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentors")),
             generators.generateUser(faker.helpers.arrayElements(this.groups, 1)),
             generators.generateUser(faker.helpers.arrayElements(this.groups, 2)),
             generators.generateUser(faker.helpers.arrayElements(this.groups, 2)),

--- a/mm-mock-server/src/server.ts
+++ b/mm-mock-server/src/server.ts
@@ -31,6 +31,11 @@ async function startApolloServer() {
             Query: mockQueries(serverState),
             Mutation: mockMutations(serverState),
             Subscription: mockSubscriptions(serverState),
+            IGroupMembership: {
+                __resolveType(obj: any, contextValue: any, info: any){
+                    return obj.__typename;
+                },
+            },
         },
     });
 


### PR DESCRIPTION
The findUsers query with GroupMemberships was not working with the mock server. Some variables were misnamed and we also needed a resolver for the IGroupMembership type.