### PR TITLE
Update mock server resolvers and state to handle new inbox features

### DIFF
--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -109,6 +109,21 @@ export function mockMutations(serverState: MockServerState) {
             });
             return channelInvitation.id;
         },
+        deleteChannelInvitation: (_: any, args: { deletePhysically: boolean, channelInvitationId: string }) => {
+            const channelInvitation = serverState.channelInvitations.find((e) => e.id == args.channelInvitationId);
+            const currentTime : string = new Date().toISOString();
+            channelInvitation.deletedAt = currentTime;
+            channelInvitation.updatedAt = currentTime;
+            serverState.pubsub.publish(PUBSUB_OBJECT_CHANGED, { objectChanged: { objectId: channelInvitation.id }});
+            serverState.pubsub.publish(PUBSUB_CHANNEL_CHANGED, { 
+                channelChanged: {
+                    channelId: channelInvitation.channel?.id,
+                    invitationId: channelInvitation.id,
+                    eventType: 'invitationDeleted',
+                }
+            });
+            return channelInvitation.id;
+        },
         deleteChannelMessage: (_: any, args: { channelMessageId: string, deletePhysically: boolean }) => {
             var channelMessage = serverState.channelMessages.find((element) => element.id == args.channelMessageId);
             const currentTime : string = new Date().toISOString();

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -200,6 +200,7 @@ export function generateChannelMessage(
         __typename: "ChannelMessage",
         id: faker.string.alphanumeric({length: 24}),
         createdBy: senderUser.id,
+        channel: channel,
         channelId: channel.id,
         messageText: text,
         createdAt: createdAt.toISOString(),

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -19,17 +19,22 @@ export class MockServerState {
             .concat(generators.generateGroup());
         this.loggedIn = false;
         this.loggedInUser = generators.generateUser(this.groups.filter(g => g.ident === "mentees"));
-        // 4 users, one for each channel and one who hasn't communicated with the logged in user
         this.otherUsers = [
-            generators.generateUser(this.groups.filter(g => g.ident === "mentors" || g.ident === "mentees")),
             generators.generateUser(this.groups.filter(g => g.ident === "mentors")),
             generators.generateUser(this.groups.filter(g => g.ident === "mentees")),
-            generators.generateUser(this.groups.filter(g => g.ident === "mentees" || g.ident === "mentors")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentors")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentees")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentees")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentors")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentees")),
+            generators.generateUser(this.groups.filter(g => g.ident === "mentors")),
         ];
         this.channels = [
             generators.generateChannel([this.loggedInUser, this.otherUsers[0]]),
+            generators.generateChannel([this.loggedInUser, this.otherUsers[4]]),
         ];
         this.channelInvitations = [
+            // RECEIVED INVITATIONS
             // accepted invitation, channel exists
             generators.generateChannelInvitation(this.otherUsers[0], this.loggedInUser, false, true),
             // pending invitations
@@ -37,20 +42,32 @@ export class MockServerState {
             generators.generateChannelInvitation(this.otherUsers[2], this.loggedInUser),
             // declined invitation
             generators.generateChannelInvitation(this.otherUsers[3], this.loggedInUser, true),
-            // TODO: accepted invitation, message doesn't exist yet in channel (a.k.a "match")
-            // generators.generateChannelInvitation([this.loggedInUser, this.otherUsers[1]], false, true),
+
+            // SENT INVITATIONS
+            // accepted invitation, channel exists
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[4], false, true),
+            // pending invitations
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[5]),
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[6]),
+            // declined invitation
+            generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[7], true),
         ];
-        const message0 = generators.generateChannelMessage('Hello!', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true);
-        const message1 = generators.generateChannelMessage('👋', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-07:00'), true, false, false);
-        const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:35:01-07:00'), true);
-        const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true);
-        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, false, true, message2.id);
-        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-07:00'), true, true, false, message2.id);
-        const message6 = generators.generateChannelMessage('👍', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:24:01-07:00'), true);
-        const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, false, true);
-        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-07:00'), true, true, false, message5.id);
-        const message9 = generators.generateChannelMessage('You got it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:00:01-07:00'), false);
-        const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:01:01-07:00'), false);
+        // Messages for first channel
+        const message0 = generators.generateChannelMessage('Hello!', this.channels[0], this.otherUsers[0], new Date('2023-07-26T12:34:01-00:00'), true);
+        const message1 = generators.generateChannelMessage('👋', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-00:00'), true, false, false);
+        const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:35:01-00:00'), true);
+        const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true);
+        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, false, true, message2.id);
+        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, true, false, message2.id);
+        const message6 = generators.generateChannelMessage('👍', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:24:01-00:00'), true);
+        const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-00:00'), true, false, true);
+        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-00:00'), true, true, false, message5.id);
+        const message9 = generators.generateChannelMessage('You got it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:00:01-00:00'), false);
+        const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:01:01-00:00'), false);
+        this.channels[0].latestMessage = message10;
+        // Messages for second channel
+        const message11 = generators.generateChannelMessage('Hi! How about connecting?', this.channels[1], this.loggedInUser, new Date('2023-09-09T09:47:39-00:00'), true);
+        this.channels[1].latestMessage = message11;
         this.channelMessages = [
             message0,
             message1,
@@ -63,7 +80,7 @@ export class MockServerState {
             message8,
             message9,
             message10,
+            message11,
         ];
-        this.channels[0].latestMessage = message10;
     }
 }


### PR DESCRIPTION
Makes the latest app version functional with the mock server. The following were added:

- Added query for myChannelInvitations
- Server state starts with both sent and received invitations
- Server stat starts with 2 ongoing conversations, one with unseen messages, the other without
- Withdraw sent invitations