### PR TITLE
Make it possible again to run debug version of the app

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.micromentor.mm_flutter_app">
+    package="com.micromentor.mm_flutter_app">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.


### PR DESCRIPTION
This completes the changes originally made in https://github.com/micromentor-team/mm-flutter-app/pull/108. Without it it's impossible to run `flutter run` for me.