### PR TITLE
Refactored sign up related pages to use a generic widget SignUpTemplate

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -226,6 +226,7 @@
     "iAmAnEntrepreneur": "I am an entrepreneur",
     "entrepreneurDescription": "I own a business and I am looking for a mentor",
     "iAmAMentor": "I am a mentor",
-    "mentorDescription": "I am an experienced professional and I want to share my knowledge"
+    "mentorDescription": "I am an experienced professional and I want to share my knowledge",
+    "invalidEmailSnackBar": "Please enter a valid email address"
 
 }

--- a/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
+++ b/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
 
 import '../../molecules/login_radio_button_cards.dart';
-import '../../molecules/sign_up_bottom_buttons.dart';
+import 'sign_up_bottom_buttons.dart';
 
 class MentorOrEntrepreneurScreen extends StatefulWidget {
   const MentorOrEntrepreneurScreen({Key? key}) : super(key: key);
@@ -20,56 +23,34 @@ class _MentorOrEntrepreneurScreenState
     final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(Insets.paddingExtraLarge),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              const LinearProgressIndicator(value: 0.25),
-              const SizedBox(height: Insets.paddingMedium),
-              Text(
-                l10n.roleMicroMentor,
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-              const SizedBox(height: Insets.paddingMedium),
-              createEntrepreneurMentorCards(context),
-              const SizedBox(height: Insets.paddingMedium),
-              Padding(
-                padding: const EdgeInsets.all(Insets.paddingSmall),
-                child: InkWell(
-                  child: Text(l10n.learnMoreAboutMentoring,
-                      style: TextStyle(
-                        color: theme.colorScheme.primary,
-                        decoration: TextDecoration.underline,
-                      )),
-                  onTap: () {},
-                ),
-              ),
-              const Spacer(),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: Insets.paddingExtraLarge * 2),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Icon(Icons.lock_outline, color: theme.colorScheme.outline),
-                    Expanded(
-                        child: Text(l10n.signUpHiddenInfoDesc,
-                            softWrap: true,
-                            style: theme.textTheme.bodySmall
-                                ?.copyWith(color: theme.colorScheme.outline))),
-                  ],
-                ),
-              ),
-              const SignUpBottomButtons(),
-            ],
+    return SignUpTemplate(
+      progress: SignUpProgress.one,
+      title: l10n.roleMicroMentor,
+      bottomButtons: SignUpBottomButtons(
+          leftButtonText: l10n.previous,
+          rightButtonText: l10n.next,
+          leftOnPress: () {
+            context.pop();
+          },
+          rightOnPress: () {}),
+      footer: SignUpIconFooter(
+          icon: Icons.lock_outline, text: l10n.signUpHiddenInfoDesc),
+      body: Column(
+        children: [
+          createEntrepreneurMentorCards(context),
+          const SizedBox(height: Insets.paddingMedium),
+          Padding(
+            padding: const EdgeInsets.all(Insets.paddingSmall),
+            child: InkWell(
+              child: Text(l10n.learnMoreAboutMentoring,
+                  style: TextStyle(
+                    color: theme.colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  )),
+              onTap: () {},
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/widgets/screens/sign_up/sign_up_bottom_buttons.dart
+++ b/lib/widgets/screens/sign_up/sign_up_bottom_buttons.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class SignUpBottomButtons extends StatelessWidget {

--- a/lib/widgets/screens/sign_up/sign_up_bottom_buttons.dart
+++ b/lib/widgets/screens/sign_up/sign_up_bottom_buttons.dart
@@ -1,20 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class SignUpBottomButtons extends StatelessWidget {
-  final String? nextRoute;
+  final String leftButtonText;
+  final String rightButtonText;
+  final Function()? leftOnPress;
+  final Function()? rightOnPress;
 
   const SignUpBottomButtons({
     Key? key,
-    this.nextRoute,
+    required this.leftButtonText,
+    required this.rightButtonText,
+    this.leftOnPress,
+    this.rightOnPress,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     return SizedBox(
       height: 64.0,
@@ -25,13 +29,11 @@ class SignUpBottomButtons extends StatelessWidget {
             style: TextButton.styleFrom(
               minimumSize: Dimensions.bigButtonSize,
             ),
-            onPressed: () {
-              context.pop();
-            },
+            onPressed: leftOnPress,
             child: Text(
-              l10n.previous,
+              leftButtonText,
               style: theme.textTheme.labelLarge?.copyWith(
-                color: theme.colorScheme.secondary,
+                color: theme.colorScheme.primary,
               ),
             ),
           ),
@@ -43,13 +45,9 @@ class SignUpBottomButtons extends StatelessWidget {
               backgroundColor: theme.colorScheme.primary,
               textStyle: theme.textTheme.labelLarge,
             ),
-            onPressed: () {
-              if (nextRoute != null) {
-                context.push(nextRoute!);
-              }
-            },
+            onPressed: rightOnPress,
             child: Text(
-              l10n.next,
+              rightButtonText,
               style: theme.textTheme.labelLarge?.copyWith(
                 color: theme.colorScheme.onPrimary,
               ),

--- a/lib/widgets/screens/sign_up/sign_up_email.dart
+++ b/lib/widgets/screens/sign_up/sign_up_email.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
-import 'package:mm_flutter_app/widgets/molecules/sign_up_bottom_buttons.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_bottom_buttons.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
 
 import '../../atoms/text_form_field_widget.dart';
 
@@ -18,62 +21,31 @@ class _SignUpEmailState extends State<SignUpEmail> {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(Insets.paddingExtraLarge),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              const LinearProgressIndicator(value: 0.25),
-              const SizedBox(height: Insets.paddingMedium),
-              Text(
-                l10n.whatIsYourEmailAddress,
-                softWrap: true,
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-              const SizedBox(height: Insets.paddingMedium),
-              TextFormFieldWidget(
-                  textController: emailTextController,
-                  label: l10n.emailAddress,
-                  onPressed: (value) {
-                    setState(() {
-                      email = value;
-                    });
-                  },
-                  obscureText: false),
-              const Spacer(),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: Insets.paddingExtraLarge * 2),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Icon(Icons.lock_outline, color: theme.colorScheme.outline),
-                    Expanded(
-                      // fit: BoxFit.contain,
-                      child: Text(
-                        l10n.signUpHiddenInfoDesc,
-                        softWrap: true,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.outline,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SignUpBottomButtons(),
-            ],
-          ),
-        ),
-      ),
-    );
+    return SignUpTemplate(
+        progress: SignUpProgress.one,
+        title: l10n.whatIsYourEmailAddress,
+        body: TextFormFieldWidget(
+            textController: emailTextController,
+            label: l10n.emailAddress,
+            onPressed: (value) {
+              setState(() {
+                email = value;
+              });
+            },
+            obscureText: false),
+        footer: SignUpIconFooter(
+            icon: Icons.lock_outline, text: l10n.signUpHiddenInfoDesc),
+        bottomButtons: SignUpBottomButtons(
+          leftButtonText: l10n.previous,
+          rightButtonText: l10n.next,
+          leftOnPress: () {
+            context.pop();
+          },
+          rightOnPress: () {
+            context.push(Routes.entrepreneurOrMentor.path);
+          },
+        ));
   }
 }

--- a/lib/widgets/screens/sign_up/sign_up_email.dart
+++ b/lib/widgets/screens/sign_up/sign_up_email.dart
@@ -1,3 +1,4 @@
+import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
@@ -17,6 +18,7 @@ class SignUpEmail extends StatefulWidget {
 
 class _SignUpEmailState extends State<SignUpEmail> {
   TextEditingController? emailTextController;
+  final _formKey = GlobalKey<FormState>();
   String? email;
 
   @override
@@ -26,15 +28,25 @@ class _SignUpEmailState extends State<SignUpEmail> {
     return SignUpTemplate(
         progress: SignUpProgress.one,
         title: l10n.whatIsYourEmailAddress,
-        body: TextFormFieldWidget(
-            textController: emailTextController,
-            label: l10n.emailAddress,
-            onPressed: (value) {
-              setState(() {
-                email = value;
-              });
-            },
-            obscureText: false),
+        body: Form(
+            key: _formKey,
+            child: TextFormFieldWidget(
+              textController: emailTextController,
+              label: l10n.emailAddress,
+              onPressed: (value) {
+                setState(() {
+                  email = value;
+                });
+              },
+              obscureText: false,
+              validator: (value) {
+                bool validEmail = EmailValidator.validate(value!);
+                if (validEmail != true) {
+                  return l10n.invalidEmailSnackBar;
+                }
+                return null;
+              },
+            )),
         footer: SignUpIconFooter(
             icon: Icons.lock_outline, text: l10n.signUpHiddenInfoDesc),
         bottomButtons: SignUpBottomButtons(
@@ -44,7 +56,9 @@ class _SignUpEmailState extends State<SignUpEmail> {
             context.pop();
           },
           rightOnPress: () {
-            context.push(Routes.entrepreneurOrMentor.path);
+            if (_formKey.currentState!.validate()) {
+              context.push(Routes.entrepreneurOrMentor.path);
+            }
           },
         ));
   }

--- a/lib/widgets/screens/sign_up/sign_up_icon_footer.dart
+++ b/lib/widgets/screens/sign_up/sign_up_icon_footer.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class SignUpIconFooter extends StatelessWidget {
+  final IconData icon;
+  final String text;
+
+  const SignUpIconFooter({
+    super.key,
+    required this.icon,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Icon(icon, color: theme.colorScheme.outline),
+        Expanded(
+          // fit: BoxFit.contain,
+          child: Text(
+            text,
+            softWrap: true,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/screens/sign_up/sign_up_screen.dart
+++ b/lib/widgets/screens/sign_up/sign_up_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
 
 import '../../atoms/social_sign_in_button.dart';
 
@@ -13,104 +14,84 @@ class SignUpScreen extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations l10n = AppLocalizations.of(context)!;
 
-    return Scaffold(
-        body: SafeArea(
-            child: SingleChildScrollView(
-                child: Padding(
-                    padding: const EdgeInsets.all(Insets.paddingExtraLarge),
-                    child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.max,
-                        children: [
-                          const LinearProgressIndicator(value: 0.25),
-                          const SizedBox(height: Insets.paddingMedium),
-                          Text(
-                            l10n.signUp,
-                            style: theme.textTheme.headlineSmall?.copyWith(
-                              color: theme.colorScheme.primary,
-                            ),
-                          ),
-                          Padding(
-                              padding:
-                                  const EdgeInsets.all(Insets.paddingMedium),
-                              child: SizedBox(
-                                  width: 320,
-                                  child: Text(
-                                    l10n.signUpDesc,
-                                    textAlign: TextAlign.center,
-                                    style: theme.textTheme.bodyMedium?.copyWith(
-                                      color: theme.colorScheme.outline,
-                                    ),
-                                  ))),
-                          Text(
-                            l10n.continueWith,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              color: theme.colorScheme.primary,
-                            ),
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                          SocialSignInButton(
-                            option: SignInOptions.facebook,
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                          SocialSignInButton(
-                            option: SignInOptions.whatsapp,
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                          SocialSignInButton(
-                            option: SignInOptions.linkedin,
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                          SocialSignInButton(
-                            option: SignInOptions.telegram,
-                            onPressed: () {},
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                          SocialSignInButton(
-                            option: SignInOptions.google,
-                            onPressed: () {},
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                                vertical: Insets.paddingMedium),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Expanded(
-                                    child: Divider(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .outline)),
-                                Text(
-                                  l10n.or,
-                                  style: theme.textTheme.labelMedium?.copyWith(
-                                    color: theme.colorScheme.secondary,
-                                  ),
-                                ),
-                                Expanded(
-                                    child: Divider(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .outline)),
-                              ],
-                            ),
-                          ),
-                          Padding(
-                              padding:
-                                  const EdgeInsets.all(Insets.paddingSmall),
-                              child: InkWell(
-                                child: Text(l10n.continueWithEmail,
-                                    style: TextStyle(
-                                      color: theme.colorScheme.primary,
-                                      decoration: TextDecoration.underline,
-                                    )),
-                                onTap: () {
-                                  context.push(Routes.signupEmail.path);
-                                },
-                              )),
-                        ])))));
+    return SignUpTemplate(
+        title: l10n.signUp,
+        progress: SignUpProgress.one,
+        body: Column(children: [
+          Padding(
+              padding: const EdgeInsets.all(Insets.paddingMedium),
+              child: SizedBox(
+                  width: 320,
+                  child: Text(
+                    l10n.signUpDesc,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ))),
+          Text(
+            l10n.continueWith,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: Insets.paddingMedium),
+          SocialSignInButton(
+            option: SignInOptions.facebook,
+            onPressed: () {},
+          ),
+          const SizedBox(height: Insets.paddingMedium),
+          SocialSignInButton(
+            option: SignInOptions.whatsapp,
+            onPressed: () {},
+          ),
+          const SizedBox(height: Insets.paddingMedium),
+          SocialSignInButton(
+            option: SignInOptions.linkedin,
+            onPressed: () {},
+          ),
+          const SizedBox(height: Insets.paddingMedium),
+          SocialSignInButton(
+            option: SignInOptions.telegram,
+            onPressed: () {},
+          ),
+          const SizedBox(height: Insets.paddingMedium),
+          SocialSignInButton(
+            option: SignInOptions.google,
+            onPressed: () {},
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: Insets.paddingMedium),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                    child:
+                        Divider(color: Theme.of(context).colorScheme.outline)),
+                Text(
+                  l10n.or,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.secondary,
+                  ),
+                ),
+                Expanded(
+                    child:
+                        Divider(color: Theme.of(context).colorScheme.outline)),
+              ],
+            ),
+          ),
+          Padding(
+              padding: const EdgeInsets.all(Insets.paddingSmall),
+              child: InkWell(
+                child: Text(l10n.continueWithEmail,
+                    style: TextStyle(
+                      color: theme.colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                    )),
+                onTap: () {
+                  context.push(Routes.signupEmail.path);
+                },
+              )),
+        ]));
   }
 }

--- a/lib/widgets/screens/sign_up/sign_up_template.dart
+++ b/lib/widgets/screens/sign_up/sign_up_template.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+
+enum SignUpProgress { one, two, three, four }
+
+double _SignUpProgressToDouble(SignUpProgress signUpProgress) {
+  switch (signUpProgress) {
+    case SignUpProgress.one:
+      return 0.25;
+    case SignUpProgress.two:
+      return 0.5;
+    case SignUpProgress.three:
+      return 0.75;
+    default:
+      return 1.0;
+  }
+}
+
+class SignUpTemplate extends StatelessWidget {
+  final SignUpProgress progress;
+  final String title;
+  final Widget body;
+  final Widget? footer;
+  final Widget? bottomButtons;
+
+  const SignUpTemplate(
+      {super.key,
+      required this.progress,
+      required this.title,
+      required this.body,
+      this.footer,
+      this.bottomButtons});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(Insets.paddingExtraLarge),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              LinearProgressIndicator(value: _SignUpProgressToDouble(progress)),
+              const SizedBox(height: Insets.paddingMedium),
+              Text(
+                title,
+                softWrap: true,
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: Insets.paddingMedium),
+              body,
+              const Spacer(),
+              if (footer != null)
+                Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: Insets.paddingExtraLarge * 2),
+                    child: footer),
+              if (bottomButtons != null) bottomButtons!,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/screens/sign_up/sign_up_template.dart
+++ b/lib/widgets/screens/sign_up/sign_up_template.dart
@@ -3,7 +3,7 @@ import 'package:mm_flutter_app/constants/app_constants.dart';
 
 enum SignUpProgress { one, two, three, four }
 
-double _SignUpProgressToDouble(SignUpProgress signUpProgress) {
+double _signUpProgressToDouble(SignUpProgress signUpProgress) {
   switch (signUpProgress) {
     case SignUpProgress.one:
       return 0.25;
@@ -43,7 +43,7 @@ class SignUpTemplate extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.max,
             children: [
-              LinearProgressIndicator(value: _SignUpProgressToDouble(progress)),
+              LinearProgressIndicator(value: _signUpProgressToDouble(progress)),
               const SizedBox(height: Insets.paddingMedium),
               Text(
                 title,


### PR DESCRIPTION
1. Create a generic widget SignUpTemplate for sign up pages. 
2. Move bottom buttons widget to under sign up folder, and make it more customizable, as future pages would require changes in the onPressed functions and button texts.
3. Extracted footer to a standalone SignUpIconFooter widget for reuse.
4. Input validation for email page

(connected mentor page with sign up email page for testing purpose, I will update it in the future once we have more screens)