### PR TITLE
Temporarily remove Welcome screen from sign-in flow for testing session

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,6 @@ import 'package:mm_flutter_app/utilities/router.dart';
 import 'package:mm_flutter_app/utilities/utility.dart';
 import 'package:mm_flutter_app/widgets/atoms/loading.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_in/sign_in_screen.dart';
-import 'package:mm_flutter_app/widgets/screens/welcome/welcome_screen.dart';
 import 'package:provider/provider.dart';
 
 import 'firebase_options.dart';
@@ -76,13 +75,11 @@ class _StartScreenState extends State<StartScreen> {
         return AppUtility.widgetForAsyncSnapshot(
           snapshot: snapshot,
           onLoading: () => const LoadingScreen(),
-          onError: () => const WelcomeScreen(),
+          onError: () => SignInScreen(nextRouteName: widget.nextRouteName),
           onReady: () {
             if (snapshot.data?.response == null) {
               // Empty result means that the user not signed in.
-              return widget.nextRouteName == Routes.home.name
-                  ? const WelcomeScreen()
-                  : SignInScreen(nextRouteName: widget.nextRouteName);
+              return SignInScreen(nextRouteName: widget.nextRouteName);
             }
             WidgetsBinding.instance.addPostFrameCallback((_) {
               context.goNamed(widget.nextRouteName);


### PR DESCRIPTION
Remove Welcome screen to simplify the registration and login flow for the next demo. This commit will be reverted after August testing session. The Welcome screen and Signup flow in general will be tested in the September session.