### PR TITLE
Matching, profile updates to match backend progress

### DIFF
--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -824,6 +824,35 @@ const documentNodeMutationCreateUserSearch = DocumentNode(definitions: [
             selectionSet: null,
           ),
           FieldNode(
+            name: NameNode(value: 'runInfos'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'finishedAt'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'matchCount'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
             name: NameNode(value: '__typename'),
             alias: null,
             arguments: [],
@@ -853,6 +882,7 @@ class Mutation$CreateUserSearch$createUserSearch {
     this.expiresAt,
     required this.userId,
     this.updatedAt,
+    this.runInfos,
     this.$__typename = 'UserSearch',
   });
 
@@ -866,6 +896,7 @@ class Mutation$CreateUserSearch$createUserSearch {
     final l$expiresAt = json['expiresAt'];
     final l$userId = json['userId'];
     final l$updatedAt = json['updatedAt'];
+    final l$runInfos = json['runInfos'];
     final l$$__typename = json['__typename'];
     return Mutation$CreateUserSearch$createUserSearch(
       name: (l$name as String?),
@@ -882,6 +913,11 @@ class Mutation$CreateUserSearch$createUserSearch {
       userId: (l$userId as String),
       updatedAt:
           l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
+      runInfos: (l$runInfos as List<dynamic>?)
+          ?.map((e) =>
+              Mutation$CreateUserSearch$createUserSearch$runInfos.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
       $__typename: (l$$__typename as String),
     );
   }
@@ -901,6 +937,8 @@ class Mutation$CreateUserSearch$createUserSearch {
   final String userId;
 
   final DateTime? updatedAt;
+
+  final List<Mutation$CreateUserSearch$createUserSearch$runInfos>? runInfos;
 
   final String $__typename;
 
@@ -926,6 +964,8 @@ class Mutation$CreateUserSearch$createUserSearch {
     _resultData['userId'] = l$userId;
     final l$updatedAt = updatedAt;
     _resultData['updatedAt'] = l$updatedAt?.toIso8601String();
+    final l$runInfos = runInfos;
+    _resultData['runInfos'] = l$runInfos?.map((e) => e.toJson()).toList();
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -941,6 +981,7 @@ class Mutation$CreateUserSearch$createUserSearch {
     final l$expiresAt = expiresAt;
     final l$userId = userId;
     final l$updatedAt = updatedAt;
+    final l$runInfos = runInfos;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$name,
@@ -951,6 +992,7 @@ class Mutation$CreateUserSearch$createUserSearch {
       l$expiresAt,
       l$userId,
       l$updatedAt,
+      l$runInfos == null ? null : Object.hashAll(l$runInfos.map((v) => v)),
       l$$__typename,
     ]);
   }
@@ -1004,6 +1046,22 @@ class Mutation$CreateUserSearch$createUserSearch {
     if (l$updatedAt != lOther$updatedAt) {
       return false;
     }
+    final l$runInfos = runInfos;
+    final lOther$runInfos = other.runInfos;
+    if (l$runInfos != null && lOther$runInfos != null) {
+      if (l$runInfos.length != lOther$runInfos.length) {
+        return false;
+      }
+      for (int i = 0; i < l$runInfos.length; i++) {
+        final l$runInfos$entry = l$runInfos[i];
+        final lOther$runInfos$entry = lOther$runInfos[i];
+        if (l$runInfos$entry != lOther$runInfos$entry) {
+          return false;
+        }
+      }
+    } else if (l$runInfos != lOther$runInfos) {
+      return false;
+    }
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
     if (l$$__typename != lOther$$__typename) {
@@ -1041,8 +1099,15 @@ abstract class CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes> {
     DateTime? expiresAt,
     String? userId,
     DateTime? updatedAt,
+    List<Mutation$CreateUserSearch$createUserSearch$runInfos>? runInfos,
     String? $__typename,
   });
+  TRes runInfos(
+      Iterable<Mutation$CreateUserSearch$createUserSearch$runInfos>? Function(
+              Iterable<
+                  CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<
+                      Mutation$CreateUserSearch$createUserSearch$runInfos>>?)
+          _fn);
 }
 
 class _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
@@ -1067,6 +1132,7 @@ class _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
     Object? expiresAt = _undefined,
     Object? userId = _undefined,
     Object? updatedAt = _undefined,
+    Object? runInfos = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Mutation$CreateUserSearch$createUserSearch(
@@ -1090,10 +1156,26 @@ class _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
         updatedAt: updatedAt == _undefined
             ? _instance.updatedAt
             : (updatedAt as DateTime?),
+        runInfos: runInfos == _undefined
+            ? _instance.runInfos
+            : (runInfos
+                as List<Mutation$CreateUserSearch$createUserSearch$runInfos>?),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
       ));
+  TRes runInfos(
+          Iterable<Mutation$CreateUserSearch$createUserSearch$runInfos>? Function(
+                  Iterable<
+                      CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<
+                          Mutation$CreateUserSearch$createUserSearch$runInfos>>?)
+              _fn) =>
+      call(
+          runInfos: _fn(_instance.runInfos?.map((e) =>
+              CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos(
+                e,
+                (i) => i,
+              )))?.toList());
 }
 
 class _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
@@ -1111,6 +1193,165 @@ class _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
     DateTime? expiresAt,
     String? userId,
     DateTime? updatedAt,
+    List<Mutation$CreateUserSearch$createUserSearch$runInfos>? runInfos,
+    String? $__typename,
+  }) =>
+      _res;
+  runInfos(_fn) => _res;
+}
+
+class Mutation$CreateUserSearch$createUserSearch$runInfos {
+  Mutation$CreateUserSearch$createUserSearch$runInfos({
+    this.finishedAt,
+    required this.matchCount,
+    this.$__typename = 'UserSearchRunInfo',
+  });
+
+  factory Mutation$CreateUserSearch$createUserSearch$runInfos.fromJson(
+      Map<String, dynamic> json) {
+    final l$finishedAt = json['finishedAt'];
+    final l$matchCount = json['matchCount'];
+    final l$$__typename = json['__typename'];
+    return Mutation$CreateUserSearch$createUserSearch$runInfos(
+      finishedAt: l$finishedAt == null
+          ? null
+          : DateTime.parse((l$finishedAt as String)),
+      matchCount: (l$matchCount as int),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final DateTime? finishedAt;
+
+  final int matchCount;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$finishedAt = finishedAt;
+    _resultData['finishedAt'] = l$finishedAt?.toIso8601String();
+    final l$matchCount = matchCount;
+    _resultData['matchCount'] = l$matchCount;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$finishedAt = finishedAt;
+    final l$matchCount = matchCount;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$finishedAt,
+      l$matchCount,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Mutation$CreateUserSearch$createUserSearch$runInfos) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$finishedAt = finishedAt;
+    final lOther$finishedAt = other.finishedAt;
+    if (l$finishedAt != lOther$finishedAt) {
+      return false;
+    }
+    final l$matchCount = matchCount;
+    final lOther$matchCount = other.matchCount;
+    if (l$matchCount != lOther$matchCount) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Mutation$CreateUserSearch$createUserSearch$runInfos
+    on Mutation$CreateUserSearch$createUserSearch$runInfos {
+  CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<
+          Mutation$CreateUserSearch$createUserSearch$runInfos>
+      get copyWith =>
+          CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<
+    TRes> {
+  factory CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos(
+    Mutation$CreateUserSearch$createUserSearch$runInfos instance,
+    TRes Function(Mutation$CreateUserSearch$createUserSearch$runInfos) then,
+  ) = _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch$runInfos;
+
+  factory CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos.stub(
+          TRes res) =
+      _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch$runInfos;
+
+  TRes call({
+    DateTime? finishedAt,
+    int? matchCount,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch$runInfos<TRes>
+    implements
+        CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<TRes> {
+  _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch$runInfos(
+    this._instance,
+    this._then,
+  );
+
+  final Mutation$CreateUserSearch$createUserSearch$runInfos _instance;
+
+  final TRes Function(Mutation$CreateUserSearch$createUserSearch$runInfos)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? finishedAt = _undefined,
+    Object? matchCount = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Mutation$CreateUserSearch$createUserSearch$runInfos(
+        finishedAt: finishedAt == _undefined
+            ? _instance.finishedAt
+            : (finishedAt as DateTime?),
+        matchCount: matchCount == _undefined || matchCount == null
+            ? _instance.matchCount
+            : (matchCount as int),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch$runInfos<
+        TRes>
+    implements
+        CopyWith$Mutation$CreateUserSearch$createUserSearch$runInfos<TRes> {
+  _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch$runInfos(
+      this._res);
+
+  TRes _res;
+
+  call({
+    DateTime? finishedAt,
+    int? matchCount,
     String? $__typename,
   }) =>
       _res;
@@ -1332,6 +1573,27 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
               ),
               FieldNode(
                 name: NameNode(value: 'userHandle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'offersHelp'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'seeksHelp'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'jobTitle'),
                 alias: null,
                 arguments: [],
                 directives: [],
@@ -1641,6 +1903,13 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
             directives: [],
             selectionSet: SelectionSetNode(selections: [
               FieldNode(
+                name: NameNode(value: 'finishedAt'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'matchCount'),
                 alias: null,
                 arguments: [],
@@ -1932,6 +2201,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
     this.fullName,
     this.avatarUrl,
     this.userHandle,
+    required this.offersHelp,
+    required this.seeksHelp,
+    this.jobTitle,
     this.countryOfResidence,
     required this.groupMemberships,
     required this.companies,
@@ -1947,6 +2219,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
     final l$fullName = json['fullName'];
     final l$avatarUrl = json['avatarUrl'];
     final l$userHandle = json['userHandle'];
+    final l$offersHelp = json['offersHelp'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$jobTitle = json['jobTitle'];
     final l$countryOfResidence = json['countryOfResidence'];
     final l$groupMemberships = json['groupMemberships'];
     final l$companies = json['companies'];
@@ -1959,6 +2234,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
       fullName: (l$fullName as String?),
       avatarUrl: (l$avatarUrl as String?),
       userHandle: (l$userHandle as String?),
+      offersHelp: (l$offersHelp as bool),
+      seeksHelp: (l$seeksHelp as bool),
+      jobTitle: (l$jobTitle as String?),
       countryOfResidence: l$countryOfResidence == null
           ? null
           : Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
@@ -1991,6 +2269,12 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
 
   final String? userHandle;
 
+  final bool offersHelp;
+
+  final bool seeksHelp;
+
+  final String? jobTitle;
+
   final Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
       countryOfResidence;
 
@@ -2018,6 +2302,12 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
     _resultData['avatarUrl'] = l$avatarUrl;
     final l$userHandle = userHandle;
     _resultData['userHandle'] = l$userHandle;
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
     final l$countryOfResidence = countryOfResidence;
     _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
     final l$groupMemberships = groupMemberships;
@@ -2039,6 +2329,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
     final l$fullName = fullName;
     final l$avatarUrl = avatarUrl;
     final l$userHandle = userHandle;
+    final l$offersHelp = offersHelp;
+    final l$seeksHelp = seeksHelp;
+    final l$jobTitle = jobTitle;
     final l$countryOfResidence = countryOfResidence;
     final l$groupMemberships = groupMemberships;
     final l$companies = companies;
@@ -2051,6 +2344,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
       l$fullName,
       l$avatarUrl,
       l$userHandle,
+      l$offersHelp,
+      l$seeksHelp,
+      l$jobTitle,
       l$countryOfResidence,
       Object.hashAll(l$groupMemberships.map((v) => v)),
       Object.hashAll(l$companies.map((v) => v)),
@@ -2100,6 +2396,21 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers {
     final l$userHandle = userHandle;
     final lOther$userHandle = other.userHandle;
     if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
       return false;
     }
     final l$countryOfResidence = countryOfResidence;
@@ -2170,6 +2481,9 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
     Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>?
@@ -2216,6 +2530,9 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
     Object? fullName = _undefined,
     Object? avatarUrl = _undefined,
     Object? userHandle = _undefined,
+    Object? offersHelp = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? jobTitle = _undefined,
     Object? countryOfResidence = _undefined,
     Object? groupMemberships = _undefined,
     Object? companies = _undefined,
@@ -2237,6 +2554,14 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
         userHandle: userHandle == _undefined
             ? _instance.userHandle
             : (userHandle as String?),
+        offersHelp: offersHelp == _undefined || offersHelp == null
+            ? _instance.offersHelp
+            : (offersHelp as bool),
+        seeksHelp: seeksHelp == _undefined || seeksHelp == null
+            ? _instance.seeksHelp
+            : (seeksHelp as bool),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
         countryOfResidence: countryOfResidence == _undefined
             ? _instance.countryOfResidence
             : (countryOfResidence
@@ -2306,6 +2631,9 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
     Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>?
@@ -4659,6 +4987,7 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$compan
 
 class Query$MyUserSearches$myUserSearches$runInfos {
   Query$MyUserSearches$myUserSearches$runInfos({
+    this.finishedAt,
     required this.matchCount,
     this.topUserIds,
     this.$__typename = 'UserSearchRunInfo',
@@ -4666,16 +4995,22 @@ class Query$MyUserSearches$myUserSearches$runInfos {
 
   factory Query$MyUserSearches$myUserSearches$runInfos.fromJson(
       Map<String, dynamic> json) {
+    final l$finishedAt = json['finishedAt'];
     final l$matchCount = json['matchCount'];
     final l$topUserIds = json['topUserIds'];
     final l$$__typename = json['__typename'];
     return Query$MyUserSearches$myUserSearches$runInfos(
+      finishedAt: l$finishedAt == null
+          ? null
+          : DateTime.parse((l$finishedAt as String)),
       matchCount: (l$matchCount as int),
       topUserIds:
           (l$topUserIds as List<dynamic>?)?.map((e) => (e as String)).toList(),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final DateTime? finishedAt;
 
   final int matchCount;
 
@@ -4685,6 +5020,8 @@ class Query$MyUserSearches$myUserSearches$runInfos {
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$finishedAt = finishedAt;
+    _resultData['finishedAt'] = l$finishedAt?.toIso8601String();
     final l$matchCount = matchCount;
     _resultData['matchCount'] = l$matchCount;
     final l$topUserIds = topUserIds;
@@ -4696,10 +5033,12 @@ class Query$MyUserSearches$myUserSearches$runInfos {
 
   @override
   int get hashCode {
+    final l$finishedAt = finishedAt;
     final l$matchCount = matchCount;
     final l$topUserIds = topUserIds;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$finishedAt,
       l$matchCount,
       l$topUserIds == null ? null : Object.hashAll(l$topUserIds.map((v) => v)),
       l$$__typename,
@@ -4713,6 +5052,11 @@ class Query$MyUserSearches$myUserSearches$runInfos {
     }
     if (!(other is Query$MyUserSearches$myUserSearches$runInfos) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$finishedAt = finishedAt;
+    final lOther$finishedAt = other.finishedAt;
+    if (l$finishedAt != lOther$finishedAt) {
       return false;
     }
     final l$matchCount = matchCount;
@@ -4765,6 +5109,7 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$runInfos<TRes> {
       _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$runInfos;
 
   TRes call({
+    DateTime? finishedAt,
     int? matchCount,
     List<String>? topUserIds,
     String? $__typename,
@@ -4785,11 +5130,15 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$runInfos<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? finishedAt = _undefined,
     Object? matchCount = _undefined,
     Object? topUserIds = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$MyUserSearches$myUserSearches$runInfos(
+        finishedAt: finishedAt == _undefined
+            ? _instance.finishedAt
+            : (finishedAt as DateTime?),
         matchCount: matchCount == _undefined || matchCount == null
             ? _instance.matchCount
             : (matchCount as int),
@@ -4809,6 +5158,7 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$runInfos<TRes>
   TRes _res;
 
   call({
+    DateTime? finishedAt,
     int? matchCount,
     List<String>? topUserIds,
     String? $__typename,
@@ -5131,6 +5481,27 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                 selectionSet: null,
               ),
               FieldNode(
+                name: NameNode(value: 'offersHelp'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'seeksHelp'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'jobTitle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'countryOfResidence'),
                 alias: null,
                 arguments: [],
@@ -5434,6 +5805,13 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
             directives: [],
             selectionSet: SelectionSetNode(selections: [
               FieldNode(
+                name: NameNode(value: 'finishedAt'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'matchCount'),
                 alias: null,
                 arguments: [],
@@ -5728,6 +6106,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     this.fullName,
     this.avatarUrl,
     this.userHandle,
+    required this.offersHelp,
+    required this.seeksHelp,
+    this.jobTitle,
     this.countryOfResidence,
     required this.groupMemberships,
     required this.companies,
@@ -5743,6 +6124,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$fullName = json['fullName'];
     final l$avatarUrl = json['avatarUrl'];
     final l$userHandle = json['userHandle'];
+    final l$offersHelp = json['offersHelp'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$jobTitle = json['jobTitle'];
     final l$countryOfResidence = json['countryOfResidence'];
     final l$groupMemberships = json['groupMemberships'];
     final l$companies = json['companies'];
@@ -5755,6 +6139,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
       fullName: (l$fullName as String?),
       avatarUrl: (l$avatarUrl as String?),
       userHandle: (l$userHandle as String?),
+      offersHelp: (l$offersHelp as bool),
+      seeksHelp: (l$seeksHelp as bool),
+      jobTitle: (l$jobTitle as String?),
       countryOfResidence: l$countryOfResidence == null
           ? null
           : Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
@@ -5787,6 +6174,12 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
 
   final String? userHandle;
 
+  final bool offersHelp;
+
+  final bool seeksHelp;
+
+  final String? jobTitle;
+
   final Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
       countryOfResidence;
 
@@ -5815,6 +6208,12 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     _resultData['avatarUrl'] = l$avatarUrl;
     final l$userHandle = userHandle;
     _resultData['userHandle'] = l$userHandle;
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
     final l$countryOfResidence = countryOfResidence;
     _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
     final l$groupMemberships = groupMemberships;
@@ -5836,6 +6235,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$fullName = fullName;
     final l$avatarUrl = avatarUrl;
     final l$userHandle = userHandle;
+    final l$offersHelp = offersHelp;
+    final l$seeksHelp = seeksHelp;
+    final l$jobTitle = jobTitle;
     final l$countryOfResidence = countryOfResidence;
     final l$groupMemberships = groupMemberships;
     final l$companies = companies;
@@ -5848,6 +6250,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
       l$fullName,
       l$avatarUrl,
       l$userHandle,
+      l$offersHelp,
+      l$seeksHelp,
+      l$jobTitle,
       l$countryOfResidence,
       Object.hashAll(l$groupMemberships.map((v) => v)),
       Object.hashAll(l$companies.map((v) => v)),
@@ -5897,6 +6302,21 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$userHandle = userHandle;
     final lOther$userHandle = other.userHandle;
     if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
       return false;
     }
     final l$countryOfResidence = countryOfResidence;
@@ -5967,6 +6387,9 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
     Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
@@ -6014,6 +6437,9 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes>
     Object? fullName = _undefined,
     Object? avatarUrl = _undefined,
     Object? userHandle = _undefined,
+    Object? offersHelp = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? jobTitle = _undefined,
     Object? countryOfResidence = _undefined,
     Object? groupMemberships = _undefined,
     Object? companies = _undefined,
@@ -6035,6 +6461,14 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes>
         userHandle: userHandle == _undefined
             ? _instance.userHandle
             : (userHandle as String?),
+        offersHelp: offersHelp == _undefined || offersHelp == null
+            ? _instance.offersHelp
+            : (offersHelp as bool),
+        seeksHelp: seeksHelp == _undefined || seeksHelp == null
+            ? _instance.seeksHelp
+            : (seeksHelp as bool),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
         countryOfResidence: countryOfResidence == _undefined
             ? _instance.countryOfResidence
             : (countryOfResidence
@@ -6105,6 +6539,9 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<
     String? fullName,
     String? avatarUrl,
     String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
     Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
@@ -8463,6 +8900,7 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$co
 
 class Query$FindUserSearch$findUserSearchById$runInfos {
   Query$FindUserSearch$findUserSearchById$runInfos({
+    this.finishedAt,
     required this.matchCount,
     this.topUserIds,
     this.$__typename = 'UserSearchRunInfo',
@@ -8470,16 +8908,22 @@ class Query$FindUserSearch$findUserSearchById$runInfos {
 
   factory Query$FindUserSearch$findUserSearchById$runInfos.fromJson(
       Map<String, dynamic> json) {
+    final l$finishedAt = json['finishedAt'];
     final l$matchCount = json['matchCount'];
     final l$topUserIds = json['topUserIds'];
     final l$$__typename = json['__typename'];
     return Query$FindUserSearch$findUserSearchById$runInfos(
+      finishedAt: l$finishedAt == null
+          ? null
+          : DateTime.parse((l$finishedAt as String)),
       matchCount: (l$matchCount as int),
       topUserIds:
           (l$topUserIds as List<dynamic>?)?.map((e) => (e as String)).toList(),
       $__typename: (l$$__typename as String),
     );
   }
+
+  final DateTime? finishedAt;
 
   final int matchCount;
 
@@ -8489,6 +8933,8 @@ class Query$FindUserSearch$findUserSearchById$runInfos {
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
+    final l$finishedAt = finishedAt;
+    _resultData['finishedAt'] = l$finishedAt?.toIso8601String();
     final l$matchCount = matchCount;
     _resultData['matchCount'] = l$matchCount;
     final l$topUserIds = topUserIds;
@@ -8500,10 +8946,12 @@ class Query$FindUserSearch$findUserSearchById$runInfos {
 
   @override
   int get hashCode {
+    final l$finishedAt = finishedAt;
     final l$matchCount = matchCount;
     final l$topUserIds = topUserIds;
     final l$$__typename = $__typename;
     return Object.hashAll([
+      l$finishedAt,
       l$matchCount,
       l$topUserIds == null ? null : Object.hashAll(l$topUserIds.map((v) => v)),
       l$$__typename,
@@ -8517,6 +8965,11 @@ class Query$FindUserSearch$findUserSearchById$runInfos {
     }
     if (!(other is Query$FindUserSearch$findUserSearchById$runInfos) ||
         runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$finishedAt = finishedAt;
+    final lOther$finishedAt = other.finishedAt;
+    if (l$finishedAt != lOther$finishedAt) {
       return false;
     }
     final l$matchCount = matchCount;
@@ -8570,6 +9023,7 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<TRes> {
       _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos;
 
   TRes call({
+    DateTime? finishedAt,
     int? matchCount,
     List<String>? topUserIds,
     String? $__typename,
@@ -8590,11 +9044,15 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$runInfos<TRes>
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
+    Object? finishedAt = _undefined,
     Object? matchCount = _undefined,
     Object? topUserIds = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindUserSearch$findUserSearchById$runInfos(
+        finishedAt: finishedAt == _undefined
+            ? _instance.finishedAt
+            : (finishedAt as DateTime?),
         matchCount: matchCount == _undefined || matchCount == null
             ? _instance.matchCount
             : (matchCount as int),
@@ -8614,6 +9072,7 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos<TRes>
   TRes _res;
 
   call({
+    DateTime? finishedAt,
     int? matchCount,
     List<String>? topUserIds,
     String? $__typename,

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -1613,13 +1613,6 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
                     selectionSet: null,
                   ),
                   FieldNode(
-                    name: NameNode(value: 'textId'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
                     name: NameNode(value: '__typename'),
                     alias: null,
                     arguments: [],
@@ -1649,20 +1642,6 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
                     )),
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
-                      FieldNode(
-                        name: NameNode(value: 'expertisesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industriesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
                       FieldNode(
                         name: NameNode(value: 'expertises'),
                         alias: null,
@@ -1731,20 +1710,6 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
                     )),
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
-                      FieldNode(
-                        name: NameNode(value: 'soughtExpertisesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industryTextId'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
                       FieldNode(
                         name: NameNode(value: 'soughtExpertises'),
                         alias: null,
@@ -1821,13 +1786,6 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
                     selectionSet: null,
                   ),
                   FieldNode(
-                    name: NameNode(value: 'companyStageTextId'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
                     name: NameNode(value: 'companyStage'),
                     alias: null,
                     arguments: [],
@@ -1848,13 +1806,6 @@ const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
                         selectionSet: null,
                       ),
                     ]),
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'companyTypeTextId'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
                   ),
                   FieldNode(
                     name: NameNode(value: 'companyType'),
@@ -2655,25 +2606,20 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
 class Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
   Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence({
     this.translatedValue,
-    required this.textId,
     this.$__typename = 'Country',
   });
 
   factory Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence.fromJson(
       Map<String, dynamic> json) {
     final l$translatedValue = json['translatedValue'];
-    final l$textId = json['textId'];
     final l$$__typename = json['__typename'];
     return Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
       translatedValue: (l$translatedValue as String?),
-      textId: (l$textId as String),
       $__typename: (l$$__typename as String),
     );
   }
 
   final String? translatedValue;
-
-  final String textId;
 
   final String $__typename;
 
@@ -2681,8 +2627,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
     final _resultData = <String, dynamic>{};
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
-    final l$textId = textId;
-    _resultData['textId'] = l$textId;
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -2691,11 +2635,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
   @override
   int get hashCode {
     final l$translatedValue = translatedValue;
-    final l$textId = textId;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$translatedValue,
-      l$textId,
       l$$__typename,
     ]);
   }
@@ -2713,11 +2655,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
     final l$translatedValue = translatedValue;
     final lOther$translatedValue = other.translatedValue;
     if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$textId = textId;
-    final lOther$textId = other.textId;
-    if (l$textId != lOther$textId) {
       return false;
     }
     final l$$__typename = $__typename;
@@ -2756,7 +2693,6 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countr
 
   TRes call({
     String? translatedValue,
-    String? textId,
     String? $__typename,
   });
 }
@@ -2782,7 +2718,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfR
 
   TRes call({
     Object? translatedValue = _undefined,
-    Object? textId = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
@@ -2790,9 +2725,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfR
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
-        textId: textId == _undefined || textId == null
-            ? _instance.textId
-            : (textId as String),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
@@ -2811,7 +2743,6 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countr
 
   call({
     String? translatedValue,
-    String? textId,
     String? $__typename,
   }) =>
       _res;
@@ -3049,8 +2980,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
     implements
         Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
   Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership({
-    this.expertisesTextIds,
-    this.industriesTextIds,
     required this.expertises,
     required this.industries,
     this.endorsements,
@@ -3060,20 +2989,12 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
 
   factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership.fromJson(
       Map<String, dynamic> json) {
-    final l$expertisesTextIds = json['expertisesTextIds'];
-    final l$industriesTextIds = json['industriesTextIds'];
     final l$expertises = json['expertises'];
     final l$industries = json['industries'];
     final l$endorsements = json['endorsements'];
     final l$$__typename = json['__typename'];
     final l$groupIdent = json['groupIdent'];
     return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
-      expertisesTextIds: (l$expertisesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
-      industriesTextIds: (l$industriesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
       expertises: (l$expertises as List<dynamic>)
           .map((e) =>
               Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
@@ -3089,10 +3010,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
       groupIdent: (l$groupIdent as String),
     );
   }
-
-  final List<String>? expertisesTextIds;
-
-  final List<String>? industriesTextIds;
 
   final List<
           Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
@@ -3110,12 +3027,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
-    final l$expertisesTextIds = expertisesTextIds;
-    _resultData['expertisesTextIds'] =
-        l$expertisesTextIds?.map((e) => e).toList();
-    final l$industriesTextIds = industriesTextIds;
-    _resultData['industriesTextIds'] =
-        l$industriesTextIds?.map((e) => e).toList();
     final l$expertises = expertises;
     _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
     final l$industries = industries;
@@ -3131,20 +3042,12 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
 
   @override
   int get hashCode {
-    final l$expertisesTextIds = expertisesTextIds;
-    final l$industriesTextIds = industriesTextIds;
     final l$expertises = expertises;
     final l$industries = industries;
     final l$endorsements = endorsements;
     final l$$__typename = $__typename;
     final l$groupIdent = groupIdent;
     return Object.hashAll([
-      l$expertisesTextIds == null
-          ? null
-          : Object.hashAll(l$expertisesTextIds.map((v) => v)),
-      l$industriesTextIds == null
-          ? null
-          : Object.hashAll(l$industriesTextIds.map((v) => v)),
       Object.hashAll(l$expertises.map((v) => v)),
       Object.hashAll(l$industries.map((v) => v)),
       l$endorsements,
@@ -3161,38 +3064,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentor
     if (!(other
             is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership) ||
         runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$expertisesTextIds = expertisesTextIds;
-    final lOther$expertisesTextIds = other.expertisesTextIds;
-    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
-      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$expertisesTextIds.length; i++) {
-        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
-        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
-        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
-      return false;
-    }
-    final l$industriesTextIds = industriesTextIds;
-    final lOther$industriesTextIds = other.industriesTextIds;
-    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
-      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$industriesTextIds.length; i++) {
-        final l$industriesTextIds$entry = l$industriesTextIds[i];
-        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
-        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$industriesTextIds != lOther$industriesTextIds) {
       return false;
     }
     final l$expertises = expertises;
@@ -3264,8 +3135,6 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupM
       _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership;
 
   TRes call({
-    List<String>? expertisesTextIds,
-    List<String>? industriesTextIds,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
         expertises,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
@@ -3308,8 +3177,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMembe
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
-    Object? expertisesTextIds = _undefined,
-    Object? industriesTextIds = _undefined,
     Object? expertises = _undefined,
     Object? industries = _undefined,
     Object? endorsements = _undefined,
@@ -3318,12 +3185,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMembe
   }) =>
       _then(
           Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
-        expertisesTextIds: expertisesTextIds == _undefined
-            ? _instance.expertisesTextIds
-            : (expertisesTextIds as List<String>?),
-        industriesTextIds: industriesTextIds == _undefined
-            ? _instance.industriesTextIds
-            : (industriesTextIds as List<String>?),
         expertises: expertises == _undefined || expertises == null
             ? _instance.expertises
             : (expertises as List<
@@ -3379,8 +3240,6 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupM
   TRes _res;
 
   call({
-    List<String>? expertisesTextIds,
-    List<String>? industriesTextIds,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
         expertises,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
@@ -3688,8 +3547,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
     implements
         Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
   Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership({
-    this.soughtExpertisesTextIds,
-    this.industryTextId,
     required this.soughtExpertises,
     this.industry,
     this.$__typename = 'MenteesGroupMembership',
@@ -3698,17 +3555,11 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
 
   factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership.fromJson(
       Map<String, dynamic> json) {
-    final l$soughtExpertisesTextIds = json['soughtExpertisesTextIds'];
-    final l$industryTextId = json['industryTextId'];
     final l$soughtExpertises = json['soughtExpertises'];
     final l$industry = json['industry'];
     final l$$__typename = json['__typename'];
     final l$groupIdent = json['groupIdent'];
     return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
-      soughtExpertisesTextIds: (l$soughtExpertisesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
-      industryTextId: (l$industryTextId as String?),
       soughtExpertises: (l$soughtExpertises as List<dynamic>)
           .map((e) =>
               Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
@@ -3723,10 +3574,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
     );
   }
 
-  final List<String>? soughtExpertisesTextIds;
-
-  final String? industryTextId;
-
   final List<
           Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
       soughtExpertises;
@@ -3740,11 +3587,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    _resultData['soughtExpertisesTextIds'] =
-        l$soughtExpertisesTextIds?.map((e) => e).toList();
-    final l$industryTextId = industryTextId;
-    _resultData['industryTextId'] = l$industryTextId;
     final l$soughtExpertises = soughtExpertises;
     _resultData['soughtExpertises'] =
         l$soughtExpertises.map((e) => e.toJson()).toList();
@@ -3759,17 +3601,11 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
 
   @override
   int get hashCode {
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    final l$industryTextId = industryTextId;
     final l$soughtExpertises = soughtExpertises;
     final l$industry = industry;
     final l$$__typename = $__typename;
     final l$groupIdent = groupIdent;
     return Object.hashAll([
-      l$soughtExpertisesTextIds == null
-          ? null
-          : Object.hashAll(l$soughtExpertisesTextIds.map((v) => v)),
-      l$industryTextId,
       Object.hashAll(l$soughtExpertises.map((v) => v)),
       l$industry,
       l$$__typename,
@@ -3785,31 +3621,6 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$Mentee
     if (!(other
             is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership) ||
         runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    final lOther$soughtExpertisesTextIds = other.soughtExpertisesTextIds;
-    if (l$soughtExpertisesTextIds != null &&
-        lOther$soughtExpertisesTextIds != null) {
-      if (l$soughtExpertisesTextIds.length !=
-          lOther$soughtExpertisesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$soughtExpertisesTextIds.length; i++) {
-        final l$soughtExpertisesTextIds$entry = l$soughtExpertisesTextIds[i];
-        final lOther$soughtExpertisesTextIds$entry =
-            lOther$soughtExpertisesTextIds[i];
-        if (l$soughtExpertisesTextIds$entry !=
-            lOther$soughtExpertisesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$soughtExpertisesTextIds != lOther$soughtExpertisesTextIds) {
-      return false;
-    }
-    final l$industryTextId = industryTextId;
-    final lOther$industryTextId = other.industryTextId;
-    if (l$industryTextId != lOther$industryTextId) {
       return false;
     }
     final l$soughtExpertises = soughtExpertises;
@@ -3869,8 +3680,6 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupM
       _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership;
 
   TRes call({
-    List<String>? soughtExpertisesTextIds,
-    String? industryTextId,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
         soughtExpertises,
     Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
@@ -3908,8 +3717,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMembe
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
-    Object? soughtExpertisesTextIds = _undefined,
-    Object? industryTextId = _undefined,
     Object? soughtExpertises = _undefined,
     Object? industry = _undefined,
     Object? $__typename = _undefined,
@@ -3917,12 +3724,6 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMembe
   }) =>
       _then(
           Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
-        soughtExpertisesTextIds: soughtExpertisesTextIds == _undefined
-            ? _instance.soughtExpertisesTextIds
-            : (soughtExpertisesTextIds as List<String>?),
-        industryTextId: industryTextId == _undefined
-            ? _instance.industryTextId
-            : (industryTextId as String?),
         soughtExpertises: soughtExpertises == _undefined ||
                 soughtExpertises == null
             ? _instance.soughtExpertises
@@ -3973,8 +3774,6 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupM
   TRes _res;
 
   call({
-    List<String>? soughtExpertisesTextIds,
-    String? industryTextId,
     List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
         soughtExpertises,
     Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
@@ -4431,9 +4230,7 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupM
 class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
   Query$MyUserSearches$myUserSearches$topFoundUsers$companies({
     required this.name,
-    this.companyStageTextId,
     this.companyStage,
-    this.companyTypeTextId,
     this.companyType,
     this.$__typename = 'Company',
   });
@@ -4441,19 +4238,15 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
   factory Query$MyUserSearches$myUserSearches$topFoundUsers$companies.fromJson(
       Map<String, dynamic> json) {
     final l$name = json['name'];
-    final l$companyStageTextId = json['companyStageTextId'];
     final l$companyStage = json['companyStage'];
-    final l$companyTypeTextId = json['companyTypeTextId'];
     final l$companyType = json['companyType'];
     final l$$__typename = json['__typename'];
     return Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
       name: (l$name as String),
-      companyStageTextId: (l$companyStageTextId as String?),
       companyStage: l$companyStage == null
           ? null
           : Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
               .fromJson((l$companyStage as Map<String, dynamic>)),
-      companyTypeTextId: (l$companyTypeTextId as String?),
       companyType: l$companyType == null
           ? null
           : Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
@@ -4464,12 +4257,8 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
 
   final String name;
 
-  final String? companyStageTextId;
-
   final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
       companyStage;
-
-  final String? companyTypeTextId;
 
   final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
       companyType;
@@ -4480,12 +4269,8 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
     final _resultData = <String, dynamic>{};
     final l$name = name;
     _resultData['name'] = l$name;
-    final l$companyStageTextId = companyStageTextId;
-    _resultData['companyStageTextId'] = l$companyStageTextId;
     final l$companyStage = companyStage;
     _resultData['companyStage'] = l$companyStage?.toJson();
-    final l$companyTypeTextId = companyTypeTextId;
-    _resultData['companyTypeTextId'] = l$companyTypeTextId;
     final l$companyType = companyType;
     _resultData['companyType'] = l$companyType?.toJson();
     final l$$__typename = $__typename;
@@ -4496,16 +4281,12 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
   @override
   int get hashCode {
     final l$name = name;
-    final l$companyStageTextId = companyStageTextId;
     final l$companyStage = companyStage;
-    final l$companyTypeTextId = companyTypeTextId;
     final l$companyType = companyType;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$name,
-      l$companyStageTextId,
       l$companyStage,
-      l$companyTypeTextId,
       l$companyType,
       l$$__typename,
     ]);
@@ -4526,19 +4307,9 @@ class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
     if (l$name != lOther$name) {
       return false;
     }
-    final l$companyStageTextId = companyStageTextId;
-    final lOther$companyStageTextId = other.companyStageTextId;
-    if (l$companyStageTextId != lOther$companyStageTextId) {
-      return false;
-    }
     final l$companyStage = companyStage;
     final lOther$companyStage = other.companyStage;
     if (l$companyStage != lOther$companyStage) {
-      return false;
-    }
-    final l$companyTypeTextId = companyTypeTextId;
-    final lOther$companyTypeTextId = other.companyTypeTextId;
-    if (l$companyTypeTextId != lOther$companyTypeTextId) {
       return false;
     }
     final l$companyType = companyType;
@@ -4580,10 +4351,8 @@ abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$compan
 
   TRes call({
     String? name,
-    String? companyStageTextId,
     Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
         companyStage,
-    String? companyTypeTextId,
     Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
         companyType,
     String? $__typename,
@@ -4613,9 +4382,7 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
 
   TRes call({
     Object? name = _undefined,
-    Object? companyStageTextId = _undefined,
     Object? companyStage = _undefined,
-    Object? companyTypeTextId = _undefined,
     Object? companyType = _undefined,
     Object? $__typename = _undefined,
   }) =>
@@ -4623,16 +4390,10 @@ class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
         name: name == _undefined || name == null
             ? _instance.name
             : (name as String),
-        companyStageTextId: companyStageTextId == _undefined
-            ? _instance.companyStageTextId
-            : (companyStageTextId as String?),
         companyStage: companyStage == _undefined
             ? _instance.companyStage
             : (companyStage
                 as Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?),
-        companyTypeTextId: companyTypeTextId == _undefined
-            ? _instance.companyTypeTextId
-            : (companyTypeTextId as String?),
         companyType: companyType == _undefined
             ? _instance.companyType
             : (companyType
@@ -4674,10 +4435,8 @@ class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$compan
 
   call({
     String? name,
-    String? companyStageTextId,
     Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
         companyStage,
-    String? companyTypeTextId,
     Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
         companyType,
     String? $__typename,
@@ -5502,6 +5261,20 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                 selectionSet: null,
               ),
               FieldNode(
+                name: NameNode(value: 'cityOfResidence'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'regionOfResidence'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
                 name: NameNode(value: 'countryOfResidence'),
                 alias: null,
                 arguments: [],
@@ -5509,13 +5282,6 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                 selectionSet: SelectionSetNode(selections: [
                   FieldNode(
                     name: NameNode(value: 'translatedValue'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'textId'),
                     alias: null,
                     arguments: [],
                     directives: [],
@@ -5552,43 +5318,7 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
                       FieldNode(
-                        name: NameNode(value: 'expertisesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industriesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
                         name: NameNode(value: 'expertises'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: SelectionSetNode(selections: [
-                          FieldNode(
-                            name: NameNode(value: 'translatedValue'),
-                            alias: null,
-                            arguments: [],
-                            directives: [],
-                            selectionSet: null,
-                          ),
-                          FieldNode(
-                            name: NameNode(value: '__typename'),
-                            alias: null,
-                            arguments: [],
-                            directives: [],
-                            selectionSet: null,
-                          ),
-                        ]),
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industries'),
                         alias: null,
                         arguments: [],
                         directives: [],
@@ -5634,43 +5364,7 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                     directives: [],
                     selectionSet: SelectionSetNode(selections: [
                       FieldNode(
-                        name: NameNode(value: 'soughtExpertisesTextIds'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industryTextId'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
                         name: NameNode(value: 'soughtExpertises'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: SelectionSetNode(selections: [
-                          FieldNode(
-                            name: NameNode(value: 'translatedValue'),
-                            alias: null,
-                            arguments: [],
-                            directives: [],
-                            selectionSet: null,
-                          ),
-                          FieldNode(
-                            name: NameNode(value: '__typename'),
-                            alias: null,
-                            arguments: [],
-                            directives: [],
-                            selectionSet: null,
-                          ),
-                        ]),
-                      ),
-                      FieldNode(
-                        name: NameNode(value: 'industry'),
                         alias: null,
                         arguments: [],
                         directives: [],
@@ -5721,64 +5415,6 @@ const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
                     arguments: [],
                     directives: [],
                     selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'companyStageTextId'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'companyStage'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: SelectionSetNode(selections: [
-                      FieldNode(
-                        name: NameNode(value: 'translatedValue'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: '__typename'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                    ]),
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'companyTypeTextId'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: null,
-                  ),
-                  FieldNode(
-                    name: NameNode(value: 'companyType'),
-                    alias: null,
-                    arguments: [],
-                    directives: [],
-                    selectionSet: SelectionSetNode(selections: [
-                      FieldNode(
-                        name: NameNode(value: 'translatedValue'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      FieldNode(
-                        name: NameNode(value: '__typename'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                    ]),
                   ),
                   FieldNode(
                     name: NameNode(value: '__typename'),
@@ -6109,6 +5745,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     required this.offersHelp,
     required this.seeksHelp,
     this.jobTitle,
+    this.cityOfResidence,
+    this.regionOfResidence,
     this.countryOfResidence,
     required this.groupMemberships,
     required this.companies,
@@ -6127,6 +5765,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$offersHelp = json['offersHelp'];
     final l$seeksHelp = json['seeksHelp'];
     final l$jobTitle = json['jobTitle'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
     final l$countryOfResidence = json['countryOfResidence'];
     final l$groupMemberships = json['groupMemberships'];
     final l$companies = json['companies'];
@@ -6142,6 +5782,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
       offersHelp: (l$offersHelp as bool),
       seeksHelp: (l$seeksHelp as bool),
       jobTitle: (l$jobTitle as String?),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
       countryOfResidence: l$countryOfResidence == null
           ? null
           : Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
@@ -6180,6 +5822,10 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
 
   final String? jobTitle;
 
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
   final Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
       countryOfResidence;
 
@@ -6214,6 +5860,10 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     _resultData['seeksHelp'] = l$seeksHelp;
     final l$jobTitle = jobTitle;
     _resultData['jobTitle'] = l$jobTitle;
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
     final l$countryOfResidence = countryOfResidence;
     _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
     final l$groupMemberships = groupMemberships;
@@ -6238,6 +5888,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$offersHelp = offersHelp;
     final l$seeksHelp = seeksHelp;
     final l$jobTitle = jobTitle;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
     final l$countryOfResidence = countryOfResidence;
     final l$groupMemberships = groupMemberships;
     final l$companies = companies;
@@ -6253,6 +5905,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
       l$offersHelp,
       l$seeksHelp,
       l$jobTitle,
+      l$cityOfResidence,
+      l$regionOfResidence,
       l$countryOfResidence,
       Object.hashAll(l$groupMemberships.map((v) => v)),
       Object.hashAll(l$companies.map((v) => v)),
@@ -6317,6 +5971,16 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers {
     final l$jobTitle = jobTitle;
     final lOther$jobTitle = other.jobTitle;
     if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
       return false;
     }
     final l$countryOfResidence = countryOfResidence;
@@ -6390,6 +6054,8 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
     bool? offersHelp,
     bool? seeksHelp,
     String? jobTitle,
+    String? cityOfResidence,
+    String? regionOfResidence,
     Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
@@ -6440,6 +6106,8 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes>
     Object? offersHelp = _undefined,
     Object? seeksHelp = _undefined,
     Object? jobTitle = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
     Object? countryOfResidence = _undefined,
     Object? groupMemberships = _undefined,
     Object? companies = _undefined,
@@ -6469,6 +6137,12 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes>
             : (seeksHelp as bool),
         jobTitle:
             jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
         countryOfResidence: countryOfResidence == _undefined
             ? _instance.countryOfResidence
             : (countryOfResidence
@@ -6542,6 +6216,8 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<
     bool? offersHelp,
     bool? seeksHelp,
     String? jobTitle,
+    String? cityOfResidence,
+    String? regionOfResidence,
     Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
         countryOfResidence,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
@@ -6563,25 +6239,20 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<
 class Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
   Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence({
     this.translatedValue,
-    required this.textId,
     this.$__typename = 'Country',
   });
 
   factory Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence.fromJson(
       Map<String, dynamic> json) {
     final l$translatedValue = json['translatedValue'];
-    final l$textId = json['textId'];
     final l$$__typename = json['__typename'];
     return Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
       translatedValue: (l$translatedValue as String?),
-      textId: (l$textId as String),
       $__typename: (l$$__typename as String),
     );
   }
 
   final String? translatedValue;
-
-  final String textId;
 
   final String $__typename;
 
@@ -6589,8 +6260,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
     final _resultData = <String, dynamic>{};
     final l$translatedValue = translatedValue;
     _resultData['translatedValue'] = l$translatedValue;
-    final l$textId = textId;
-    _resultData['textId'] = l$textId;
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -6599,11 +6268,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
   @override
   int get hashCode {
     final l$translatedValue = translatedValue;
-    final l$textId = textId;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$translatedValue,
-      l$textId,
       l$$__typename,
     ]);
   }
@@ -6621,11 +6288,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
     final l$translatedValue = translatedValue;
     final lOther$translatedValue = other.translatedValue;
     if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$textId = textId;
-    final lOther$textId = other.textId;
-    if (l$textId != lOther$textId) {
       return false;
     }
     final l$$__typename = $__typename;
@@ -6664,7 +6326,6 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$co
 
   TRes call({
     String? translatedValue,
-    String? textId,
     String? $__typename,
   });
 }
@@ -6690,7 +6351,6 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countr
 
   TRes call({
     Object? translatedValue = _undefined,
-    Object? textId = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(
@@ -6698,9 +6358,6 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countr
         translatedValue: translatedValue == _undefined
             ? _instance.translatedValue
             : (translatedValue as String?),
-        textId: textId == _undefined || textId == null
-            ? _instance.textId
-            : (textId as String),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
@@ -6719,7 +6376,6 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$co
 
   call({
     String? translatedValue,
-    String? textId,
     String? $__typename,
   }) =>
       _res;
@@ -6960,10 +6616,7 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
     implements
         Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
   Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership({
-    this.expertisesTextIds,
-    this.industriesTextIds,
     required this.expertises,
-    required this.industries,
     this.endorsements,
     this.$__typename = 'MentorsGroupMembership',
     required this.groupIdent,
@@ -6971,28 +6624,14 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
 
   factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership.fromJson(
       Map<String, dynamic> json) {
-    final l$expertisesTextIds = json['expertisesTextIds'];
-    final l$industriesTextIds = json['industriesTextIds'];
     final l$expertises = json['expertises'];
-    final l$industries = json['industries'];
     final l$endorsements = json['endorsements'];
     final l$$__typename = json['__typename'];
     final l$groupIdent = json['groupIdent'];
     return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
-      expertisesTextIds: (l$expertisesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
-      industriesTextIds: (l$industriesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
       expertises: (l$expertises as List<dynamic>)
           .map((e) =>
               Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
-                  .fromJson((e as Map<String, dynamic>)))
-          .toList(),
-      industries: (l$industries as List<dynamic>)
-          .map((e) =>
-              Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
                   .fromJson((e as Map<String, dynamic>)))
           .toList(),
       endorsements: (l$endorsements as int?),
@@ -7001,17 +6640,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
     );
   }
 
-  final List<String>? expertisesTextIds;
-
-  final List<String>? industriesTextIds;
-
   final List<
           Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
       expertises;
-
-  final List<
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
-      industries;
 
   final int? endorsements;
 
@@ -7021,16 +6652,8 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
-    final l$expertisesTextIds = expertisesTextIds;
-    _resultData['expertisesTextIds'] =
-        l$expertisesTextIds?.map((e) => e).toList();
-    final l$industriesTextIds = industriesTextIds;
-    _resultData['industriesTextIds'] =
-        l$industriesTextIds?.map((e) => e).toList();
     final l$expertises = expertises;
     _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
-    final l$industries = industries;
-    _resultData['industries'] = l$industries.map((e) => e.toJson()).toList();
     final l$endorsements = endorsements;
     _resultData['endorsements'] = l$endorsements;
     final l$$__typename = $__typename;
@@ -7042,22 +6665,12 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
 
   @override
   int get hashCode {
-    final l$expertisesTextIds = expertisesTextIds;
-    final l$industriesTextIds = industriesTextIds;
     final l$expertises = expertises;
-    final l$industries = industries;
     final l$endorsements = endorsements;
     final l$$__typename = $__typename;
     final l$groupIdent = groupIdent;
     return Object.hashAll([
-      l$expertisesTextIds == null
-          ? null
-          : Object.hashAll(l$expertisesTextIds.map((v) => v)),
-      l$industriesTextIds == null
-          ? null
-          : Object.hashAll(l$industriesTextIds.map((v) => v)),
       Object.hashAll(l$expertises.map((v) => v)),
-      Object.hashAll(l$industries.map((v) => v)),
       l$endorsements,
       l$$__typename,
       l$groupIdent,
@@ -7074,38 +6687,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
         runtimeType != other.runtimeType) {
       return false;
     }
-    final l$expertisesTextIds = expertisesTextIds;
-    final lOther$expertisesTextIds = other.expertisesTextIds;
-    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
-      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$expertisesTextIds.length; i++) {
-        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
-        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
-        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
-      return false;
-    }
-    final l$industriesTextIds = industriesTextIds;
-    final lOther$industriesTextIds = other.industriesTextIds;
-    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
-      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$industriesTextIds.length; i++) {
-        final l$industriesTextIds$entry = l$industriesTextIds[i];
-        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
-        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$industriesTextIds != lOther$industriesTextIds) {
-      return false;
-    }
     final l$expertises = expertises;
     final lOther$expertises = other.expertises;
     if (l$expertises.length != lOther$expertises.length) {
@@ -7115,18 +6696,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
       final l$expertises$entry = l$expertises[i];
       final lOther$expertises$entry = lOther$expertises[i];
       if (l$expertises$entry != lOther$expertises$entry) {
-        return false;
-      }
-    }
-    final l$industries = industries;
-    final lOther$industries = other.industries;
-    if (l$industries.length != lOther$industries.length) {
-      return false;
-    }
-    for (int i = 0; i < l$industries.length; i++) {
-      final l$industries$entry = l$industries[i];
-      final lOther$industries$entry = lOther$industries[i];
-      if (l$industries$entry != lOther$industries$entry) {
         return false;
       }
     }
@@ -7175,12 +6744,8 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
       _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership;
 
   TRes call({
-    List<String>? expertisesTextIds,
-    List<String>? industriesTextIds,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
         expertises,
-    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
-        industries,
     int? endorsements,
     String? $__typename,
     String? groupIdent,
@@ -7190,12 +6755,6 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
               Iterable<
                   CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
                       Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
-          _fn);
-  TRes industries(
-      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
-              Iterable<
-                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-                      Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
           _fn);
 }
 
@@ -7219,30 +6778,17 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupM
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
-    Object? expertisesTextIds = _undefined,
-    Object? industriesTextIds = _undefined,
     Object? expertises = _undefined,
-    Object? industries = _undefined,
     Object? endorsements = _undefined,
     Object? $__typename = _undefined,
     Object? groupIdent = _undefined,
   }) =>
       _then(
           Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
-        expertisesTextIds: expertisesTextIds == _undefined
-            ? _instance.expertisesTextIds
-            : (expertisesTextIds as List<String>?),
-        industriesTextIds: industriesTextIds == _undefined
-            ? _instance.industriesTextIds
-            : (industriesTextIds as List<String>?),
         expertises: expertises == _undefined || expertises == null
             ? _instance.expertises
             : (expertises as List<
                 Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>),
-        industries: industries == _undefined || industries == null
-            ? _instance.industries
-            : (industries as List<
-                Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>),
         endorsements: endorsements == _undefined
             ? _instance.endorsements
             : (endorsements as int?),
@@ -7265,18 +6811,6 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupM
                 e,
                 (i) => i,
               ))).toList());
-  TRes industries(
-          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
-                  Iterable<
-                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-                          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
-              _fn) =>
-      call(
-          industries: _fn(_instance.industries.map((e) =>
-              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-                e,
-                (i) => i,
-              ))).toList());
 }
 
 class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
@@ -7290,19 +6824,14 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
   TRes _res;
 
   call({
-    List<String>? expertisesTextIds,
-    List<String>? industriesTextIds,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
         expertises,
-    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
-        industries,
     int? endorsements,
     String? $__typename,
     String? groupIdent,
   }) =>
       _res;
   expertises(_fn) => _res;
-  industries(_fn) => _res;
 }
 
 class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises {
@@ -7450,200 +6979,34 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
       _res;
 }
 
-class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
-  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries({
-    this.translatedValue,
-    this.$__typename = 'Industry',
-  });
-
-  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.fromJson(
-      Map<String, dynamic> json) {
-    final l$translatedValue = json['translatedValue'];
-    final l$$__typename = json['__typename'];
-    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-      translatedValue: (l$translatedValue as String?),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final String? translatedValue;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$translatedValue = translatedValue;
-    _resultData['translatedValue'] = l$translatedValue;
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$translatedValue = translatedValue;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$translatedValue,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other
-            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$translatedValue = translatedValue;
-    final lOther$translatedValue = other.translatedValue;
-    if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
-    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
-      get copyWith =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-            this,
-            (i) => i,
-          );
-}
-
-abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-    TRes> {
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
-        instance,
-    TRes Function(
-            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
-        then,
-  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
-
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.stub(
-          TRes res) =
-      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
-
-  TRes call({
-    String? translatedValue,
-    String? $__typename,
-  });
-}
-
-class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-            TRes> {
-  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-    this._instance,
-    this._then,
-  );
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
-      _instance;
-
-  final TRes Function(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
-      _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? translatedValue = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-        translatedValue: translatedValue == _undefined
-            ? _instance.translatedValue
-            : (translatedValue as String?),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-}
-
-class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
-            TRes> {
-  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
-      this._res);
-
-  TRes _res;
-
-  call({
-    String? translatedValue,
-    String? $__typename,
-  }) =>
-      _res;
-}
-
 class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
     implements
         Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
   Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership({
-    this.soughtExpertisesTextIds,
-    this.industryTextId,
     required this.soughtExpertises,
-    this.industry,
     this.$__typename = 'MenteesGroupMembership',
     required this.groupIdent,
   });
 
   factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership.fromJson(
       Map<String, dynamic> json) {
-    final l$soughtExpertisesTextIds = json['soughtExpertisesTextIds'];
-    final l$industryTextId = json['industryTextId'];
     final l$soughtExpertises = json['soughtExpertises'];
-    final l$industry = json['industry'];
     final l$$__typename = json['__typename'];
     final l$groupIdent = json['groupIdent'];
     return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
-      soughtExpertisesTextIds: (l$soughtExpertisesTextIds as List<dynamic>?)
-          ?.map((e) => (e as String))
-          .toList(),
-      industryTextId: (l$industryTextId as String?),
       soughtExpertises: (l$soughtExpertises as List<dynamic>)
           .map((e) =>
               Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
                   .fromJson((e as Map<String, dynamic>)))
           .toList(),
-      industry: l$industry == null
-          ? null
-          : Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-              .fromJson((l$industry as Map<String, dynamic>)),
       $__typename: (l$$__typename as String),
       groupIdent: (l$groupIdent as String),
     );
   }
 
-  final List<String>? soughtExpertisesTextIds;
-
-  final String? industryTextId;
-
   final List<
           Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
       soughtExpertises;
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
-      industry;
 
   final String $__typename;
 
@@ -7651,16 +7014,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
 
   Map<String, dynamic> toJson() {
     final _resultData = <String, dynamic>{};
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    _resultData['soughtExpertisesTextIds'] =
-        l$soughtExpertisesTextIds?.map((e) => e).toList();
-    final l$industryTextId = industryTextId;
-    _resultData['industryTextId'] = l$industryTextId;
     final l$soughtExpertises = soughtExpertises;
     _resultData['soughtExpertises'] =
         l$soughtExpertises.map((e) => e.toJson()).toList();
-    final l$industry = industry;
-    _resultData['industry'] = l$industry?.toJson();
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     final l$groupIdent = groupIdent;
@@ -7670,19 +7026,11 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
 
   @override
   int get hashCode {
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    final l$industryTextId = industryTextId;
     final l$soughtExpertises = soughtExpertises;
-    final l$industry = industry;
     final l$$__typename = $__typename;
     final l$groupIdent = groupIdent;
     return Object.hashAll([
-      l$soughtExpertisesTextIds == null
-          ? null
-          : Object.hashAll(l$soughtExpertisesTextIds.map((v) => v)),
-      l$industryTextId,
       Object.hashAll(l$soughtExpertises.map((v) => v)),
-      l$industry,
       l$$__typename,
       l$groupIdent,
     ]);
@@ -7698,31 +7046,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
         runtimeType != other.runtimeType) {
       return false;
     }
-    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
-    final lOther$soughtExpertisesTextIds = other.soughtExpertisesTextIds;
-    if (l$soughtExpertisesTextIds != null &&
-        lOther$soughtExpertisesTextIds != null) {
-      if (l$soughtExpertisesTextIds.length !=
-          lOther$soughtExpertisesTextIds.length) {
-        return false;
-      }
-      for (int i = 0; i < l$soughtExpertisesTextIds.length; i++) {
-        final l$soughtExpertisesTextIds$entry = l$soughtExpertisesTextIds[i];
-        final lOther$soughtExpertisesTextIds$entry =
-            lOther$soughtExpertisesTextIds[i];
-        if (l$soughtExpertisesTextIds$entry !=
-            lOther$soughtExpertisesTextIds$entry) {
-          return false;
-        }
-      }
-    } else if (l$soughtExpertisesTextIds != lOther$soughtExpertisesTextIds) {
-      return false;
-    }
-    final l$industryTextId = industryTextId;
-    final lOther$industryTextId = other.industryTextId;
-    if (l$industryTextId != lOther$industryTextId) {
-      return false;
-    }
     final l$soughtExpertises = soughtExpertises;
     final lOther$soughtExpertises = other.soughtExpertises;
     if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
@@ -7734,11 +7057,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$Me
       if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
         return false;
       }
-    }
-    final l$industry = industry;
-    final lOther$industry = other.industry;
-    if (l$industry != lOther$industry) {
-      return false;
     }
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
@@ -7780,12 +7098,8 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
       _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership;
 
   TRes call({
-    List<String>? soughtExpertisesTextIds,
-    String? industryTextId,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
         soughtExpertises,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
-        industry,
     String? $__typename,
     String? groupIdent,
   });
@@ -7795,8 +7109,6 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
                   CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
                       Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
           _fn);
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-      TRes> get industry;
 }
 
 class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
@@ -7819,30 +7131,17 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupM
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
-    Object? soughtExpertisesTextIds = _undefined,
-    Object? industryTextId = _undefined,
     Object? soughtExpertises = _undefined,
-    Object? industry = _undefined,
     Object? $__typename = _undefined,
     Object? groupIdent = _undefined,
   }) =>
       _then(
           Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
-        soughtExpertisesTextIds: soughtExpertisesTextIds == _undefined
-            ? _instance.soughtExpertisesTextIds
-            : (soughtExpertisesTextIds as List<String>?),
-        industryTextId: industryTextId == _undefined
-            ? _instance.industryTextId
-            : (industryTextId as String?),
         soughtExpertises: soughtExpertises == _undefined ||
                 soughtExpertises == null
             ? _instance.soughtExpertises
             : (soughtExpertises as List<
                 Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
-        industry: industry == _undefined
-            ? _instance.industry
-            : (industry
-                as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
@@ -7862,15 +7161,6 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupM
                 e,
                 (i) => i,
               ))).toList());
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-      TRes> get industry {
-    final local$industry = _instance.industry;
-    return local$industry == null
-        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-            .stub(_then(_instance))
-        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-            local$industry, (e) => call(industry: e));
-  }
 }
 
 class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
@@ -7884,22 +7174,13 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
   TRes _res;
 
   call({
-    List<String>? soughtExpertisesTextIds,
-    String? industryTextId,
     List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
         soughtExpertises,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
-        industry,
     String? $__typename,
     String? groupIdent,
   }) =>
       _res;
   soughtExpertises(_fn) => _res;
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-          TRes>
-      get industry =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-              .stub(_res);
 }
 
 class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
@@ -8036,151 +7317,6 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
         CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
             TRes> {
   _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
-      this._res);
-
-  TRes _res;
-
-  call({
-    String? translatedValue,
-    String? $__typename,
-  }) =>
-      _res;
-}
-
-class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
-  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry({
-    this.translatedValue,
-    this.$__typename = 'Industry',
-  });
-
-  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.fromJson(
-      Map<String, dynamic> json) {
-    final l$translatedValue = json['translatedValue'];
-    final l$$__typename = json['__typename'];
-    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-      translatedValue: (l$translatedValue as String?),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final String? translatedValue;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$translatedValue = translatedValue;
-    _resultData['translatedValue'] = l$translatedValue;
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$translatedValue = translatedValue;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$translatedValue,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other
-            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$translatedValue = translatedValue;
-    final lOther$translatedValue = other.translatedValue;
-    if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry>
-      get copyWith =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-            this,
-            (i) => i,
-          );
-}
-
-abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-    TRes> {
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-        instance,
-    TRes Function(
-            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
-        then,
-  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
-
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.stub(
-          TRes res) =
-      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
-
-  TRes call({
-    String? translatedValue,
-    String? $__typename,
-  });
-}
-
-class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-            TRes> {
-  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-    this._instance,
-    this._then,
-  );
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
-      _instance;
-
-  final TRes Function(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
-      _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? translatedValue = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
-        translatedValue: translatedValue == _undefined
-            ? _instance.translatedValue
-            : (translatedValue as String?),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-}
-
-class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
-            TRes> {
-  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
       this._res);
 
   TRes _res;
@@ -8342,48 +7478,20 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$gr
 class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
   Query$FindUserSearch$findUserSearchById$topFoundUsers$companies({
     required this.name,
-    this.companyStageTextId,
-    this.companyStage,
-    this.companyTypeTextId,
-    this.companyType,
     this.$__typename = 'Company',
   });
 
   factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies.fromJson(
       Map<String, dynamic> json) {
     final l$name = json['name'];
-    final l$companyStageTextId = json['companyStageTextId'];
-    final l$companyStage = json['companyStage'];
-    final l$companyTypeTextId = json['companyTypeTextId'];
-    final l$companyType = json['companyType'];
     final l$$__typename = json['__typename'];
     return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
       name: (l$name as String),
-      companyStageTextId: (l$companyStageTextId as String?),
-      companyStage: l$companyStage == null
-          ? null
-          : Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-              .fromJson((l$companyStage as Map<String, dynamic>)),
-      companyTypeTextId: (l$companyTypeTextId as String?),
-      companyType: l$companyType == null
-          ? null
-          : Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-              .fromJson((l$companyType as Map<String, dynamic>)),
       $__typename: (l$$__typename as String),
     );
   }
 
   final String name;
-
-  final String? companyStageTextId;
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
-      companyStage;
-
-  final String? companyTypeTextId;
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
-      companyType;
 
   final String $__typename;
 
@@ -8391,14 +7499,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
     final _resultData = <String, dynamic>{};
     final l$name = name;
     _resultData['name'] = l$name;
-    final l$companyStageTextId = companyStageTextId;
-    _resultData['companyStageTextId'] = l$companyStageTextId;
-    final l$companyStage = companyStage;
-    _resultData['companyStage'] = l$companyStage?.toJson();
-    final l$companyTypeTextId = companyTypeTextId;
-    _resultData['companyTypeTextId'] = l$companyTypeTextId;
-    final l$companyType = companyType;
-    _resultData['companyType'] = l$companyType?.toJson();
     final l$$__typename = $__typename;
     _resultData['__typename'] = l$$__typename;
     return _resultData;
@@ -8407,17 +7507,9 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
   @override
   int get hashCode {
     final l$name = name;
-    final l$companyStageTextId = companyStageTextId;
-    final l$companyStage = companyStage;
-    final l$companyTypeTextId = companyTypeTextId;
-    final l$companyType = companyType;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$name,
-      l$companyStageTextId,
-      l$companyStage,
-      l$companyTypeTextId,
-      l$companyType,
       l$$__typename,
     ]);
   }
@@ -8435,26 +7527,6 @@ class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
     final l$name = name;
     final lOther$name = other.name;
     if (l$name != lOther$name) {
-      return false;
-    }
-    final l$companyStageTextId = companyStageTextId;
-    final lOther$companyStageTextId = other.companyStageTextId;
-    if (l$companyStageTextId != lOther$companyStageTextId) {
-      return false;
-    }
-    final l$companyStage = companyStage;
-    final lOther$companyStage = other.companyStage;
-    if (l$companyStage != lOther$companyStage) {
-      return false;
-    }
-    final l$companyTypeTextId = companyTypeTextId;
-    final lOther$companyTypeTextId = other.companyTypeTextId;
-    if (l$companyTypeTextId != lOther$companyTypeTextId) {
-      return false;
-    }
-    final l$companyType = companyType;
-    final lOther$companyType = other.companyType;
-    if (l$companyType != lOther$companyType) {
       return false;
     }
     final l$$__typename = $__typename;
@@ -8492,18 +7564,8 @@ abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$co
 
   TRes call({
     String? name,
-    String? companyStageTextId,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
-        companyStage,
-    String? companyTypeTextId,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
-        companyType,
     String? $__typename,
   });
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-      TRes> get companyStage;
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-      TRes> get companyType;
 }
 
 class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
@@ -8526,53 +7588,16 @@ class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$compan
 
   TRes call({
     Object? name = _undefined,
-    Object? companyStageTextId = _undefined,
-    Object? companyStage = _undefined,
-    Object? companyTypeTextId = _undefined,
-    Object? companyType = _undefined,
     Object? $__typename = _undefined,
   }) =>
       _then(Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
         name: name == _undefined || name == null
             ? _instance.name
             : (name as String),
-        companyStageTextId: companyStageTextId == _undefined
-            ? _instance.companyStageTextId
-            : (companyStageTextId as String?),
-        companyStage: companyStage == _undefined
-            ? _instance.companyStage
-            : (companyStage
-                as Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?),
-        companyTypeTextId: companyTypeTextId == _undefined
-            ? _instance.companyTypeTextId
-            : (companyTypeTextId as String?),
-        companyType: companyType == _undefined
-            ? _instance.companyType
-            : (companyType
-                as Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?),
         $__typename: $__typename == _undefined || $__typename == null
             ? _instance.$__typename
             : ($__typename as String),
       ));
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-      TRes> get companyStage {
-    final local$companyStage = _instance.companyStage;
-    return local$companyStage == null
-        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-            .stub(_then(_instance))
-        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-            local$companyStage, (e) => call(companyStage: e));
-  }
-
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-      TRes> get companyType {
-    final local$companyType = _instance.companyType;
-    return local$companyType == null
-        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-            .stub(_then(_instance))
-        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-            local$companyType, (e) => call(companyType: e));
-  }
 }
 
 class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
@@ -8587,312 +7612,6 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$co
 
   call({
     String? name,
-    String? companyStageTextId,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
-        companyStage,
-    String? companyTypeTextId,
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
-        companyType,
-    String? $__typename,
-  }) =>
-      _res;
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-          TRes>
-      get companyStage =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-              .stub(_res);
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-          TRes>
-      get companyType =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-              .stub(_res);
-}
-
-class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage {
-  Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage({
-    this.translatedValue,
-    this.$__typename = 'CompanyStage',
-  });
-
-  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage.fromJson(
-      Map<String, dynamic> json) {
-    final l$translatedValue = json['translatedValue'];
-    final l$$__typename = json['__typename'];
-    return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-      translatedValue: (l$translatedValue as String?),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final String? translatedValue;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$translatedValue = translatedValue;
-    _resultData['translatedValue'] = l$translatedValue;
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$translatedValue = translatedValue;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$translatedValue,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other
-            is Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$translatedValue = translatedValue;
-    final lOther$translatedValue = other.translatedValue;
-    if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-    on Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage {
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage>
-      get copyWith =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-            this,
-            (i) => i,
-          );
-}
-
-abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-    TRes> {
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-        instance,
-    TRes Function(
-            Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage)
-        then,
-  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage;
-
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage.stub(
-          TRes res) =
-      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage;
-
-  TRes call({
-    String? translatedValue,
-    String? $__typename,
-  });
-}
-
-class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-            TRes> {
-  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-    this._instance,
-    this._then,
-  );
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
-      _instance;
-
-  final TRes Function(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage)
-      _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? translatedValue = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-        translatedValue: translatedValue == _undefined
-            ? _instance.translatedValue
-            : (translatedValue as String?),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-}
-
-class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
-            TRes> {
-  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
-      this._res);
-
-  TRes _res;
-
-  call({
-    String? translatedValue,
-    String? $__typename,
-  }) =>
-      _res;
-}
-
-class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType {
-  Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType({
-    this.translatedValue,
-    this.$__typename = 'CompanyType',
-  });
-
-  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType.fromJson(
-      Map<String, dynamic> json) {
-    final l$translatedValue = json['translatedValue'];
-    final l$$__typename = json['__typename'];
-    return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-      translatedValue: (l$translatedValue as String?),
-      $__typename: (l$$__typename as String),
-    );
-  }
-
-  final String? translatedValue;
-
-  final String $__typename;
-
-  Map<String, dynamic> toJson() {
-    final _resultData = <String, dynamic>{};
-    final l$translatedValue = translatedValue;
-    _resultData['translatedValue'] = l$translatedValue;
-    final l$$__typename = $__typename;
-    _resultData['__typename'] = l$$__typename;
-    return _resultData;
-  }
-
-  @override
-  int get hashCode {
-    final l$translatedValue = translatedValue;
-    final l$$__typename = $__typename;
-    return Object.hashAll([
-      l$translatedValue,
-      l$$__typename,
-    ]);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other
-            is Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$translatedValue = translatedValue;
-    final lOther$translatedValue = other.translatedValue;
-    if (l$translatedValue != lOther$translatedValue) {
-      return false;
-    }
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) {
-      return false;
-    }
-    return true;
-  }
-}
-
-extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-    on Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType {
-  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType>
-      get copyWith =>
-          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-            this,
-            (i) => i,
-          );
-}
-
-abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-    TRes> {
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-        instance,
-    TRes Function(
-            Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType)
-        then,
-  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType;
-
-  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType.stub(
-          TRes res) =
-      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType;
-
-  TRes call({
-    String? translatedValue,
-    String? $__typename,
-  });
-}
-
-class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-            TRes> {
-  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-    this._instance,
-    this._then,
-  );
-
-  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
-      _instance;
-
-  final TRes Function(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType)
-      _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? translatedValue = _undefined,
-    Object? $__typename = _undefined,
-  }) =>
-      _then(
-          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-        translatedValue: translatedValue == _undefined
-            ? _instance.translatedValue
-            : (translatedValue as String?),
-        $__typename: $__typename == _undefined || $__typename == null
-            ? _instance.$__typename
-            : ($__typename as String),
-      ));
-}
-
-class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-        TRes>
-    implements
-        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
-            TRes> {
-  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
-      this._res);
-
-  TRes _res;
-
-  call({
-    String? translatedValue,
     String? $__typename,
   }) =>
       _res;
@@ -18119,6 +16838,9146 @@ class _CopyWithStubImpl$Query$FindUserDetailedProfile$findUserById$groupMembersh
 
   call({
     String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindMentorUserDetailedProfile {
+  factory Variables$Query$FindMentorUserDetailedProfile({required String id}) =>
+      Variables$Query$FindMentorUserDetailedProfile._({
+        r'id': id,
+      });
+
+  Variables$Query$FindMentorUserDetailedProfile._(this._$data);
+
+  factory Variables$Query$FindMentorUserDetailedProfile.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$id = data['id'];
+    result$data['id'] = (l$id as String);
+    return Variables$Query$FindMentorUserDetailedProfile._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String get id => (_$data['id'] as String);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$id = id;
+    result$data['id'] = l$id;
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindMentorUserDetailedProfile<
+          Variables$Query$FindMentorUserDetailedProfile>
+      get copyWith => CopyWith$Variables$Query$FindMentorUserDetailedProfile(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindMentorUserDetailedProfile) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    return Object.hashAll([l$id]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindMentorUserDetailedProfile<TRes> {
+  factory CopyWith$Variables$Query$FindMentorUserDetailedProfile(
+    Variables$Query$FindMentorUserDetailedProfile instance,
+    TRes Function(Variables$Query$FindMentorUserDetailedProfile) then,
+  ) = _CopyWithImpl$Variables$Query$FindMentorUserDetailedProfile;
+
+  factory CopyWith$Variables$Query$FindMentorUserDetailedProfile.stub(
+          TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindMentorUserDetailedProfile;
+
+  TRes call({String? id});
+}
+
+class _CopyWithImpl$Variables$Query$FindMentorUserDetailedProfile<TRes>
+    implements CopyWith$Variables$Query$FindMentorUserDetailedProfile<TRes> {
+  _CopyWithImpl$Variables$Query$FindMentorUserDetailedProfile(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindMentorUserDetailedProfile _instance;
+
+  final TRes Function(Variables$Query$FindMentorUserDetailedProfile) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? id = _undefined}) =>
+      _then(Variables$Query$FindMentorUserDetailedProfile._({
+        ..._instance._$data,
+        if (id != _undefined && id != null) 'id': (id as String),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindMentorUserDetailedProfile<TRes>
+    implements CopyWith$Variables$Query$FindMentorUserDetailedProfile<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindMentorUserDetailedProfile(this._res);
+
+  TRes _res;
+
+  call({String? id}) => _res;
+}
+
+class Query$FindMentorUserDetailedProfile {
+  Query$FindMentorUserDetailedProfile({
+    required this.findUserById,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindMentorUserDetailedProfile.fromJson(
+      Map<String, dynamic> json) {
+    final l$findUserById = json['findUserById'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile(
+      findUserById: Query$FindMentorUserDetailedProfile$findUserById.fromJson(
+          (l$findUserById as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindMentorUserDetailedProfile$findUserById findUserById;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUserById = findUserById;
+    _resultData['findUserById'] = l$findUserById.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUserById = findUserById;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$findUserById,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUserDetailedProfile) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUserById = findUserById;
+    final lOther$findUserById = other.findUserById;
+    if (l$findUserById != lOther$findUserById) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile
+    on Query$FindMentorUserDetailedProfile {
+  CopyWith$Query$FindMentorUserDetailedProfile<
+          Query$FindMentorUserDetailedProfile>
+      get copyWith => CopyWith$Query$FindMentorUserDetailedProfile(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile<TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile(
+    Query$FindMentorUserDetailedProfile instance,
+    TRes Function(Query$FindMentorUserDetailedProfile) then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile;
+
+  TRes call({
+    Query$FindMentorUserDetailedProfile$findUserById? findUserById,
+    String? $__typename,
+  });
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes>
+      get findUserById;
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile<TRes>
+    implements CopyWith$Query$FindMentorUserDetailedProfile<TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile _instance;
+
+  final TRes Function(Query$FindMentorUserDetailedProfile) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUserById = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile(
+        findUserById: findUserById == _undefined || findUserById == null
+            ? _instance.findUserById
+            : (findUserById
+                as Query$FindMentorUserDetailedProfile$findUserById),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes>
+      get findUserById {
+    final local$findUserById = _instance.findUserById;
+    return CopyWith$Query$FindMentorUserDetailedProfile$findUserById(
+        local$findUserById, (e) => call(findUserById: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile<TRes>
+    implements CopyWith$Query$FindMentorUserDetailedProfile<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindMentorUserDetailedProfile$findUserById? findUserById,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes>
+      get findUserById =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById.stub(_res);
+}
+
+const documentNodeQueryFindMentorUserDetailedProfile =
+    DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindMentorUserDetailedProfile'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'id')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUserById'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'id'),
+            value: VariableNode(name: NameNode(value: 'id')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'offersHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'seeksHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'websites'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'value'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'label'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'spokenLanguages'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'groupMemberships'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'groupId'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'groupIdent'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MentorsGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'expertisesTextIds'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'industriesTextIds'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'expertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'industries'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'endorsements'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'expectationsForMentees'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'pronounsDisplay'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'pronouns'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'businessExperiences'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'businessName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'jobTitle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'startDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'endDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'city'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'state'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'country'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'academicExperiences'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'institutionName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'degreeType'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'fieldOfStudy'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'startDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'endDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidenceTextId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfOriginTextId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'companies'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'name'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindMentorUserDetailedProfile$findUserById {
+  Query$FindMentorUserDetailedProfile$findUserById({
+    required this.id,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    required this.offersHelp,
+    required this.seeksHelp,
+    this.websites,
+    required this.spokenLanguages,
+    this.avatarUrl,
+    required this.groupMemberships,
+    required this.pronounsDisplay,
+    required this.pronouns,
+    this.businessExperiences,
+    this.academicExperiences,
+    this.cityOfResidence,
+    this.regionOfResidence,
+    this.countryOfResidenceTextId,
+    this.countryOfResidence,
+    this.cityOfOrigin,
+    this.regionOfOrigin,
+    this.countryOfOriginTextId,
+    this.countryOfOrigin,
+    this.jobTitle,
+    required this.companies,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$offersHelp = json['offersHelp'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$websites = json['websites'];
+    final l$spokenLanguages = json['spokenLanguages'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$pronounsDisplay = json['pronounsDisplay'];
+    final l$pronouns = json['pronouns'];
+    final l$businessExperiences = json['businessExperiences'];
+    final l$academicExperiences = json['academicExperiences'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
+    final l$countryOfResidenceTextId = json['countryOfResidenceTextId'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$cityOfOrigin = json['cityOfOrigin'];
+    final l$regionOfOrigin = json['regionOfOrigin'];
+    final l$countryOfOriginTextId = json['countryOfOriginTextId'];
+    final l$countryOfOrigin = json['countryOfOrigin'];
+    final l$jobTitle = json['jobTitle'];
+    final l$companies = json['companies'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById(
+      id: (l$id as String),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      offersHelp: (l$offersHelp as bool),
+      seeksHelp: (l$seeksHelp as bool),
+      websites: (l$websites as List<dynamic>?)
+          ?.map((e) => Query$FindMentorUserDetailedProfile$findUserById$websites
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      spokenLanguages: (l$spokenLanguages as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      avatarUrl: (l$avatarUrl as String?),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$groupMemberships
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      pronounsDisplay: (l$pronounsDisplay as String),
+      pronouns: (l$pronouns as List<dynamic>)
+          .map((e) => Query$FindMentorUserDetailedProfile$findUserById$pronouns
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      businessExperiences: (l$businessExperiences as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$businessExperiences
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      academicExperiences: (l$academicExperiences as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$academicExperiences
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
+      countryOfResidenceTextId: (l$countryOfResidenceTextId as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+              .fromJson((l$countryOfResidence as Map<String, dynamic>)),
+      cityOfOrigin: (l$cityOfOrigin as String?),
+      regionOfOrigin: (l$regionOfOrigin as String?),
+      countryOfOriginTextId: (l$countryOfOriginTextId as String?),
+      countryOfOrigin: l$countryOfOrigin == null
+          ? null
+          : Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin
+              .fromJson((l$countryOfOrigin as Map<String, dynamic>)),
+      jobTitle: (l$jobTitle as String?),
+      companies: (l$companies as List<dynamic>)
+          .map((e) => Query$FindMentorUserDetailedProfile$findUserById$companies
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final bool offersHelp;
+
+  final bool seeksHelp;
+
+  final List<Query$FindMentorUserDetailedProfile$findUserById$websites>?
+      websites;
+
+  final List<Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>
+      spokenLanguages;
+
+  final String? avatarUrl;
+
+  final List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>
+      groupMemberships;
+
+  final String pronounsDisplay;
+
+  final List<Query$FindMentorUserDetailedProfile$findUserById$pronouns>
+      pronouns;
+
+  final List<
+          Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>?
+      businessExperiences;
+
+  final List<
+          Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>?
+      academicExperiences;
+
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
+  final String? countryOfResidenceTextId;
+
+  final Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence?
+      countryOfResidence;
+
+  final String? cityOfOrigin;
+
+  final String? regionOfOrigin;
+
+  final String? countryOfOriginTextId;
+
+  final Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin?
+      countryOfOrigin;
+
+  final String? jobTitle;
+
+  final List<Query$FindMentorUserDetailedProfile$findUserById$companies>
+      companies;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp;
+    final l$websites = websites;
+    _resultData['websites'] = l$websites?.map((e) => e.toJson()).toList();
+    final l$spokenLanguages = spokenLanguages;
+    _resultData['spokenLanguages'] =
+        l$spokenLanguages.map((e) => e.toJson()).toList();
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$pronounsDisplay = pronounsDisplay;
+    _resultData['pronounsDisplay'] = l$pronounsDisplay;
+    final l$pronouns = pronouns;
+    _resultData['pronouns'] = l$pronouns.map((e) => e.toJson()).toList();
+    final l$businessExperiences = businessExperiences;
+    _resultData['businessExperiences'] =
+        l$businessExperiences?.map((e) => e.toJson()).toList();
+    final l$academicExperiences = academicExperiences;
+    _resultData['academicExperiences'] =
+        l$academicExperiences?.map((e) => e.toJson()).toList();
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    _resultData['countryOfResidenceTextId'] = l$countryOfResidenceTextId;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$cityOfOrigin = cityOfOrigin;
+    _resultData['cityOfOrigin'] = l$cityOfOrigin;
+    final l$regionOfOrigin = regionOfOrigin;
+    _resultData['regionOfOrigin'] = l$regionOfOrigin;
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    _resultData['countryOfOriginTextId'] = l$countryOfOriginTextId;
+    final l$countryOfOrigin = countryOfOrigin;
+    _resultData['countryOfOrigin'] = l$countryOfOrigin?.toJson();
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$offersHelp = offersHelp;
+    final l$seeksHelp = seeksHelp;
+    final l$websites = websites;
+    final l$spokenLanguages = spokenLanguages;
+    final l$avatarUrl = avatarUrl;
+    final l$groupMemberships = groupMemberships;
+    final l$pronounsDisplay = pronounsDisplay;
+    final l$pronouns = pronouns;
+    final l$businessExperiences = businessExperiences;
+    final l$academicExperiences = academicExperiences;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    final l$countryOfResidence = countryOfResidence;
+    final l$cityOfOrigin = cityOfOrigin;
+    final l$regionOfOrigin = regionOfOrigin;
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    final l$countryOfOrigin = countryOfOrigin;
+    final l$jobTitle = jobTitle;
+    final l$companies = companies;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$offersHelp,
+      l$seeksHelp,
+      l$websites == null ? null : Object.hashAll(l$websites.map((v) => v)),
+      Object.hashAll(l$spokenLanguages.map((v) => v)),
+      l$avatarUrl,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      l$pronounsDisplay,
+      Object.hashAll(l$pronouns.map((v) => v)),
+      l$businessExperiences == null
+          ? null
+          : Object.hashAll(l$businessExperiences.map((v) => v)),
+      l$academicExperiences == null
+          ? null
+          : Object.hashAll(l$academicExperiences.map((v) => v)),
+      l$cityOfResidence,
+      l$regionOfResidence,
+      l$countryOfResidenceTextId,
+      l$countryOfResidence,
+      l$cityOfOrigin,
+      l$regionOfOrigin,
+      l$countryOfOriginTextId,
+      l$countryOfOrigin,
+      l$jobTitle,
+      Object.hashAll(l$companies.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUserDetailedProfile$findUserById) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$websites = websites;
+    final lOther$websites = other.websites;
+    if (l$websites != null && lOther$websites != null) {
+      if (l$websites.length != lOther$websites.length) {
+        return false;
+      }
+      for (int i = 0; i < l$websites.length; i++) {
+        final l$websites$entry = l$websites[i];
+        final lOther$websites$entry = lOther$websites[i];
+        if (l$websites$entry != lOther$websites$entry) {
+          return false;
+        }
+      }
+    } else if (l$websites != lOther$websites) {
+      return false;
+    }
+    final l$spokenLanguages = spokenLanguages;
+    final lOther$spokenLanguages = other.spokenLanguages;
+    if (l$spokenLanguages.length != lOther$spokenLanguages.length) {
+      return false;
+    }
+    for (int i = 0; i < l$spokenLanguages.length; i++) {
+      final l$spokenLanguages$entry = l$spokenLanguages[i];
+      final lOther$spokenLanguages$entry = lOther$spokenLanguages[i];
+      if (l$spokenLanguages$entry != lOther$spokenLanguages$entry) {
+        return false;
+      }
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$pronounsDisplay = pronounsDisplay;
+    final lOther$pronounsDisplay = other.pronounsDisplay;
+    if (l$pronounsDisplay != lOther$pronounsDisplay) {
+      return false;
+    }
+    final l$pronouns = pronouns;
+    final lOther$pronouns = other.pronouns;
+    if (l$pronouns.length != lOther$pronouns.length) {
+      return false;
+    }
+    for (int i = 0; i < l$pronouns.length; i++) {
+      final l$pronouns$entry = l$pronouns[i];
+      final lOther$pronouns$entry = lOther$pronouns[i];
+      if (l$pronouns$entry != lOther$pronouns$entry) {
+        return false;
+      }
+    }
+    final l$businessExperiences = businessExperiences;
+    final lOther$businessExperiences = other.businessExperiences;
+    if (l$businessExperiences != null && lOther$businessExperiences != null) {
+      if (l$businessExperiences.length != lOther$businessExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$businessExperiences.length; i++) {
+        final l$businessExperiences$entry = l$businessExperiences[i];
+        final lOther$businessExperiences$entry = lOther$businessExperiences[i];
+        if (l$businessExperiences$entry != lOther$businessExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$businessExperiences != lOther$businessExperiences) {
+      return false;
+    }
+    final l$academicExperiences = academicExperiences;
+    final lOther$academicExperiences = other.academicExperiences;
+    if (l$academicExperiences != null && lOther$academicExperiences != null) {
+      if (l$academicExperiences.length != lOther$academicExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$academicExperiences.length; i++) {
+        final l$academicExperiences$entry = l$academicExperiences[i];
+        final lOther$academicExperiences$entry = lOther$academicExperiences[i];
+        if (l$academicExperiences$entry != lOther$academicExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$academicExperiences != lOther$academicExperiences) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
+      return false;
+    }
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    final lOther$countryOfResidenceTextId = other.countryOfResidenceTextId;
+    if (l$countryOfResidenceTextId != lOther$countryOfResidenceTextId) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$cityOfOrigin = cityOfOrigin;
+    final lOther$cityOfOrigin = other.cityOfOrigin;
+    if (l$cityOfOrigin != lOther$cityOfOrigin) {
+      return false;
+    }
+    final l$regionOfOrigin = regionOfOrigin;
+    final lOther$regionOfOrigin = other.regionOfOrigin;
+    if (l$regionOfOrigin != lOther$regionOfOrigin) {
+      return false;
+    }
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    final lOther$countryOfOriginTextId = other.countryOfOriginTextId;
+    if (l$countryOfOriginTextId != lOther$countryOfOriginTextId) {
+      return false;
+    }
+    final l$countryOfOrigin = countryOfOrigin;
+    final lOther$countryOfOrigin = other.countryOfOrigin;
+    if (l$countryOfOrigin != lOther$countryOfOrigin) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById
+    on Query$FindMentorUserDetailedProfile$findUserById {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById<
+          Query$FindMentorUserDetailedProfile$findUserById>
+      get copyWith => CopyWith$Query$FindMentorUserDetailedProfile$findUserById(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById(
+    Query$FindMentorUserDetailedProfile$findUserById instance,
+    TRes Function(Query$FindMentorUserDetailedProfile$findUserById) then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById;
+
+  TRes call({
+    String? id,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    bool? offersHelp,
+    bool? seeksHelp,
+    List<Query$FindMentorUserDetailedProfile$findUserById$websites>? websites,
+    List<Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>?
+        spokenLanguages,
+    String? avatarUrl,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>?
+        groupMemberships,
+    String? pronounsDisplay,
+    List<Query$FindMentorUserDetailedProfile$findUserById$pronouns>? pronouns,
+    List<Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>?
+        businessExperiences,
+    List<Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>?
+        academicExperiences,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    String? countryOfResidenceTextId,
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence?
+        countryOfResidence,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin?
+        countryOfOrigin,
+    String? jobTitle,
+    List<Query$FindMentorUserDetailedProfile$findUserById$companies>? companies,
+    String? $__typename,
+  });
+  TRes websites(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$websites>? Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+                      Query$FindMentorUserDetailedProfile$findUserById$websites>>?)
+          _fn);
+  TRes spokenLanguages(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+                      Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>>)
+          _fn);
+  TRes groupMemberships(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+                      Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>>)
+          _fn);
+  TRes pronouns(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$pronouns> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+                      Query$FindMentorUserDetailedProfile$findUserById$pronouns>>)
+          _fn);
+  TRes businessExperiences(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>? Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+                      Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>>?)
+          _fn);
+  TRes academicExperiences(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>? Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+                      Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>>?)
+          _fn);
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+      TRes> get countryOfResidence;
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+      TRes> get countryOfOrigin;
+  TRes companies(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$companies> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+                      Query$FindMentorUserDetailedProfile$findUserById$companies>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById<TRes>
+    implements CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById _instance;
+
+  final TRes Function(Query$FindMentorUserDetailedProfile$findUserById) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? offersHelp = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? websites = _undefined,
+    Object? spokenLanguages = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? pronounsDisplay = _undefined,
+    Object? pronouns = _undefined,
+    Object? businessExperiences = _undefined,
+    Object? academicExperiences = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
+    Object? countryOfResidenceTextId = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? cityOfOrigin = _undefined,
+    Object? regionOfOrigin = _undefined,
+    Object? countryOfOriginTextId = _undefined,
+    Object? countryOfOrigin = _undefined,
+    Object? jobTitle = _undefined,
+    Object? companies = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        offersHelp: offersHelp == _undefined || offersHelp == null
+            ? _instance.offersHelp
+            : (offersHelp as bool),
+        seeksHelp: seeksHelp == _undefined || seeksHelp == null
+            ? _instance.seeksHelp
+            : (seeksHelp as bool),
+        websites: websites == _undefined
+            ? _instance.websites
+            : (websites as List<
+                Query$FindMentorUserDetailedProfile$findUserById$websites>?),
+        spokenLanguages: spokenLanguages == _undefined ||
+                spokenLanguages == null
+            ? _instance.spokenLanguages
+            : (spokenLanguages as List<
+                Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        groupMemberships: groupMemberships == _undefined ||
+                groupMemberships == null
+            ? _instance.groupMemberships
+            : (groupMemberships as List<
+                Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>),
+        pronounsDisplay:
+            pronounsDisplay == _undefined || pronounsDisplay == null
+                ? _instance.pronounsDisplay
+                : (pronounsDisplay as String),
+        pronouns: pronouns == _undefined || pronouns == null
+            ? _instance.pronouns
+            : (pronouns as List<
+                Query$FindMentorUserDetailedProfile$findUserById$pronouns>),
+        businessExperiences: businessExperiences == _undefined
+            ? _instance.businessExperiences
+            : (businessExperiences as List<
+                Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>?),
+        academicExperiences: academicExperiences == _undefined
+            ? _instance.academicExperiences
+            : (academicExperiences as List<
+                Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
+        countryOfResidenceTextId: countryOfResidenceTextId == _undefined
+            ? _instance.countryOfResidenceTextId
+            : (countryOfResidenceTextId as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence?),
+        cityOfOrigin: cityOfOrigin == _undefined
+            ? _instance.cityOfOrigin
+            : (cityOfOrigin as String?),
+        regionOfOrigin: regionOfOrigin == _undefined
+            ? _instance.regionOfOrigin
+            : (regionOfOrigin as String?),
+        countryOfOriginTextId: countryOfOriginTextId == _undefined
+            ? _instance.countryOfOriginTextId
+            : (countryOfOriginTextId as String?),
+        countryOfOrigin: countryOfOrigin == _undefined
+            ? _instance.countryOfOrigin
+            : (countryOfOrigin
+                as Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin?),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<
+                Query$FindMentorUserDetailedProfile$findUserById$companies>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes websites(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$websites>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+                          Query$FindMentorUserDetailedProfile$findUserById$websites>>?)
+              _fn) =>
+      call(
+          websites: _fn(_instance.websites?.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites(
+                e,
+                (i) => i,
+              )))?.toList());
+  TRes spokenLanguages(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+                          Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>>)
+              _fn) =>
+      call(
+          spokenLanguages: _fn(_instance.spokenLanguages.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes groupMemberships(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+                          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes pronouns(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$pronouns> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+                          Query$FindMentorUserDetailedProfile$findUserById$pronouns>>)
+              _fn) =>
+      call(
+          pronouns: _fn(_instance.pronouns.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes businessExperiences(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+                          Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>>?)
+              _fn) =>
+      call(
+          businessExperiences: _fn(_instance.businessExperiences?.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+                e,
+                (i) => i,
+              )))?.toList());
+  TRes academicExperiences(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+                          Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>>?)
+              _fn) =>
+      call(
+          academicExperiences: _fn(_instance.academicExperiences?.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+                e,
+                (i) => i,
+              )))?.toList());
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+      TRes> get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+      TRes> get countryOfOrigin {
+    final local$countryOfOrigin = _instance.countryOfOrigin;
+    return local$countryOfOrigin == null
+        ? CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+            local$countryOfOrigin, (e) => call(countryOfOrigin: e));
+  }
+
+  TRes companies(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$companies> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+                          Query$FindMentorUserDetailedProfile$findUserById$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById<TRes>
+    implements CopyWith$Query$FindMentorUserDetailedProfile$findUserById<TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    bool? offersHelp,
+    bool? seeksHelp,
+    List<Query$FindMentorUserDetailedProfile$findUserById$websites>? websites,
+    List<Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>?
+        spokenLanguages,
+    String? avatarUrl,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>?
+        groupMemberships,
+    String? pronounsDisplay,
+    List<Query$FindMentorUserDetailedProfile$findUserById$pronouns>? pronouns,
+    List<Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>?
+        businessExperiences,
+    List<Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>?
+        academicExperiences,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    String? countryOfResidenceTextId,
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence?
+        countryOfResidence,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin?
+        countryOfOrigin,
+    String? jobTitle,
+    List<Query$FindMentorUserDetailedProfile$findUserById$companies>? companies,
+    String? $__typename,
+  }) =>
+      _res;
+  websites(_fn) => _res;
+  spokenLanguages(_fn) => _res;
+  groupMemberships(_fn) => _res;
+  pronouns(_fn) => _res;
+  businessExperiences(_fn) => _res;
+  academicExperiences(_fn) => _res;
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+          TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+              .stub(_res);
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+          TRes>
+      get countryOfOrigin =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin
+              .stub(_res);
+  companies(_fn) => _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$websites {
+  Query$FindMentorUserDetailedProfile$findUserById$websites({
+    required this.value,
+    this.label,
+    this.$__typename = 'LabeledStringValue',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$websites.fromJson(
+      Map<String, dynamic> json) {
+    final l$value = json['value'];
+    final l$label = json['label'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$websites(
+      value: (l$value as String),
+      label: (l$label as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String value;
+
+  final String? label;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$value = value;
+    _resultData['value'] = l$value;
+    final l$label = label;
+    _resultData['label'] = l$label;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$value = value;
+    final l$label = label;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$value,
+      l$label,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUserDetailedProfile$findUserById$websites) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$value = value;
+    final lOther$value = other.value;
+    if (l$value != lOther$value) {
+      return false;
+    }
+    final l$label = label;
+    final lOther$label = other.label;
+    if (l$label != lOther$label) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$websites
+    on Query$FindMentorUserDetailedProfile$findUserById$websites {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+          Query$FindMentorUserDetailedProfile$findUserById$websites>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites(
+    Query$FindMentorUserDetailedProfile$findUserById$websites instance,
+    TRes Function(Query$FindMentorUserDetailedProfile$findUserById$websites)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$websites;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$websites;
+
+  TRes call({
+    String? value,
+    String? label,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$websites(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$websites _instance;
+
+  final TRes Function(Query$FindMentorUserDetailedProfile$findUserById$websites)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? value = _undefined,
+    Object? label = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$websites(
+        value: value == _undefined || value == null
+            ? _instance.value
+            : (value as String),
+        label: label == _undefined ? _instance.label : (label as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$websites<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$websites(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? value,
+    String? label,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages {
+  Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages({
+    this.translatedValue,
+    this.$__typename = 'Language',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages
+    on Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+          Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+    Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages
+      _instance;
+
+  final TRes Function(
+      Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$spokenLanguages(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships({
+    required this.groupId,
+    required this.groupIdent,
+    required this.$__typename,
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MentorsGroupMembership":
+        return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      case "MenteesGroupMembership":
+        return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupId = json['groupId'];
+        final l$groupIdent = json['groupIdent'];
+        final l$$__typename = json['__typename'];
+        return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+          groupId: (l$groupId as String),
+          groupIdent: (l$groupIdent as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership);
+
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)?
+        groupMembership,
+    _T Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships
+      _instance;
+
+  final TRes Function(
+      Query$FindMentorUserDetailedProfile$findUserById$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+    implements
+        Query$FindMentorUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership({
+    this.expertisesTextIds,
+    this.industriesTextIds,
+    required this.expertises,
+    required this.industries,
+    this.endorsements,
+    this.expectationsForMentees,
+    this.$__typename = 'MentorsGroupMembership',
+    required this.groupId,
+    required this.groupIdent,
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$expertisesTextIds = json['expertisesTextIds'];
+    final l$industriesTextIds = json['industriesTextIds'];
+    final l$expertises = json['expertises'];
+    final l$industries = json['industries'];
+    final l$endorsements = json['endorsements'];
+    final l$expectationsForMentees = json['expectationsForMentees'];
+    final l$$__typename = json['__typename'];
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+      expertisesTextIds: (l$expertisesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      industriesTextIds: (l$industriesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      expertises: (l$expertises as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industries: (l$industries as List<dynamic>)
+          .map((e) =>
+              Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      endorsements: (l$endorsements as int?),
+      expectationsForMentees: (l$expectationsForMentees as String?),
+      $__typename: (l$$__typename as String),
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<String>? expertisesTextIds;
+
+  final List<String>? industriesTextIds;
+
+  final List<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>
+      expertises;
+
+  final List<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>
+      industries;
+
+  final int? endorsements;
+
+  final String? expectationsForMentees;
+
+  final String $__typename;
+
+  final String groupId;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$expertisesTextIds = expertisesTextIds;
+    _resultData['expertisesTextIds'] =
+        l$expertisesTextIds?.map((e) => e).toList();
+    final l$industriesTextIds = industriesTextIds;
+    _resultData['industriesTextIds'] =
+        l$industriesTextIds?.map((e) => e).toList();
+    final l$expertises = expertises;
+    _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
+    final l$industries = industries;
+    _resultData['industries'] = l$industries.map((e) => e.toJson()).toList();
+    final l$endorsements = endorsements;
+    _resultData['endorsements'] = l$endorsements;
+    final l$expectationsForMentees = expectationsForMentees;
+    _resultData['expectationsForMentees'] = l$expectationsForMentees;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$expertisesTextIds = expertisesTextIds;
+    final l$industriesTextIds = industriesTextIds;
+    final l$expertises = expertises;
+    final l$industries = industries;
+    final l$endorsements = endorsements;
+    final l$expectationsForMentees = expectationsForMentees;
+    final l$$__typename = $__typename;
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      l$expertisesTextIds == null
+          ? null
+          : Object.hashAll(l$expertisesTextIds.map((v) => v)),
+      l$industriesTextIds == null
+          ? null
+          : Object.hashAll(l$industriesTextIds.map((v) => v)),
+      Object.hashAll(l$expertises.map((v) => v)),
+      Object.hashAll(l$industries.map((v) => v)),
+      l$endorsements,
+      l$expectationsForMentees,
+      l$$__typename,
+      l$groupId,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$expertisesTextIds = expertisesTextIds;
+    final lOther$expertisesTextIds = other.expertisesTextIds;
+    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
+      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$expertisesTextIds.length; i++) {
+        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
+        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
+        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
+      return false;
+    }
+    final l$industriesTextIds = industriesTextIds;
+    final lOther$industriesTextIds = other.industriesTextIds;
+    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
+      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$industriesTextIds.length; i++) {
+        final l$industriesTextIds$entry = l$industriesTextIds[i];
+        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
+        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$industriesTextIds != lOther$industriesTextIds) {
+      return false;
+    }
+    final l$expertises = expertises;
+    final lOther$expertises = other.expertises;
+    if (l$expertises.length != lOther$expertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$expertises.length; i++) {
+      final l$expertises$entry = l$expertises[i];
+      final lOther$expertises$entry = lOther$expertises[i];
+      if (l$expertises$entry != lOther$expertises$entry) {
+        return false;
+      }
+    }
+    final l$industries = industries;
+    final lOther$industries = other.industries;
+    if (l$industries.length != lOther$industries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$industries.length; i++) {
+      final l$industries$entry = l$industries[i];
+      final lOther$industries$entry = lOther$industries[i];
+      if (l$industries$entry != lOther$industries$entry) {
+        return false;
+      }
+    }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
+    final l$expectationsForMentees = expectationsForMentees;
+    final lOther$expectationsForMentees = other.expectationsForMentees;
+    if (l$expectationsForMentees != lOther$expectationsForMentees) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? expectationsForMentees,
+    String? $__typename,
+    String? groupId,
+    String? groupIdent,
+  });
+  TRes expertises(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+                      Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>>)
+          _fn);
+  TRes industries(
+      Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries> Function(
+              Iterable<
+                  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+                      Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? expertisesTextIds = _undefined,
+    Object? industriesTextIds = _undefined,
+    Object? expertises = _undefined,
+    Object? industries = _undefined,
+    Object? endorsements = _undefined,
+    Object? expectationsForMentees = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+        expertisesTextIds: expertisesTextIds == _undefined
+            ? _instance.expertisesTextIds
+            : (expertisesTextIds as List<String>?),
+        industriesTextIds: industriesTextIds == _undefined
+            ? _instance.industriesTextIds
+            : (industriesTextIds as List<String>?),
+        expertises: expertises == _undefined || expertises == null
+            ? _instance.expertises
+            : (expertises as List<
+                Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>),
+        industries: industries == _undefined || industries == null
+            ? _instance.industries
+            : (industries as List<
+                Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>),
+        endorsements: endorsements == _undefined
+            ? _instance.endorsements
+            : (endorsements as int?),
+        expectationsForMentees: expectationsForMentees == _undefined
+            ? _instance.expectationsForMentees
+            : (expectationsForMentees as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes expertises(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+                          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>>)
+              _fn) =>
+      call(
+          expertises: _fn(_instance.expertises.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes industries(
+          Iterable<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries> Function(
+                  Iterable<
+                      CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+                          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>>)
+              _fn) =>
+      call(
+          industries: _fn(_instance.industries.map((e) =>
+              CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? expectationsForMentees,
+    String? $__typename,
+    String? groupId,
+    String? groupIdent,
+  }) =>
+      _res;
+  expertises(_fn) => _res;
+  industries(_fn) => _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$expertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership$industries(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+    implements
+        Query$FindMentorUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership({
+    required this.groupId,
+    required this.groupIdent,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+    implements
+        Query$FindMentorUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership({
+    required this.groupId,
+    required this.groupIdent,
+    this.$__typename = 'MenteesGroupMembership',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+    on Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+    Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$pronouns {
+  Query$FindMentorUserDetailedProfile$findUserById$pronouns({
+    this.translatedValue,
+    this.$__typename = 'Pronoun',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$pronouns.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMentorUserDetailedProfile$findUserById$pronouns) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$pronouns
+    on Query$FindMentorUserDetailedProfile$findUserById$pronouns {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+          Query$FindMentorUserDetailedProfile$findUserById$pronouns>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+    Query$FindMentorUserDetailedProfile$findUserById$pronouns instance,
+    TRes Function(Query$FindMentorUserDetailedProfile$findUserById$pronouns)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$pronouns _instance;
+
+  final TRes Function(Query$FindMentorUserDetailedProfile$findUserById$pronouns)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$pronouns<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$pronouns(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$businessExperiences {
+  Query$FindMentorUserDetailedProfile$findUserById$businessExperiences({
+    required this.businessName,
+    required this.jobTitle,
+    required this.startDate,
+    this.endDate,
+    this.city,
+    this.state,
+    this.country,
+    this.$__typename = 'BusinessExperience',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$businessExperiences.fromJson(
+      Map<String, dynamic> json) {
+    final l$businessName = json['businessName'];
+    final l$jobTitle = json['jobTitle'];
+    final l$startDate = json['startDate'];
+    final l$endDate = json['endDate'];
+    final l$city = json['city'];
+    final l$state = json['state'];
+    final l$country = json['country'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+      businessName: (l$businessName as String),
+      jobTitle: (l$jobTitle as String),
+      startDate: DateTime.parse((l$startDate as String)),
+      endDate: l$endDate == null ? null : DateTime.parse((l$endDate as String)),
+      city: (l$city as String?),
+      state: (l$state as String?),
+      country: (l$country as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String businessName;
+
+  final String jobTitle;
+
+  final DateTime startDate;
+
+  final DateTime? endDate;
+
+  final String? city;
+
+  final String? state;
+
+  final String? country;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$businessName = businessName;
+    _resultData['businessName'] = l$businessName;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$startDate = startDate;
+    _resultData['startDate'] = l$startDate.toIso8601String();
+    final l$endDate = endDate;
+    _resultData['endDate'] = l$endDate?.toIso8601String();
+    final l$city = city;
+    _resultData['city'] = l$city;
+    final l$state = state;
+    _resultData['state'] = l$state;
+    final l$country = country;
+    _resultData['country'] = l$country;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$businessName = businessName;
+    final l$jobTitle = jobTitle;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$city = city;
+    final l$state = state;
+    final l$country = country;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$businessName,
+      l$jobTitle,
+      l$startDate,
+      l$endDate,
+      l$city,
+      l$state,
+      l$country,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$businessExperiences) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$businessName = businessName;
+    final lOther$businessName = other.businessName;
+    if (l$businessName != lOther$businessName) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$city = city;
+    final lOther$city = other.city;
+    if (l$city != lOther$city) {
+      return false;
+    }
+    final l$state = state;
+    final lOther$state = other.state;
+    if (l$state != lOther$state) {
+      return false;
+    }
+    final l$country = country;
+    final lOther$country = other.country;
+    if (l$country != lOther$country) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences
+    on Query$FindMentorUserDetailedProfile$findUserById$businessExperiences {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+          Query$FindMentorUserDetailedProfile$findUserById$businessExperiences>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+    Query$FindMentorUserDetailedProfile$findUserById$businessExperiences
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$businessExperiences)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences;
+
+  TRes call({
+    String? businessName,
+    String? jobTitle,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? city,
+    String? state,
+    String? country,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$businessExperiences
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$businessExperiences)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? businessName = _undefined,
+    Object? jobTitle = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? city = _undefined,
+    Object? state = _undefined,
+    Object? country = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+        businessName: businessName == _undefined || businessName == null
+            ? _instance.businessName
+            : (businessName as String),
+        jobTitle: jobTitle == _undefined || jobTitle == null
+            ? _instance.jobTitle
+            : (jobTitle as String),
+        startDate: startDate == _undefined || startDate == null
+            ? _instance.startDate
+            : (startDate as DateTime),
+        endDate:
+            endDate == _undefined ? _instance.endDate : (endDate as DateTime?),
+        city: city == _undefined ? _instance.city : (city as String?),
+        state: state == _undefined ? _instance.state : (state as String?),
+        country:
+            country == _undefined ? _instance.country : (country as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$businessExperiences(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? businessName,
+    String? jobTitle,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? city,
+    String? state,
+    String? country,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$academicExperiences {
+  Query$FindMentorUserDetailedProfile$findUserById$academicExperiences({
+    required this.institutionName,
+    this.degreeType,
+    this.fieldOfStudy,
+    required this.startDate,
+    this.endDate,
+    this.$__typename = 'AcademicExperience',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$academicExperiences.fromJson(
+      Map<String, dynamic> json) {
+    final l$institutionName = json['institutionName'];
+    final l$degreeType = json['degreeType'];
+    final l$fieldOfStudy = json['fieldOfStudy'];
+    final l$startDate = json['startDate'];
+    final l$endDate = json['endDate'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+      institutionName: (l$institutionName as String),
+      degreeType: (l$degreeType as String?),
+      fieldOfStudy: (l$fieldOfStudy as String?),
+      startDate: DateTime.parse((l$startDate as String)),
+      endDate: l$endDate == null ? null : DateTime.parse((l$endDate as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String institutionName;
+
+  final String? degreeType;
+
+  final String? fieldOfStudy;
+
+  final DateTime startDate;
+
+  final DateTime? endDate;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$institutionName = institutionName;
+    _resultData['institutionName'] = l$institutionName;
+    final l$degreeType = degreeType;
+    _resultData['degreeType'] = l$degreeType;
+    final l$fieldOfStudy = fieldOfStudy;
+    _resultData['fieldOfStudy'] = l$fieldOfStudy;
+    final l$startDate = startDate;
+    _resultData['startDate'] = l$startDate.toIso8601String();
+    final l$endDate = endDate;
+    _resultData['endDate'] = l$endDate?.toIso8601String();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$institutionName = institutionName;
+    final l$degreeType = degreeType;
+    final l$fieldOfStudy = fieldOfStudy;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$institutionName,
+      l$degreeType,
+      l$fieldOfStudy,
+      l$startDate,
+      l$endDate,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$academicExperiences) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$institutionName = institutionName;
+    final lOther$institutionName = other.institutionName;
+    if (l$institutionName != lOther$institutionName) {
+      return false;
+    }
+    final l$degreeType = degreeType;
+    final lOther$degreeType = other.degreeType;
+    if (l$degreeType != lOther$degreeType) {
+      return false;
+    }
+    final l$fieldOfStudy = fieldOfStudy;
+    final lOther$fieldOfStudy = other.fieldOfStudy;
+    if (l$fieldOfStudy != lOther$fieldOfStudy) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences
+    on Query$FindMentorUserDetailedProfile$findUserById$academicExperiences {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+          Query$FindMentorUserDetailedProfile$findUserById$academicExperiences>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+    Query$FindMentorUserDetailedProfile$findUserById$academicExperiences
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$academicExperiences)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences;
+
+  TRes call({
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$academicExperiences
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$academicExperiences)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? institutionName = _undefined,
+    Object? degreeType = _undefined,
+    Object? fieldOfStudy = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+        institutionName:
+            institutionName == _undefined || institutionName == null
+                ? _instance.institutionName
+                : (institutionName as String),
+        degreeType: degreeType == _undefined
+            ? _instance.degreeType
+            : (degreeType as String?),
+        fieldOfStudy: fieldOfStudy == _undefined
+            ? _instance.fieldOfStudy
+            : (fieldOfStudy as String?),
+        startDate: startDate == _undefined || startDate == null
+            ? _instance.startDate
+            : (startDate as DateTime),
+        endDate:
+            endDate == _undefined ? _instance.endDate : (endDate as DateTime?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$academicExperiences(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence {
+  Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+    on Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+          Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+        instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence
+      _instance;
+
+  final TRes Function(
+          Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin {
+  Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin
+    on Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+          Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+    Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin instance,
+    TRes Function(
+            Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin
+      _instance;
+
+  final TRes Function(
+      Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$countryOfOrigin(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMentorUserDetailedProfile$findUserById$companies {
+  Query$FindMentorUserDetailedProfile$findUserById$companies({
+    required this.name,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$FindMentorUserDetailedProfile$findUserById$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMentorUserDetailedProfile$findUserById$companies(
+      name: (l$name as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String name;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMentorUserDetailedProfile$findUserById$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMentorUserDetailedProfile$findUserById$companies
+    on Query$FindMentorUserDetailedProfile$findUserById$companies {
+  CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+          Query$FindMentorUserDetailedProfile$findUserById$companies>
+      get copyWith =>
+          CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+    TRes> {
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies(
+    Query$FindMentorUserDetailedProfile$findUserById$companies instance,
+    TRes Function(Query$FindMentorUserDetailedProfile$findUserById$companies)
+        then,
+  ) = _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$companies;
+
+  factory CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$companies;
+
+  TRes call({
+    String? name,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+            TRes> {
+  _CopyWithImpl$Query$FindMentorUserDetailedProfile$findUserById$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMentorUserDetailedProfile$findUserById$companies _instance;
+
+  final TRes Function(
+      Query$FindMentorUserDetailedProfile$findUserById$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMentorUserDetailedProfile$findUserById$companies(
+        name: name == _undefined || name == null
+            ? _instance.name
+            : (name as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindMentorUserDetailedProfile$findUserById$companies<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMentorUserDetailedProfile$findUserById$companies(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindMenteeUserDetailedProfile {
+  factory Variables$Query$FindMenteeUserDetailedProfile({required String id}) =>
+      Variables$Query$FindMenteeUserDetailedProfile._({
+        r'id': id,
+      });
+
+  Variables$Query$FindMenteeUserDetailedProfile._(this._$data);
+
+  factory Variables$Query$FindMenteeUserDetailedProfile.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$id = data['id'];
+    result$data['id'] = (l$id as String);
+    return Variables$Query$FindMenteeUserDetailedProfile._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String get id => (_$data['id'] as String);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$id = id;
+    result$data['id'] = l$id;
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindMenteeUserDetailedProfile<
+          Variables$Query$FindMenteeUserDetailedProfile>
+      get copyWith => CopyWith$Variables$Query$FindMenteeUserDetailedProfile(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindMenteeUserDetailedProfile) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    return Object.hashAll([l$id]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindMenteeUserDetailedProfile<TRes> {
+  factory CopyWith$Variables$Query$FindMenteeUserDetailedProfile(
+    Variables$Query$FindMenteeUserDetailedProfile instance,
+    TRes Function(Variables$Query$FindMenteeUserDetailedProfile) then,
+  ) = _CopyWithImpl$Variables$Query$FindMenteeUserDetailedProfile;
+
+  factory CopyWith$Variables$Query$FindMenteeUserDetailedProfile.stub(
+          TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindMenteeUserDetailedProfile;
+
+  TRes call({String? id});
+}
+
+class _CopyWithImpl$Variables$Query$FindMenteeUserDetailedProfile<TRes>
+    implements CopyWith$Variables$Query$FindMenteeUserDetailedProfile<TRes> {
+  _CopyWithImpl$Variables$Query$FindMenteeUserDetailedProfile(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindMenteeUserDetailedProfile _instance;
+
+  final TRes Function(Variables$Query$FindMenteeUserDetailedProfile) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? id = _undefined}) =>
+      _then(Variables$Query$FindMenteeUserDetailedProfile._({
+        ..._instance._$data,
+        if (id != _undefined && id != null) 'id': (id as String),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindMenteeUserDetailedProfile<TRes>
+    implements CopyWith$Variables$Query$FindMenteeUserDetailedProfile<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindMenteeUserDetailedProfile(this._res);
+
+  TRes _res;
+
+  call({String? id}) => _res;
+}
+
+class Query$FindMenteeUserDetailedProfile {
+  Query$FindMenteeUserDetailedProfile({
+    required this.findUserById,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile.fromJson(
+      Map<String, dynamic> json) {
+    final l$findUserById = json['findUserById'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile(
+      findUserById: Query$FindMenteeUserDetailedProfile$findUserById.fromJson(
+          (l$findUserById as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindMenteeUserDetailedProfile$findUserById findUserById;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUserById = findUserById;
+    _resultData['findUserById'] = l$findUserById.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUserById = findUserById;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$findUserById,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUserDetailedProfile) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUserById = findUserById;
+    final lOther$findUserById = other.findUserById;
+    if (l$findUserById != lOther$findUserById) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile
+    on Query$FindMenteeUserDetailedProfile {
+  CopyWith$Query$FindMenteeUserDetailedProfile<
+          Query$FindMenteeUserDetailedProfile>
+      get copyWith => CopyWith$Query$FindMenteeUserDetailedProfile(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile<TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile(
+    Query$FindMenteeUserDetailedProfile instance,
+    TRes Function(Query$FindMenteeUserDetailedProfile) then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile;
+
+  TRes call({
+    Query$FindMenteeUserDetailedProfile$findUserById? findUserById,
+    String? $__typename,
+  });
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes>
+      get findUserById;
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile<TRes>
+    implements CopyWith$Query$FindMenteeUserDetailedProfile<TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile _instance;
+
+  final TRes Function(Query$FindMenteeUserDetailedProfile) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUserById = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile(
+        findUserById: findUserById == _undefined || findUserById == null
+            ? _instance.findUserById
+            : (findUserById
+                as Query$FindMenteeUserDetailedProfile$findUserById),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes>
+      get findUserById {
+    final local$findUserById = _instance.findUserById;
+    return CopyWith$Query$FindMenteeUserDetailedProfile$findUserById(
+        local$findUserById, (e) => call(findUserById: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile<TRes>
+    implements CopyWith$Query$FindMenteeUserDetailedProfile<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindMenteeUserDetailedProfile$findUserById? findUserById,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes>
+      get findUserById =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById.stub(_res);
+}
+
+const documentNodeQueryFindMenteeUserDetailedProfile =
+    DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindMenteeUserDetailedProfile'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'id')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUserById'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'id'),
+            value: VariableNode(name: NameNode(value: 'id')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'email'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userHandle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'offersHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'seeksHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'websites'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'value'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'label'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'spokenLanguages'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'groupMemberships'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'groupId'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'groupIdent'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MenteesGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'soughtExpertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'industry'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'reasonsForStartingBusiness'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'companies'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'name'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'description'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'websites'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'value'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'label'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'companyStage'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'translatedValue'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'companyType'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'translatedValue'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'pronounsDisplay'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'pronouns'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'businessExperiences'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'businessName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'jobTitle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'startDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'endDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'city'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'state'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'country'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'academicExperiences'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'institutionName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'degreeType'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'fieldOfStudy'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'startDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'endDate'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidenceTextId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfOriginTextId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfOrigin'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindMenteeUserDetailedProfile$findUserById {
+  Query$FindMenteeUserDetailedProfile$findUserById({
+    required this.id,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.email,
+    this.userHandle,
+    required this.offersHelp,
+    required this.seeksHelp,
+    this.websites,
+    required this.spokenLanguages,
+    this.avatarUrl,
+    required this.groupMemberships,
+    this.jobTitle,
+    required this.companies,
+    required this.pronounsDisplay,
+    required this.pronouns,
+    this.businessExperiences,
+    this.academicExperiences,
+    this.cityOfResidence,
+    this.regionOfResidence,
+    this.countryOfResidenceTextId,
+    this.countryOfResidence,
+    this.cityOfOrigin,
+    this.regionOfOrigin,
+    this.countryOfOriginTextId,
+    this.countryOfOrigin,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$email = json['email'];
+    final l$userHandle = json['userHandle'];
+    final l$offersHelp = json['offersHelp'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$websites = json['websites'];
+    final l$spokenLanguages = json['spokenLanguages'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$jobTitle = json['jobTitle'];
+    final l$companies = json['companies'];
+    final l$pronounsDisplay = json['pronounsDisplay'];
+    final l$pronouns = json['pronouns'];
+    final l$businessExperiences = json['businessExperiences'];
+    final l$academicExperiences = json['academicExperiences'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
+    final l$countryOfResidenceTextId = json['countryOfResidenceTextId'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$cityOfOrigin = json['cityOfOrigin'];
+    final l$regionOfOrigin = json['regionOfOrigin'];
+    final l$countryOfOriginTextId = json['countryOfOriginTextId'];
+    final l$countryOfOrigin = json['countryOfOrigin'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById(
+      id: (l$id as String),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      email: (l$email as String?),
+      userHandle: (l$userHandle as String?),
+      offersHelp: (l$offersHelp as bool),
+      seeksHelp: (l$seeksHelp as bool),
+      websites: (l$websites as List<dynamic>?)
+          ?.map((e) => Query$FindMenteeUserDetailedProfile$findUserById$websites
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      spokenLanguages: (l$spokenLanguages as List<dynamic>)
+          .map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      avatarUrl: (l$avatarUrl as String?),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      jobTitle: (l$jobTitle as String?),
+      companies: (l$companies as List<dynamic>)
+          .map((e) => Query$FindMenteeUserDetailedProfile$findUserById$companies
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      pronounsDisplay: (l$pronounsDisplay as String),
+      pronouns: (l$pronouns as List<dynamic>)
+          .map((e) => Query$FindMenteeUserDetailedProfile$findUserById$pronouns
+              .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      businessExperiences: (l$businessExperiences as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      academicExperiences: (l$academicExperiences as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
+      countryOfResidenceTextId: (l$countryOfResidenceTextId as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+              .fromJson((l$countryOfResidence as Map<String, dynamic>)),
+      cityOfOrigin: (l$cityOfOrigin as String?),
+      regionOfOrigin: (l$regionOfOrigin as String?),
+      countryOfOriginTextId: (l$countryOfOriginTextId as String?),
+      countryOfOrigin: l$countryOfOrigin == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin
+              .fromJson((l$countryOfOrigin as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? email;
+
+  final String? userHandle;
+
+  final bool offersHelp;
+
+  final bool seeksHelp;
+
+  final List<Query$FindMenteeUserDetailedProfile$findUserById$websites>?
+      websites;
+
+  final List<Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>
+      spokenLanguages;
+
+  final String? avatarUrl;
+
+  final List<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>
+      groupMemberships;
+
+  final String? jobTitle;
+
+  final List<Query$FindMenteeUserDetailedProfile$findUserById$companies>
+      companies;
+
+  final String pronounsDisplay;
+
+  final List<Query$FindMenteeUserDetailedProfile$findUserById$pronouns>
+      pronouns;
+
+  final List<
+          Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>?
+      businessExperiences;
+
+  final List<
+          Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>?
+      academicExperiences;
+
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
+  final String? countryOfResidenceTextId;
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence?
+      countryOfResidence;
+
+  final String? cityOfOrigin;
+
+  final String? regionOfOrigin;
+
+  final String? countryOfOriginTextId;
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin?
+      countryOfOrigin;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp;
+    final l$websites = websites;
+    _resultData['websites'] = l$websites?.map((e) => e.toJson()).toList();
+    final l$spokenLanguages = spokenLanguages;
+    _resultData['spokenLanguages'] =
+        l$spokenLanguages.map((e) => e.toJson()).toList();
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$pronounsDisplay = pronounsDisplay;
+    _resultData['pronounsDisplay'] = l$pronounsDisplay;
+    final l$pronouns = pronouns;
+    _resultData['pronouns'] = l$pronouns.map((e) => e.toJson()).toList();
+    final l$businessExperiences = businessExperiences;
+    _resultData['businessExperiences'] =
+        l$businessExperiences?.map((e) => e.toJson()).toList();
+    final l$academicExperiences = academicExperiences;
+    _resultData['academicExperiences'] =
+        l$academicExperiences?.map((e) => e.toJson()).toList();
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    _resultData['countryOfResidenceTextId'] = l$countryOfResidenceTextId;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$cityOfOrigin = cityOfOrigin;
+    _resultData['cityOfOrigin'] = l$cityOfOrigin;
+    final l$regionOfOrigin = regionOfOrigin;
+    _resultData['regionOfOrigin'] = l$regionOfOrigin;
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    _resultData['countryOfOriginTextId'] = l$countryOfOriginTextId;
+    final l$countryOfOrigin = countryOfOrigin;
+    _resultData['countryOfOrigin'] = l$countryOfOrigin?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$email = email;
+    final l$userHandle = userHandle;
+    final l$offersHelp = offersHelp;
+    final l$seeksHelp = seeksHelp;
+    final l$websites = websites;
+    final l$spokenLanguages = spokenLanguages;
+    final l$avatarUrl = avatarUrl;
+    final l$groupMemberships = groupMemberships;
+    final l$jobTitle = jobTitle;
+    final l$companies = companies;
+    final l$pronounsDisplay = pronounsDisplay;
+    final l$pronouns = pronouns;
+    final l$businessExperiences = businessExperiences;
+    final l$academicExperiences = academicExperiences;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    final l$countryOfResidence = countryOfResidence;
+    final l$cityOfOrigin = cityOfOrigin;
+    final l$regionOfOrigin = regionOfOrigin;
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    final l$countryOfOrigin = countryOfOrigin;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$email,
+      l$userHandle,
+      l$offersHelp,
+      l$seeksHelp,
+      l$websites == null ? null : Object.hashAll(l$websites.map((v) => v)),
+      Object.hashAll(l$spokenLanguages.map((v) => v)),
+      l$avatarUrl,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      l$jobTitle,
+      Object.hashAll(l$companies.map((v) => v)),
+      l$pronounsDisplay,
+      Object.hashAll(l$pronouns.map((v) => v)),
+      l$businessExperiences == null
+          ? null
+          : Object.hashAll(l$businessExperiences.map((v) => v)),
+      l$academicExperiences == null
+          ? null
+          : Object.hashAll(l$academicExperiences.map((v) => v)),
+      l$cityOfResidence,
+      l$regionOfResidence,
+      l$countryOfResidenceTextId,
+      l$countryOfResidence,
+      l$cityOfOrigin,
+      l$regionOfOrigin,
+      l$countryOfOriginTextId,
+      l$countryOfOrigin,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUserDetailedProfile$findUserById) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$websites = websites;
+    final lOther$websites = other.websites;
+    if (l$websites != null && lOther$websites != null) {
+      if (l$websites.length != lOther$websites.length) {
+        return false;
+      }
+      for (int i = 0; i < l$websites.length; i++) {
+        final l$websites$entry = l$websites[i];
+        final lOther$websites$entry = lOther$websites[i];
+        if (l$websites$entry != lOther$websites$entry) {
+          return false;
+        }
+      }
+    } else if (l$websites != lOther$websites) {
+      return false;
+    }
+    final l$spokenLanguages = spokenLanguages;
+    final lOther$spokenLanguages = other.spokenLanguages;
+    if (l$spokenLanguages.length != lOther$spokenLanguages.length) {
+      return false;
+    }
+    for (int i = 0; i < l$spokenLanguages.length; i++) {
+      final l$spokenLanguages$entry = l$spokenLanguages[i];
+      final lOther$spokenLanguages$entry = lOther$spokenLanguages[i];
+      if (l$spokenLanguages$entry != lOther$spokenLanguages$entry) {
+        return false;
+      }
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$pronounsDisplay = pronounsDisplay;
+    final lOther$pronounsDisplay = other.pronounsDisplay;
+    if (l$pronounsDisplay != lOther$pronounsDisplay) {
+      return false;
+    }
+    final l$pronouns = pronouns;
+    final lOther$pronouns = other.pronouns;
+    if (l$pronouns.length != lOther$pronouns.length) {
+      return false;
+    }
+    for (int i = 0; i < l$pronouns.length; i++) {
+      final l$pronouns$entry = l$pronouns[i];
+      final lOther$pronouns$entry = lOther$pronouns[i];
+      if (l$pronouns$entry != lOther$pronouns$entry) {
+        return false;
+      }
+    }
+    final l$businessExperiences = businessExperiences;
+    final lOther$businessExperiences = other.businessExperiences;
+    if (l$businessExperiences != null && lOther$businessExperiences != null) {
+      if (l$businessExperiences.length != lOther$businessExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$businessExperiences.length; i++) {
+        final l$businessExperiences$entry = l$businessExperiences[i];
+        final lOther$businessExperiences$entry = lOther$businessExperiences[i];
+        if (l$businessExperiences$entry != lOther$businessExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$businessExperiences != lOther$businessExperiences) {
+      return false;
+    }
+    final l$academicExperiences = academicExperiences;
+    final lOther$academicExperiences = other.academicExperiences;
+    if (l$academicExperiences != null && lOther$academicExperiences != null) {
+      if (l$academicExperiences.length != lOther$academicExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$academicExperiences.length; i++) {
+        final l$academicExperiences$entry = l$academicExperiences[i];
+        final lOther$academicExperiences$entry = lOther$academicExperiences[i];
+        if (l$academicExperiences$entry != lOther$academicExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$academicExperiences != lOther$academicExperiences) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
+      return false;
+    }
+    final l$countryOfResidenceTextId = countryOfResidenceTextId;
+    final lOther$countryOfResidenceTextId = other.countryOfResidenceTextId;
+    if (l$countryOfResidenceTextId != lOther$countryOfResidenceTextId) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$cityOfOrigin = cityOfOrigin;
+    final lOther$cityOfOrigin = other.cityOfOrigin;
+    if (l$cityOfOrigin != lOther$cityOfOrigin) {
+      return false;
+    }
+    final l$regionOfOrigin = regionOfOrigin;
+    final lOther$regionOfOrigin = other.regionOfOrigin;
+    if (l$regionOfOrigin != lOther$regionOfOrigin) {
+      return false;
+    }
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    final lOther$countryOfOriginTextId = other.countryOfOriginTextId;
+    if (l$countryOfOriginTextId != lOther$countryOfOriginTextId) {
+      return false;
+    }
+    final l$countryOfOrigin = countryOfOrigin;
+    final lOther$countryOfOrigin = other.countryOfOrigin;
+    if (l$countryOfOrigin != lOther$countryOfOrigin) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById
+    on Query$FindMenteeUserDetailedProfile$findUserById {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<
+          Query$FindMenteeUserDetailedProfile$findUserById>
+      get copyWith => CopyWith$Query$FindMenteeUserDetailedProfile$findUserById(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById(
+    Query$FindMenteeUserDetailedProfile$findUserById instance,
+    TRes Function(Query$FindMenteeUserDetailedProfile$findUserById) then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById;
+
+  TRes call({
+    String? id,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? email,
+    String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$websites>? websites,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>?
+        spokenLanguages,
+    String? avatarUrl,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>?
+        groupMemberships,
+    String? jobTitle,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$companies>? companies,
+    String? pronounsDisplay,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$pronouns>? pronouns,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>?
+        businessExperiences,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>?
+        academicExperiences,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    String? countryOfResidenceTextId,
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence?
+        countryOfResidence,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin?
+        countryOfOrigin,
+    String? $__typename,
+  });
+  TRes websites(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$websites>? Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+                      Query$FindMenteeUserDetailedProfile$findUserById$websites>>?)
+          _fn);
+  TRes spokenLanguages(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+                      Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>>)
+          _fn);
+  TRes groupMemberships(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+                      Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>>)
+          _fn);
+  TRes companies(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$companies> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+                      Query$FindMenteeUserDetailedProfile$findUserById$companies>>)
+          _fn);
+  TRes pronouns(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$pronouns> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+                      Query$FindMenteeUserDetailedProfile$findUserById$pronouns>>)
+          _fn);
+  TRes businessExperiences(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>? Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+                      Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>>?)
+          _fn);
+  TRes academicExperiences(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>? Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+                      Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>>?)
+          _fn);
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+      TRes> get countryOfResidence;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+      TRes> get countryOfOrigin;
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById<TRes>
+    implements CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById _instance;
+
+  final TRes Function(Query$FindMenteeUserDetailedProfile$findUserById) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? email = _undefined,
+    Object? userHandle = _undefined,
+    Object? offersHelp = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? websites = _undefined,
+    Object? spokenLanguages = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? jobTitle = _undefined,
+    Object? companies = _undefined,
+    Object? pronounsDisplay = _undefined,
+    Object? pronouns = _undefined,
+    Object? businessExperiences = _undefined,
+    Object? academicExperiences = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
+    Object? countryOfResidenceTextId = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? cityOfOrigin = _undefined,
+    Object? regionOfOrigin = _undefined,
+    Object? countryOfOriginTextId = _undefined,
+    Object? countryOfOrigin = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        email: email == _undefined ? _instance.email : (email as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        offersHelp: offersHelp == _undefined || offersHelp == null
+            ? _instance.offersHelp
+            : (offersHelp as bool),
+        seeksHelp: seeksHelp == _undefined || seeksHelp == null
+            ? _instance.seeksHelp
+            : (seeksHelp as bool),
+        websites: websites == _undefined
+            ? _instance.websites
+            : (websites as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$websites>?),
+        spokenLanguages: spokenLanguages == _undefined ||
+                spokenLanguages == null
+            ? _instance.spokenLanguages
+            : (spokenLanguages as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        groupMemberships: groupMemberships == _undefined ||
+                groupMemberships == null
+            ? _instance.groupMemberships
+            : (groupMemberships as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$companies>),
+        pronounsDisplay:
+            pronounsDisplay == _undefined || pronounsDisplay == null
+                ? _instance.pronounsDisplay
+                : (pronounsDisplay as String),
+        pronouns: pronouns == _undefined || pronouns == null
+            ? _instance.pronouns
+            : (pronouns as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$pronouns>),
+        businessExperiences: businessExperiences == _undefined
+            ? _instance.businessExperiences
+            : (businessExperiences as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>?),
+        academicExperiences: academicExperiences == _undefined
+            ? _instance.academicExperiences
+            : (academicExperiences as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
+        countryOfResidenceTextId: countryOfResidenceTextId == _undefined
+            ? _instance.countryOfResidenceTextId
+            : (countryOfResidenceTextId as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence?),
+        cityOfOrigin: cityOfOrigin == _undefined
+            ? _instance.cityOfOrigin
+            : (cityOfOrigin as String?),
+        regionOfOrigin: regionOfOrigin == _undefined
+            ? _instance.regionOfOrigin
+            : (regionOfOrigin as String?),
+        countryOfOriginTextId: countryOfOriginTextId == _undefined
+            ? _instance.countryOfOriginTextId
+            : (countryOfOriginTextId as String?),
+        countryOfOrigin: countryOfOrigin == _undefined
+            ? _instance.countryOfOrigin
+            : (countryOfOrigin
+                as Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes websites(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$websites>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+                          Query$FindMenteeUserDetailedProfile$findUserById$websites>>?)
+              _fn) =>
+      call(
+          websites: _fn(_instance.websites?.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites(
+                e,
+                (i) => i,
+              )))?.toList());
+  TRes spokenLanguages(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+                          Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>>)
+              _fn) =>
+      call(
+          spokenLanguages: _fn(_instance.spokenLanguages.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes groupMemberships(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+                          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes companies(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$companies> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+                          Query$FindMenteeUserDetailedProfile$findUserById$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes pronouns(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$pronouns> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+                          Query$FindMenteeUserDetailedProfile$findUserById$pronouns>>)
+              _fn) =>
+      call(
+          pronouns: _fn(_instance.pronouns.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes businessExperiences(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+                          Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>>?)
+              _fn) =>
+      call(
+          businessExperiences: _fn(_instance.businessExperiences?.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+                e,
+                (i) => i,
+              )))?.toList());
+  TRes academicExperiences(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+                          Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>>?)
+              _fn) =>
+      call(
+          academicExperiences: _fn(_instance.academicExperiences?.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+                e,
+                (i) => i,
+              )))?.toList());
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+      TRes> get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+      TRes> get countryOfOrigin {
+    final local$countryOfOrigin = _instance.countryOfOrigin;
+    return local$countryOfOrigin == null
+        ? CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+            local$countryOfOrigin, (e) => call(countryOfOrigin: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById<TRes>
+    implements CopyWith$Query$FindMenteeUserDetailedProfile$findUserById<TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? email,
+    String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$websites>? websites,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>?
+        spokenLanguages,
+    String? avatarUrl,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>?
+        groupMemberships,
+    String? jobTitle,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$companies>? companies,
+    String? pronounsDisplay,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$pronouns>? pronouns,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>?
+        businessExperiences,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>?
+        academicExperiences,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    String? countryOfResidenceTextId,
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence?
+        countryOfResidence,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin?
+        countryOfOrigin,
+    String? $__typename,
+  }) =>
+      _res;
+  websites(_fn) => _res;
+  spokenLanguages(_fn) => _res;
+  groupMemberships(_fn) => _res;
+  companies(_fn) => _res;
+  pronouns(_fn) => _res;
+  businessExperiences(_fn) => _res;
+  academicExperiences(_fn) => _res;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+          TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+              .stub(_res);
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+          TRes>
+      get countryOfOrigin =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin
+              .stub(_res);
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$websites {
+  Query$FindMenteeUserDetailedProfile$findUserById$websites({
+    required this.value,
+    this.label,
+    this.$__typename = 'LabeledStringValue',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$websites.fromJson(
+      Map<String, dynamic> json) {
+    final l$value = json['value'];
+    final l$label = json['label'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$websites(
+      value: (l$value as String),
+      label: (l$label as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String value;
+
+  final String? label;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$value = value;
+    _resultData['value'] = l$value;
+    final l$label = label;
+    _resultData['label'] = l$label;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$value = value;
+    final l$label = label;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$value,
+      l$label,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUserDetailedProfile$findUserById$websites) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$value = value;
+    final lOther$value = other.value;
+    if (l$value != lOther$value) {
+      return false;
+    }
+    final l$label = label;
+    final lOther$label = other.label;
+    if (l$label != lOther$label) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$websites
+    on Query$FindMenteeUserDetailedProfile$findUserById$websites {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+          Query$FindMenteeUserDetailedProfile$findUserById$websites>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites(
+    Query$FindMenteeUserDetailedProfile$findUserById$websites instance,
+    TRes Function(Query$FindMenteeUserDetailedProfile$findUserById$websites)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites;
+
+  TRes call({
+    String? value,
+    String? label,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$websites _instance;
+
+  final TRes Function(Query$FindMenteeUserDetailedProfile$findUserById$websites)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? value = _undefined,
+    Object? label = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$websites(
+        value: value == _undefined || value == null
+            ? _instance.value
+            : (value as String),
+        label: label == _undefined ? _instance.label : (label as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$websites<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$websites(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? value,
+    String? label,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages {
+  Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages({
+    this.translatedValue,
+    this.$__typename = 'Language',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages
+    on Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+          Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+    Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages
+      _instance;
+
+  final TRes Function(
+      Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$spokenLanguages(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships({
+    required this.groupId,
+    required this.groupIdent,
+    required this.$__typename,
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MenteesGroupMembership":
+        return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      case "MentorsGroupMembership":
+        return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupId = json['groupId'];
+        final l$groupIdent = json['groupIdent'];
+        final l$$__typename = json['__typename'];
+        return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+          groupId: (l$groupId as String),
+          groupIdent: (l$groupIdent as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership);
+
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)?
+        groupMembership,
+    _T Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships
+      _instance;
+
+  final TRes Function(
+      Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+    implements
+        Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership({
+    required this.soughtExpertises,
+    this.industry,
+    this.reasonsForStartingBusiness,
+    this.$__typename = 'MenteesGroupMembership',
+    required this.groupId,
+    required this.groupIdent,
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$soughtExpertises = json['soughtExpertises'];
+    final l$industry = json['industry'];
+    final l$reasonsForStartingBusiness = json['reasonsForStartingBusiness'];
+    final l$$__typename = json['__typename'];
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+      soughtExpertises: (l$soughtExpertises as List<dynamic>)
+          .map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industry: l$industry == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+              .fromJson((l$industry as Map<String, dynamic>)),
+      reasonsForStartingBusiness: (l$reasonsForStartingBusiness as String?),
+      $__typename: (l$$__typename as String),
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      soughtExpertises;
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry?
+      industry;
+
+  final String? reasonsForStartingBusiness;
+
+  final String $__typename;
+
+  final String groupId;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$soughtExpertises = soughtExpertises;
+    _resultData['soughtExpertises'] =
+        l$soughtExpertises.map((e) => e.toJson()).toList();
+    final l$industry = industry;
+    _resultData['industry'] = l$industry?.toJson();
+    final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
+    _resultData['reasonsForStartingBusiness'] = l$reasonsForStartingBusiness;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$soughtExpertises = soughtExpertises;
+    final l$industry = industry;
+    final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
+    final l$$__typename = $__typename;
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      Object.hashAll(l$soughtExpertises.map((v) => v)),
+      l$industry,
+      l$reasonsForStartingBusiness,
+      l$$__typename,
+      l$groupId,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$soughtExpertises = soughtExpertises;
+    final lOther$soughtExpertises = other.soughtExpertises;
+    if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$soughtExpertises.length; i++) {
+      final l$soughtExpertises$entry = l$soughtExpertises[i];
+      final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
+      if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+        return false;
+      }
+    }
+    final l$industry = industry;
+    final lOther$industry = other.industry;
+    if (l$industry != lOther$industry) {
+      return false;
+    }
+    final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
+    final lOther$reasonsForStartingBusiness = other.reasonsForStartingBusiness;
+    if (l$reasonsForStartingBusiness != lOther$reasonsForStartingBusiness) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    List<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? reasonsForStartingBusiness,
+    String? $__typename,
+    String? groupId,
+    String? groupIdent,
+  });
+  TRes soughtExpertises(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                      Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+          _fn);
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry;
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? soughtExpertises = _undefined,
+    Object? industry = _undefined,
+    Object? reasonsForStartingBusiness = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+        soughtExpertises: soughtExpertises == _undefined ||
+                soughtExpertises == null
+            ? _instance.soughtExpertises
+            : (soughtExpertises as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
+        industry: industry == _undefined
+            ? _instance.industry
+            : (industry
+                as Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry?),
+        reasonsForStartingBusiness: reasonsForStartingBusiness == _undefined
+            ? _instance.reasonsForStartingBusiness
+            : (reasonsForStartingBusiness as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes soughtExpertises(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+              _fn) =>
+      call(
+          soughtExpertises: _fn(_instance.soughtExpertises.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+                e,
+                (i) => i,
+              ))).toList());
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry {
+    final local$industry = _instance.industry;
+    return local$industry == null
+        ? CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+            local$industry, (e) => call(industry: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? reasonsForStartingBusiness,
+    String? $__typename,
+    String? groupId,
+    String? groupIdent,
+  }) =>
+      _res;
+  soughtExpertises(_fn) => _res;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+          TRes>
+      get industry =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+              .stub(_res);
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MenteesGroupMembership$industry(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+    implements
+        Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership({
+    required this.groupId,
+    required this.groupIdent,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+    implements
+        Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships {
+  Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership({
+    required this.groupId,
+    required this.groupIdent,
+    this.$__typename = 'MentorsGroupMembership',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupId = json['groupId'];
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+      groupId: (l$groupId as String),
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupId;
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupId = groupId;
+    _resultData['groupId'] = l$groupId;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupId = groupId;
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupId,
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupId = groupId;
+    final lOther$groupId = other.groupId;
+    if (l$groupId != lOther$groupId) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+    on Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+    Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupId = _undefined,
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+        groupId: groupId == _undefined || groupId == null
+            ? _instance.groupId
+            : (groupId as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupId,
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$companies {
+  Query$FindMenteeUserDetailedProfile$findUserById$companies({
+    required this.name,
+    this.description,
+    this.websites,
+    this.companyStage,
+    this.companyType,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$description = json['description'];
+    final l$websites = json['websites'];
+    final l$companyStage = json['companyStage'];
+    final l$companyType = json['companyType'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$companies(
+      name: (l$name as String),
+      description: (l$description as String?),
+      websites: (l$websites as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindMenteeUserDetailedProfile$findUserById$companies$websites
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      companyStage: l$companyStage == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+              .fromJson((l$companyStage as Map<String, dynamic>)),
+      companyType: l$companyType == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+              .fromJson((l$companyType as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String name;
+
+  final String? description;
+
+  final List<
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>?
+      websites;
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage?
+      companyStage;
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType?
+      companyType;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$description = description;
+    _resultData['description'] = l$description;
+    final l$websites = websites;
+    _resultData['websites'] = l$websites?.map((e) => e.toJson()).toList();
+    final l$companyStage = companyStage;
+    _resultData['companyStage'] = l$companyStage?.toJson();
+    final l$companyType = companyType;
+    _resultData['companyType'] = l$companyType?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$description = description;
+    final l$websites = websites;
+    final l$companyStage = companyStage;
+    final l$companyType = companyType;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$description,
+      l$websites == null ? null : Object.hashAll(l$websites.map((v) => v)),
+      l$companyStage,
+      l$companyType,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$description = description;
+    final lOther$description = other.description;
+    if (l$description != lOther$description) {
+      return false;
+    }
+    final l$websites = websites;
+    final lOther$websites = other.websites;
+    if (l$websites != null && lOther$websites != null) {
+      if (l$websites.length != lOther$websites.length) {
+        return false;
+      }
+      for (int i = 0; i < l$websites.length; i++) {
+        final l$websites$entry = l$websites[i];
+        final lOther$websites$entry = lOther$websites[i];
+        if (l$websites$entry != lOther$websites$entry) {
+          return false;
+        }
+      }
+    } else if (l$websites != lOther$websites) {
+      return false;
+    }
+    final l$companyStage = companyStage;
+    final lOther$companyStage = other.companyStage;
+    if (l$companyStage != lOther$companyStage) {
+      return false;
+    }
+    final l$companyType = companyType;
+    final lOther$companyType = other.companyType;
+    if (l$companyType != lOther$companyType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$companies
+    on Query$FindMenteeUserDetailedProfile$findUserById$companies {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+          Query$FindMenteeUserDetailedProfile$findUserById$companies>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies(
+    Query$FindMenteeUserDetailedProfile$findUserById$companies instance,
+    TRes Function(Query$FindMenteeUserDetailedProfile$findUserById$companies)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies;
+
+  TRes call({
+    String? name,
+    String? description,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>?
+        websites,
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage?
+        companyStage,
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType?
+        companyType,
+    String? $__typename,
+  });
+  TRes websites(
+      Iterable<Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>? Function(
+              Iterable<
+                  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+                      Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>>?)
+          _fn);
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+      TRes> get companyStage;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+      TRes> get companyType;
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies _instance;
+
+  final TRes Function(
+      Query$FindMenteeUserDetailedProfile$findUserById$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? description = _undefined,
+    Object? websites = _undefined,
+    Object? companyStage = _undefined,
+    Object? companyType = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$companies(
+        name: name == _undefined || name == null
+            ? _instance.name
+            : (name as String),
+        description: description == _undefined
+            ? _instance.description
+            : (description as String?),
+        websites: websites == _undefined
+            ? _instance.websites
+            : (websites as List<
+                Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>?),
+        companyStage: companyStage == _undefined
+            ? _instance.companyStage
+            : (companyStage
+                as Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage?),
+        companyType: companyType == _undefined
+            ? _instance.companyType
+            : (companyType
+                as Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes websites(
+          Iterable<Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>? Function(
+                  Iterable<
+                      CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+                          Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>>?)
+              _fn) =>
+      call(
+          websites: _fn(_instance.websites?.map((e) =>
+              CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+                e,
+                (i) => i,
+              )))?.toList());
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+      TRes> get companyStage {
+    final local$companyStage = _instance.companyStage;
+    return local$companyStage == null
+        ? CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+            local$companyStage, (e) => call(companyStage: e));
+  }
+
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+      TRes> get companyType {
+    final local$companyType = _instance.companyType;
+    return local$companyType == null
+        ? CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+            .stub(_then(_instance))
+        : CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+            local$companyType, (e) => call(companyType: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    String? description,
+    List<Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>?
+        websites,
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage?
+        companyStage,
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType?
+        companyType,
+    String? $__typename,
+  }) =>
+      _res;
+  websites(_fn) => _res;
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+          TRes>
+      get companyStage =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+              .stub(_res);
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+          TRes>
+      get companyType =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+              .stub(_res);
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$companies$websites {
+  Query$FindMenteeUserDetailedProfile$findUserById$companies$websites({
+    required this.value,
+    this.label,
+    this.$__typename = 'LabeledStringValue',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$companies$websites.fromJson(
+      Map<String, dynamic> json) {
+    final l$value = json['value'];
+    final l$label = json['label'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+      value: (l$value as String),
+      label: (l$label as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String value;
+
+  final String? label;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$value = value;
+    _resultData['value'] = l$value;
+    final l$label = label;
+    _resultData['label'] = l$label;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$value = value;
+    final l$label = label;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$value,
+      l$label,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$companies$websites) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$value = value;
+    final lOther$value = other.value;
+    if (l$value != lOther$value) {
+      return false;
+    }
+    final l$label = label;
+    final lOther$label = other.label;
+    if (l$label != lOther$label) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites
+    on Query$FindMenteeUserDetailedProfile$findUserById$companies$websites {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$websites>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$websites
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$companies$websites)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites;
+
+  TRes call({
+    String? value,
+    String? label,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies$websites
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$websites)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? value = _undefined,
+    Object? label = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+        value: value == _undefined || value == null
+            ? _instance.value
+            : (value as String),
+        label: label == _undefined ? _instance.label : (label as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$websites(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? value,
+    String? label,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage {
+  Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage({
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+    on Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyStage(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType {
+  Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType({
+    this.translatedValue,
+    this.$__typename = 'CompanyType',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+    on Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+    Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$companies$companyType(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$pronouns {
+  Query$FindMenteeUserDetailedProfile$findUserById$pronouns({
+    this.translatedValue,
+    this.$__typename = 'Pronoun',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$pronouns.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindMenteeUserDetailedProfile$findUserById$pronouns) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$pronouns
+    on Query$FindMenteeUserDetailedProfile$findUserById$pronouns {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+          Query$FindMenteeUserDetailedProfile$findUserById$pronouns>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+    Query$FindMenteeUserDetailedProfile$findUserById$pronouns instance,
+    TRes Function(Query$FindMenteeUserDetailedProfile$findUserById$pronouns)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$pronouns _instance;
+
+  final TRes Function(Query$FindMenteeUserDetailedProfile$findUserById$pronouns)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$pronouns<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$pronouns(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences {
+  Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences({
+    required this.businessName,
+    required this.jobTitle,
+    required this.startDate,
+    this.endDate,
+    this.city,
+    this.state,
+    this.country,
+    this.$__typename = 'BusinessExperience',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences.fromJson(
+      Map<String, dynamic> json) {
+    final l$businessName = json['businessName'];
+    final l$jobTitle = json['jobTitle'];
+    final l$startDate = json['startDate'];
+    final l$endDate = json['endDate'];
+    final l$city = json['city'];
+    final l$state = json['state'];
+    final l$country = json['country'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+      businessName: (l$businessName as String),
+      jobTitle: (l$jobTitle as String),
+      startDate: DateTime.parse((l$startDate as String)),
+      endDate: l$endDate == null ? null : DateTime.parse((l$endDate as String)),
+      city: (l$city as String?),
+      state: (l$state as String?),
+      country: (l$country as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String businessName;
+
+  final String jobTitle;
+
+  final DateTime startDate;
+
+  final DateTime? endDate;
+
+  final String? city;
+
+  final String? state;
+
+  final String? country;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$businessName = businessName;
+    _resultData['businessName'] = l$businessName;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$startDate = startDate;
+    _resultData['startDate'] = l$startDate.toIso8601String();
+    final l$endDate = endDate;
+    _resultData['endDate'] = l$endDate?.toIso8601String();
+    final l$city = city;
+    _resultData['city'] = l$city;
+    final l$state = state;
+    _resultData['state'] = l$state;
+    final l$country = country;
+    _resultData['country'] = l$country;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$businessName = businessName;
+    final l$jobTitle = jobTitle;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$city = city;
+    final l$state = state;
+    final l$country = country;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$businessName,
+      l$jobTitle,
+      l$startDate,
+      l$endDate,
+      l$city,
+      l$state,
+      l$country,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$businessName = businessName;
+    final lOther$businessName = other.businessName;
+    if (l$businessName != lOther$businessName) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$city = city;
+    final lOther$city = other.city;
+    if (l$city != lOther$city) {
+      return false;
+    }
+    final l$state = state;
+    final lOther$state = other.state;
+    if (l$state != lOther$state) {
+      return false;
+    }
+    final l$country = country;
+    final lOther$country = other.country;
+    if (l$country != lOther$country) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences
+    on Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+          Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+    Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences;
+
+  TRes call({
+    String? businessName,
+    String? jobTitle,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? city,
+    String? state,
+    String? country,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? businessName = _undefined,
+    Object? jobTitle = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? city = _undefined,
+    Object? state = _undefined,
+    Object? country = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+        businessName: businessName == _undefined || businessName == null
+            ? _instance.businessName
+            : (businessName as String),
+        jobTitle: jobTitle == _undefined || jobTitle == null
+            ? _instance.jobTitle
+            : (jobTitle as String),
+        startDate: startDate == _undefined || startDate == null
+            ? _instance.startDate
+            : (startDate as DateTime),
+        endDate:
+            endDate == _undefined ? _instance.endDate : (endDate as DateTime?),
+        city: city == _undefined ? _instance.city : (city as String?),
+        state: state == _undefined ? _instance.state : (state as String?),
+        country:
+            country == _undefined ? _instance.country : (country as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$businessExperiences(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? businessName,
+    String? jobTitle,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? city,
+    String? state,
+    String? country,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences {
+  Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences({
+    required this.institutionName,
+    this.degreeType,
+    this.fieldOfStudy,
+    required this.startDate,
+    this.endDate,
+    this.$__typename = 'AcademicExperience',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences.fromJson(
+      Map<String, dynamic> json) {
+    final l$institutionName = json['institutionName'];
+    final l$degreeType = json['degreeType'];
+    final l$fieldOfStudy = json['fieldOfStudy'];
+    final l$startDate = json['startDate'];
+    final l$endDate = json['endDate'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+      institutionName: (l$institutionName as String),
+      degreeType: (l$degreeType as String?),
+      fieldOfStudy: (l$fieldOfStudy as String?),
+      startDate: DateTime.parse((l$startDate as String)),
+      endDate: l$endDate == null ? null : DateTime.parse((l$endDate as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String institutionName;
+
+  final String? degreeType;
+
+  final String? fieldOfStudy;
+
+  final DateTime startDate;
+
+  final DateTime? endDate;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$institutionName = institutionName;
+    _resultData['institutionName'] = l$institutionName;
+    final l$degreeType = degreeType;
+    _resultData['degreeType'] = l$degreeType;
+    final l$fieldOfStudy = fieldOfStudy;
+    _resultData['fieldOfStudy'] = l$fieldOfStudy;
+    final l$startDate = startDate;
+    _resultData['startDate'] = l$startDate.toIso8601String();
+    final l$endDate = endDate;
+    _resultData['endDate'] = l$endDate?.toIso8601String();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$institutionName = institutionName;
+    final l$degreeType = degreeType;
+    final l$fieldOfStudy = fieldOfStudy;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$institutionName,
+      l$degreeType,
+      l$fieldOfStudy,
+      l$startDate,
+      l$endDate,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$institutionName = institutionName;
+    final lOther$institutionName = other.institutionName;
+    if (l$institutionName != lOther$institutionName) {
+      return false;
+    }
+    final l$degreeType = degreeType;
+    final lOther$degreeType = other.degreeType;
+    if (l$degreeType != lOther$degreeType) {
+      return false;
+    }
+    final l$fieldOfStudy = fieldOfStudy;
+    final lOther$fieldOfStudy = other.fieldOfStudy;
+    if (l$fieldOfStudy != lOther$fieldOfStudy) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences
+    on Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+          Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+    Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences;
+
+  TRes call({
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? institutionName = _undefined,
+    Object? degreeType = _undefined,
+    Object? fieldOfStudy = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+        institutionName:
+            institutionName == _undefined || institutionName == null
+                ? _instance.institutionName
+                : (institutionName as String),
+        degreeType: degreeType == _undefined
+            ? _instance.degreeType
+            : (degreeType as String?),
+        fieldOfStudy: fieldOfStudy == _undefined
+            ? _instance.fieldOfStudy
+            : (fieldOfStudy as String?),
+        startDate: startDate == _undefined || startDate == null
+            ? _instance.startDate
+            : (startDate as DateTime),
+        endDate:
+            endDate == _undefined ? _instance.endDate : (endDate as DateTime?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$academicExperiences(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence {
+  Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+    on Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+          Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+        instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence
+      _instance;
+
+  final TRes Function(
+          Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin {
+  Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin
+    on Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin {
+  CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+          Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin>
+      get copyWith =>
+          CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+    TRes> {
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+    Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin instance,
+    TRes Function(
+            Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin)
+        then,
+  ) = _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin;
+
+  factory CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+            TRes> {
+  _CopyWithImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin
+      _instance;
+
+  final TRes Function(
+      Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+        TRes>
+    implements
+        CopyWith$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin<
+            TRes> {
+  _CopyWithStubImpl$Query$FindMenteeUserDetailedProfile$findUserById$countryOfOrigin(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
     String? $__typename,
   }) =>
       _res;

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -501,6 +501,8126 @@ class _CopyWithStubImpl$Query$GetAuthenticatedUser$getAuthenticatedUser<TRes>
       _res;
 }
 
+class Variables$Mutation$CreateUserSearch {
+  factory Variables$Mutation$CreateUserSearch(
+          {required Input$UserSearchInput input}) =>
+      Variables$Mutation$CreateUserSearch._({
+        r'input': input,
+      });
+
+  Variables$Mutation$CreateUserSearch._(this._$data);
+
+  factory Variables$Mutation$CreateUserSearch.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$input = data['input'];
+    result$data['input'] =
+        Input$UserSearchInput.fromJson((l$input as Map<String, dynamic>));
+    return Variables$Mutation$CreateUserSearch._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Input$UserSearchInput get input => (_$data['input'] as Input$UserSearchInput);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$input = input;
+    result$data['input'] = l$input.toJson();
+    return result$data;
+  }
+
+  CopyWith$Variables$Mutation$CreateUserSearch<
+          Variables$Mutation$CreateUserSearch>
+      get copyWith => CopyWith$Variables$Mutation$CreateUserSearch(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Mutation$CreateUserSearch) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$input = input;
+    final lOther$input = other.input;
+    if (l$input != lOther$input) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$input = input;
+    return Object.hashAll([l$input]);
+  }
+}
+
+abstract class CopyWith$Variables$Mutation$CreateUserSearch<TRes> {
+  factory CopyWith$Variables$Mutation$CreateUserSearch(
+    Variables$Mutation$CreateUserSearch instance,
+    TRes Function(Variables$Mutation$CreateUserSearch) then,
+  ) = _CopyWithImpl$Variables$Mutation$CreateUserSearch;
+
+  factory CopyWith$Variables$Mutation$CreateUserSearch.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Mutation$CreateUserSearch;
+
+  TRes call({Input$UserSearchInput? input});
+}
+
+class _CopyWithImpl$Variables$Mutation$CreateUserSearch<TRes>
+    implements CopyWith$Variables$Mutation$CreateUserSearch<TRes> {
+  _CopyWithImpl$Variables$Mutation$CreateUserSearch(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Mutation$CreateUserSearch _instance;
+
+  final TRes Function(Variables$Mutation$CreateUserSearch) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? input = _undefined}) =>
+      _then(Variables$Mutation$CreateUserSearch._({
+        ..._instance._$data,
+        if (input != _undefined && input != null)
+          'input': (input as Input$UserSearchInput),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Mutation$CreateUserSearch<TRes>
+    implements CopyWith$Variables$Mutation$CreateUserSearch<TRes> {
+  _CopyWithStubImpl$Variables$Mutation$CreateUserSearch(this._res);
+
+  TRes _res;
+
+  call({Input$UserSearchInput? input}) => _res;
+}
+
+class Mutation$CreateUserSearch {
+  Mutation$CreateUserSearch({
+    required this.createUserSearch,
+    this.$__typename = 'Mutation',
+  });
+
+  factory Mutation$CreateUserSearch.fromJson(Map<String, dynamic> json) {
+    final l$createUserSearch = json['createUserSearch'];
+    final l$$__typename = json['__typename'];
+    return Mutation$CreateUserSearch(
+      createUserSearch: Mutation$CreateUserSearch$createUserSearch.fromJson(
+          (l$createUserSearch as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Mutation$CreateUserSearch$createUserSearch createUserSearch;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$createUserSearch = createUserSearch;
+    _resultData['createUserSearch'] = l$createUserSearch.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$createUserSearch = createUserSearch;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$createUserSearch,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Mutation$CreateUserSearch) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$createUserSearch = createUserSearch;
+    final lOther$createUserSearch = other.createUserSearch;
+    if (l$createUserSearch != lOther$createUserSearch) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Mutation$CreateUserSearch
+    on Mutation$CreateUserSearch {
+  CopyWith$Mutation$CreateUserSearch<Mutation$CreateUserSearch> get copyWith =>
+      CopyWith$Mutation$CreateUserSearch(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Mutation$CreateUserSearch<TRes> {
+  factory CopyWith$Mutation$CreateUserSearch(
+    Mutation$CreateUserSearch instance,
+    TRes Function(Mutation$CreateUserSearch) then,
+  ) = _CopyWithImpl$Mutation$CreateUserSearch;
+
+  factory CopyWith$Mutation$CreateUserSearch.stub(TRes res) =
+      _CopyWithStubImpl$Mutation$CreateUserSearch;
+
+  TRes call({
+    Mutation$CreateUserSearch$createUserSearch? createUserSearch,
+    String? $__typename,
+  });
+  CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes>
+      get createUserSearch;
+}
+
+class _CopyWithImpl$Mutation$CreateUserSearch<TRes>
+    implements CopyWith$Mutation$CreateUserSearch<TRes> {
+  _CopyWithImpl$Mutation$CreateUserSearch(
+    this._instance,
+    this._then,
+  );
+
+  final Mutation$CreateUserSearch _instance;
+
+  final TRes Function(Mutation$CreateUserSearch) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? createUserSearch = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Mutation$CreateUserSearch(
+        createUserSearch: createUserSearch == _undefined ||
+                createUserSearch == null
+            ? _instance.createUserSearch
+            : (createUserSearch as Mutation$CreateUserSearch$createUserSearch),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes>
+      get createUserSearch {
+    final local$createUserSearch = _instance.createUserSearch;
+    return CopyWith$Mutation$CreateUserSearch$createUserSearch(
+        local$createUserSearch, (e) => call(createUserSearch: e));
+  }
+}
+
+class _CopyWithStubImpl$Mutation$CreateUserSearch<TRes>
+    implements CopyWith$Mutation$CreateUserSearch<TRes> {
+  _CopyWithStubImpl$Mutation$CreateUserSearch(this._res);
+
+  TRes _res;
+
+  call({
+    Mutation$CreateUserSearch$createUserSearch? createUserSearch,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes>
+      get createUserSearch =>
+          CopyWith$Mutation$CreateUserSearch$createUserSearch.stub(_res);
+}
+
+const documentNodeMutationCreateUserSearch = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.mutation,
+    name: NameNode(value: 'CreateUserSearch'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'input')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'UserSearchInput'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'createUserSearch'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'input'),
+            value: VariableNode(name: NameNode(value: 'input')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'name'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'seeksHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'offersHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'searchText'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'expiresAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'updatedAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Mutation$CreateUserSearch$createUserSearch {
+  Mutation$CreateUserSearch$createUserSearch({
+    this.name,
+    this.seeksHelp,
+    this.offersHelp,
+    this.searchText,
+    required this.id,
+    this.expiresAt,
+    required this.userId,
+    this.updatedAt,
+    this.$__typename = 'UserSearch',
+  });
+
+  factory Mutation$CreateUserSearch$createUserSearch.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$offersHelp = json['offersHelp'];
+    final l$searchText = json['searchText'];
+    final l$id = json['id'];
+    final l$expiresAt = json['expiresAt'];
+    final l$userId = json['userId'];
+    final l$updatedAt = json['updatedAt'];
+    final l$$__typename = json['__typename'];
+    return Mutation$CreateUserSearch$createUserSearch(
+      name: (l$name as String?),
+      seeksHelp: l$seeksHelp == null
+          ? null
+          : fromJson$Enum$UserSearchFieldPreference((l$seeksHelp as String)),
+      offersHelp: l$offersHelp == null
+          ? null
+          : fromJson$Enum$UserSearchFieldPreference((l$offersHelp as String)),
+      searchText: (l$searchText as String?),
+      id: (l$id as String),
+      expiresAt:
+          l$expiresAt == null ? null : DateTime.parse((l$expiresAt as String)),
+      userId: (l$userId as String),
+      updatedAt:
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? name;
+
+  final Enum$UserSearchFieldPreference? seeksHelp;
+
+  final Enum$UserSearchFieldPreference? offersHelp;
+
+  final String? searchText;
+
+  final String id;
+
+  final DateTime? expiresAt;
+
+  final String userId;
+
+  final DateTime? updatedAt;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp == null
+        ? null
+        : toJson$Enum$UserSearchFieldPreference(l$seeksHelp);
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp == null
+        ? null
+        : toJson$Enum$UserSearchFieldPreference(l$offersHelp);
+    final l$searchText = searchText;
+    _resultData['searchText'] = l$searchText;
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$expiresAt = expiresAt;
+    _resultData['expiresAt'] = l$expiresAt?.toIso8601String();
+    final l$userId = userId;
+    _resultData['userId'] = l$userId;
+    final l$updatedAt = updatedAt;
+    _resultData['updatedAt'] = l$updatedAt?.toIso8601String();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$seeksHelp = seeksHelp;
+    final l$offersHelp = offersHelp;
+    final l$searchText = searchText;
+    final l$id = id;
+    final l$expiresAt = expiresAt;
+    final l$userId = userId;
+    final l$updatedAt = updatedAt;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$seeksHelp,
+      l$offersHelp,
+      l$searchText,
+      l$id,
+      l$expiresAt,
+      l$userId,
+      l$updatedAt,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Mutation$CreateUserSearch$createUserSearch) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$searchText = searchText;
+    final lOther$searchText = other.searchText;
+    if (l$searchText != lOther$searchText) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$expiresAt = expiresAt;
+    final lOther$expiresAt = other.expiresAt;
+    if (l$expiresAt != lOther$expiresAt) {
+      return false;
+    }
+    final l$userId = userId;
+    final lOther$userId = other.userId;
+    if (l$userId != lOther$userId) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Mutation$CreateUserSearch$createUserSearch
+    on Mutation$CreateUserSearch$createUserSearch {
+  CopyWith$Mutation$CreateUserSearch$createUserSearch<
+          Mutation$CreateUserSearch$createUserSearch>
+      get copyWith => CopyWith$Mutation$CreateUserSearch$createUserSearch(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes> {
+  factory CopyWith$Mutation$CreateUserSearch$createUserSearch(
+    Mutation$CreateUserSearch$createUserSearch instance,
+    TRes Function(Mutation$CreateUserSearch$createUserSearch) then,
+  ) = _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch;
+
+  factory CopyWith$Mutation$CreateUserSearch$createUserSearch.stub(TRes res) =
+      _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch;
+
+  TRes call({
+    String? name,
+    Enum$UserSearchFieldPreference? seeksHelp,
+    Enum$UserSearchFieldPreference? offersHelp,
+    String? searchText,
+    String? id,
+    DateTime? expiresAt,
+    String? userId,
+    DateTime? updatedAt,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
+    implements CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes> {
+  _CopyWithImpl$Mutation$CreateUserSearch$createUserSearch(
+    this._instance,
+    this._then,
+  );
+
+  final Mutation$CreateUserSearch$createUserSearch _instance;
+
+  final TRes Function(Mutation$CreateUserSearch$createUserSearch) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? offersHelp = _undefined,
+    Object? searchText = _undefined,
+    Object? id = _undefined,
+    Object? expiresAt = _undefined,
+    Object? userId = _undefined,
+    Object? updatedAt = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Mutation$CreateUserSearch$createUserSearch(
+        name: name == _undefined ? _instance.name : (name as String?),
+        seeksHelp: seeksHelp == _undefined
+            ? _instance.seeksHelp
+            : (seeksHelp as Enum$UserSearchFieldPreference?),
+        offersHelp: offersHelp == _undefined
+            ? _instance.offersHelp
+            : (offersHelp as Enum$UserSearchFieldPreference?),
+        searchText: searchText == _undefined
+            ? _instance.searchText
+            : (searchText as String?),
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        expiresAt: expiresAt == _undefined
+            ? _instance.expiresAt
+            : (expiresAt as DateTime?),
+        userId: userId == _undefined || userId == null
+            ? _instance.userId
+            : (userId as String),
+        updatedAt: updatedAt == _undefined
+            ? _instance.updatedAt
+            : (updatedAt as DateTime?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch<TRes>
+    implements CopyWith$Mutation$CreateUserSearch$createUserSearch<TRes> {
+  _CopyWithStubImpl$Mutation$CreateUserSearch$createUserSearch(this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    Enum$UserSearchFieldPreference? seeksHelp,
+    Enum$UserSearchFieldPreference? offersHelp,
+    String? searchText,
+    String? id,
+    DateTime? expiresAt,
+    String? userId,
+    DateTime? updatedAt,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches {
+  Query$MyUserSearches({
+    required this.myUserSearches,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$MyUserSearches.fromJson(Map<String, dynamic> json) {
+    final l$myUserSearches = json['myUserSearches'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches(
+      myUserSearches: (l$myUserSearches as List<dynamic>)
+          .map((e) => Query$MyUserSearches$myUserSearches.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$MyUserSearches$myUserSearches> myUserSearches;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$myUserSearches = myUserSearches;
+    _resultData['myUserSearches'] =
+        l$myUserSearches.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$myUserSearches = myUserSearches;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$myUserSearches.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$MyUserSearches) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$myUserSearches = myUserSearches;
+    final lOther$myUserSearches = other.myUserSearches;
+    if (l$myUserSearches.length != lOther$myUserSearches.length) {
+      return false;
+    }
+    for (int i = 0; i < l$myUserSearches.length; i++) {
+      final l$myUserSearches$entry = l$myUserSearches[i];
+      final lOther$myUserSearches$entry = lOther$myUserSearches[i];
+      if (l$myUserSearches$entry != lOther$myUserSearches$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches on Query$MyUserSearches {
+  CopyWith$Query$MyUserSearches<Query$MyUserSearches> get copyWith =>
+      CopyWith$Query$MyUserSearches(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$MyUserSearches<TRes> {
+  factory CopyWith$Query$MyUserSearches(
+    Query$MyUserSearches instance,
+    TRes Function(Query$MyUserSearches) then,
+  ) = _CopyWithImpl$Query$MyUserSearches;
+
+  factory CopyWith$Query$MyUserSearches.stub(TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches;
+
+  TRes call({
+    List<Query$MyUserSearches$myUserSearches>? myUserSearches,
+    String? $__typename,
+  });
+  TRes myUserSearches(
+      Iterable<Query$MyUserSearches$myUserSearches> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches<
+                      Query$MyUserSearches$myUserSearches>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$MyUserSearches<TRes>
+    implements CopyWith$Query$MyUserSearches<TRes> {
+  _CopyWithImpl$Query$MyUserSearches(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches _instance;
+
+  final TRes Function(Query$MyUserSearches) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? myUserSearches = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches(
+        myUserSearches: myUserSearches == _undefined || myUserSearches == null
+            ? _instance.myUserSearches
+            : (myUserSearches as List<Query$MyUserSearches$myUserSearches>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes myUserSearches(
+          Iterable<Query$MyUserSearches$myUserSearches> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches<
+                          Query$MyUserSearches$myUserSearches>>)
+              _fn) =>
+      call(
+          myUserSearches: _fn(_instance.myUserSearches
+              .map((e) => CopyWith$Query$MyUserSearches$myUserSearches(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches<TRes>
+    implements CopyWith$Query$MyUserSearches<TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$MyUserSearches$myUserSearches>? myUserSearches,
+    String? $__typename,
+  }) =>
+      _res;
+  myUserSearches(_fn) => _res;
+}
+
+const documentNodeQueryMyUserSearches = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'MyUserSearches'),
+    variableDefinitions: [],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'myUserSearches'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'topFoundUsers'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'id'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'email'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'firstName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'lastName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'fullName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'avatarUrl'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'userHandle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'countryOfResidence'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'translatedValue'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'textId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'groupMemberships'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'groupIdent'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  InlineFragmentNode(
+                    typeCondition: TypeConditionNode(
+                        on: NamedTypeNode(
+                      name: NameNode(value: 'MentorsGroupMembership'),
+                      isNonNull: false,
+                    )),
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'expertisesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industriesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'expertises'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industries'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'endorsements'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  InlineFragmentNode(
+                    typeCondition: TypeConditionNode(
+                        on: NamedTypeNode(
+                      name: NameNode(value: 'MenteesGroupMembership'),
+                      isNonNull: false,
+                    )),
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'soughtExpertisesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industryTextId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'soughtExpertises'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industry'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'companies'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'name'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyStageTextId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyStage'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyTypeTextId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyType'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'runInfos'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'matchCount'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'topUserIds'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'updatedAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$MyUserSearches$myUserSearches {
+  Query$MyUserSearches$myUserSearches({
+    required this.topFoundUsers,
+    this.runInfos,
+    this.updatedAt,
+    this.$__typename = 'UserSearch',
+  });
+
+  factory Query$MyUserSearches$myUserSearches.fromJson(
+      Map<String, dynamic> json) {
+    final l$topFoundUsers = json['topFoundUsers'];
+    final l$runInfos = json['runInfos'];
+    final l$updatedAt = json['updatedAt'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches(
+      topFoundUsers: (l$topFoundUsers as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
+      runInfos: (l$runInfos as List<dynamic>?)
+          ?.map((e) => Query$MyUserSearches$myUserSearches$runInfos.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      updatedAt:
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$MyUserSearches$myUserSearches$topFoundUsers> topFoundUsers;
+
+  final List<Query$MyUserSearches$myUserSearches$runInfos>? runInfos;
+
+  final DateTime? updatedAt;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$topFoundUsers = topFoundUsers;
+    _resultData['topFoundUsers'] =
+        l$topFoundUsers.map((e) => e.toJson()).toList();
+    final l$runInfos = runInfos;
+    _resultData['runInfos'] = l$runInfos?.map((e) => e.toJson()).toList();
+    final l$updatedAt = updatedAt;
+    _resultData['updatedAt'] = l$updatedAt?.toIso8601String();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$topFoundUsers = topFoundUsers;
+    final l$runInfos = runInfos;
+    final l$updatedAt = updatedAt;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$topFoundUsers.map((v) => v)),
+      l$runInfos == null ? null : Object.hashAll(l$runInfos.map((v) => v)),
+      l$updatedAt,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$MyUserSearches$myUserSearches) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$topFoundUsers = topFoundUsers;
+    final lOther$topFoundUsers = other.topFoundUsers;
+    if (l$topFoundUsers.length != lOther$topFoundUsers.length) {
+      return false;
+    }
+    for (int i = 0; i < l$topFoundUsers.length; i++) {
+      final l$topFoundUsers$entry = l$topFoundUsers[i];
+      final lOther$topFoundUsers$entry = lOther$topFoundUsers[i];
+      if (l$topFoundUsers$entry != lOther$topFoundUsers$entry) {
+        return false;
+      }
+    }
+    final l$runInfos = runInfos;
+    final lOther$runInfos = other.runInfos;
+    if (l$runInfos != null && lOther$runInfos != null) {
+      if (l$runInfos.length != lOther$runInfos.length) {
+        return false;
+      }
+      for (int i = 0; i < l$runInfos.length; i++) {
+        final l$runInfos$entry = l$runInfos[i];
+        final lOther$runInfos$entry = lOther$runInfos[i];
+        if (l$runInfos$entry != lOther$runInfos$entry) {
+          return false;
+        }
+      }
+    } else if (l$runInfos != lOther$runInfos) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches
+    on Query$MyUserSearches$myUserSearches {
+  CopyWith$Query$MyUserSearches$myUserSearches<
+          Query$MyUserSearches$myUserSearches>
+      get copyWith => CopyWith$Query$MyUserSearches$myUserSearches(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches<TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches(
+    Query$MyUserSearches$myUserSearches instance,
+    TRes Function(Query$MyUserSearches$myUserSearches) then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches.stub(TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches;
+
+  TRes call({
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers>? topFoundUsers,
+    List<Query$MyUserSearches$myUserSearches$runInfos>? runInfos,
+    DateTime? updatedAt,
+    String? $__typename,
+  });
+  TRes topFoundUsers(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers>>)
+          _fn);
+  TRes runInfos(
+      Iterable<Query$MyUserSearches$myUserSearches$runInfos>? Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$runInfos<
+                      Query$MyUserSearches$myUserSearches$runInfos>>?)
+          _fn);
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches<TRes>
+    implements CopyWith$Query$MyUserSearches$myUserSearches<TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches _instance;
+
+  final TRes Function(Query$MyUserSearches$myUserSearches) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? topFoundUsers = _undefined,
+    Object? runInfos = _undefined,
+    Object? updatedAt = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches$myUserSearches(
+        topFoundUsers: topFoundUsers == _undefined || topFoundUsers == null
+            ? _instance.topFoundUsers
+            : (topFoundUsers
+                as List<Query$MyUserSearches$myUserSearches$topFoundUsers>),
+        runInfos: runInfos == _undefined
+            ? _instance.runInfos
+            : (runInfos as List<Query$MyUserSearches$myUserSearches$runInfos>?),
+        updatedAt: updatedAt == _undefined
+            ? _instance.updatedAt
+            : (updatedAt as DateTime?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes topFoundUsers(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers>>)
+              _fn) =>
+      call(
+          topFoundUsers: _fn(_instance.topFoundUsers.map(
+              (e) => CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers(
+                    e,
+                    (i) => i,
+                  ))).toList());
+  TRes runInfos(
+          Iterable<Query$MyUserSearches$myUserSearches$runInfos>? Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$runInfos<
+                          Query$MyUserSearches$myUserSearches$runInfos>>?)
+              _fn) =>
+      call(
+          runInfos: _fn(_instance.runInfos?.map(
+              (e) => CopyWith$Query$MyUserSearches$myUserSearches$runInfos(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches<TRes>
+    implements CopyWith$Query$MyUserSearches$myUserSearches<TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers>? topFoundUsers,
+    List<Query$MyUserSearches$myUserSearches$runInfos>? runInfos,
+    DateTime? updatedAt,
+    String? $__typename,
+  }) =>
+      _res;
+  topFoundUsers(_fn) => _res;
+  runInfos(_fn) => _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers {
+  Query$MyUserSearches$myUserSearches$topFoundUsers({
+    required this.id,
+    this.email,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    this.countryOfResidence,
+    required this.groupMemberships,
+    required this.companies,
+    this.$__typename = 'User',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$companies = json['companies'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers(
+      id: (l$id as String),
+      email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+              .fromJson((l$countryOfResidence as Map<String, dynamic>)),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      companies: (l$companies as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers$companies
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
+      countryOfResidence;
+
+  final List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>
+      groupMemberships;
+
+  final List<Query$MyUserSearches$myUserSearches$topFoundUsers$companies>
+      companies;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$countryOfResidence = countryOfResidence;
+    final l$groupMemberships = groupMemberships;
+    final l$companies = companies;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$countryOfResidence,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      Object.hashAll(l$companies.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$MyUserSearches$myUserSearches$topFoundUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers
+    on Query$MyUserSearches$myUserSearches$topFoundUsers {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<
+          Query$MyUserSearches$myUserSearches$topFoundUsers>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers(
+    Query$MyUserSearches$myUserSearches$topFoundUsers instance,
+    TRes Function(Query$MyUserSearches$myUserSearches$topFoundUsers) then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
+        countryOfResidence,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>?
+        groupMemberships,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$companies>?
+        companies,
+    String? $__typename,
+  });
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+      TRes> get countryOfResidence;
+  TRes groupMemberships(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>>)
+          _fn);
+  TRes companies(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$companies> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers$companies>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers _instance;
+
+  final TRes Function(Query$MyUserSearches$myUserSearches$topFoundUsers) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? companies = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches$myUserSearches$topFoundUsers(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?),
+        groupMemberships: groupMemberships == _undefined ||
+                groupMemberships == null
+            ? _instance.groupMemberships
+            : (groupMemberships as List<
+                Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<
+                Query$MyUserSearches$myUserSearches$topFoundUsers$companies>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+      TRes> get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+            .stub(_then(_instance))
+        : CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  TRes groupMemberships(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map((e) =>
+              CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes companies(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$companies> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies.map((e) =>
+              CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers<TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence?
+        countryOfResidence,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>?
+        groupMemberships,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$companies>?
+        companies,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+          TRes>
+      get countryOfResidence =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+              .stub(_res);
+  groupMemberships(_fn) => _res;
+  companies(_fn) => _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence({
+    this.translatedValue,
+    required this.textId,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$textId = json['textId'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      textId: (l$textId as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String textId;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$textId = textId;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$textId,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? textId,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? textId = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? textId,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships({
+    required this.groupIdent,
+    required this.$__typename,
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MentorsGroupMembership":
+        return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      case "MenteesGroupMembership":
+        return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupIdent = json['groupIdent'];
+        final l$$__typename = json['__typename'];
+        return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+          groupIdent: (l$groupIdent as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership);
+
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    _T Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership)?
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships
+      _instance;
+
+  final TRes Function(
+      Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership
+    implements
+        Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership({
+    this.expertisesTextIds,
+    this.industriesTextIds,
+    required this.expertises,
+    required this.industries,
+    this.endorsements,
+    this.$__typename = 'MentorsGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$expertisesTextIds = json['expertisesTextIds'];
+    final l$industriesTextIds = json['industriesTextIds'];
+    final l$expertises = json['expertises'];
+    final l$industries = json['industries'];
+    final l$endorsements = json['endorsements'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+      expertisesTextIds: (l$expertisesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      industriesTextIds: (l$industriesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      expertises: (l$expertises as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industries: (l$industries as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      endorsements: (l$endorsements as int?),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<String>? expertisesTextIds;
+
+  final List<String>? industriesTextIds;
+
+  final List<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      expertises;
+
+  final List<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
+      industries;
+
+  final int? endorsements;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$expertisesTextIds = expertisesTextIds;
+    _resultData['expertisesTextIds'] =
+        l$expertisesTextIds?.map((e) => e).toList();
+    final l$industriesTextIds = industriesTextIds;
+    _resultData['industriesTextIds'] =
+        l$industriesTextIds?.map((e) => e).toList();
+    final l$expertises = expertises;
+    _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
+    final l$industries = industries;
+    _resultData['industries'] = l$industries.map((e) => e.toJson()).toList();
+    final l$endorsements = endorsements;
+    _resultData['endorsements'] = l$endorsements;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$expertisesTextIds = expertisesTextIds;
+    final l$industriesTextIds = industriesTextIds;
+    final l$expertises = expertises;
+    final l$industries = industries;
+    final l$endorsements = endorsements;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      l$expertisesTextIds == null
+          ? null
+          : Object.hashAll(l$expertisesTextIds.map((v) => v)),
+      l$industriesTextIds == null
+          ? null
+          : Object.hashAll(l$industriesTextIds.map((v) => v)),
+      Object.hashAll(l$expertises.map((v) => v)),
+      Object.hashAll(l$industries.map((v) => v)),
+      l$endorsements,
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$expertisesTextIds = expertisesTextIds;
+    final lOther$expertisesTextIds = other.expertisesTextIds;
+    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
+      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$expertisesTextIds.length; i++) {
+        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
+        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
+        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
+      return false;
+    }
+    final l$industriesTextIds = industriesTextIds;
+    final lOther$industriesTextIds = other.industriesTextIds;
+    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
+      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$industriesTextIds.length; i++) {
+        final l$industriesTextIds$entry = l$industriesTextIds[i];
+        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
+        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$industriesTextIds != lOther$industriesTextIds) {
+      return false;
+    }
+    final l$expertises = expertises;
+    final lOther$expertises = other.expertises;
+    if (l$expertises.length != lOther$expertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$expertises.length; i++) {
+      final l$expertises$entry = l$expertises[i];
+      final lOther$expertises$entry = lOther$expertises[i];
+      if (l$expertises$entry != lOther$expertises$entry) {
+        return false;
+      }
+    }
+    final l$industries = industries;
+    final lOther$industries = other.industries;
+    if (l$industries.length != lOther$industries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$industries.length; i++) {
+      final l$industries$entry = l$industries[i];
+      final lOther$industries$entry = lOther$industries[i];
+      if (l$industries$entry != lOther$industries$entry) {
+        return false;
+      }
+    }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes expertises(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+          _fn);
+  TRes industries(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? expertisesTextIds = _undefined,
+    Object? industriesTextIds = _undefined,
+    Object? expertises = _undefined,
+    Object? industries = _undefined,
+    Object? endorsements = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+        expertisesTextIds: expertisesTextIds == _undefined
+            ? _instance.expertisesTextIds
+            : (expertisesTextIds as List<String>?),
+        industriesTextIds: industriesTextIds == _undefined
+            ? _instance.industriesTextIds
+            : (industriesTextIds as List<String>?),
+        expertises: expertises == _undefined || expertises == null
+            ? _instance.expertises
+            : (expertises as List<
+                Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>),
+        industries: industries == _undefined || industries == null
+            ? _instance.industries
+            : (industries as List<
+                Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>),
+        endorsements: endorsements == _undefined
+            ? _instance.endorsements
+            : (endorsements as int?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes expertises(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+              _fn) =>
+      call(
+          expertises: _fn(_instance.expertises.map((e) =>
+              CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes industries(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+              _fn) =>
+      call(
+          industries: _fn(_instance.industries.map((e) =>
+              CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  expertises(_fn) => _res;
+  industries(_fn) => _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership
+    implements
+        Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership({
+    this.soughtExpertisesTextIds,
+    this.industryTextId,
+    required this.soughtExpertises,
+    this.industry,
+    this.$__typename = 'MenteesGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$soughtExpertisesTextIds = json['soughtExpertisesTextIds'];
+    final l$industryTextId = json['industryTextId'];
+    final l$soughtExpertises = json['soughtExpertises'];
+    final l$industry = json['industry'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+      soughtExpertisesTextIds: (l$soughtExpertisesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      industryTextId: (l$industryTextId as String?),
+      soughtExpertises: (l$soughtExpertises as List<dynamic>)
+          .map((e) =>
+              Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industry: l$industry == null
+          ? null
+          : Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+              .fromJson((l$industry as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<String>? soughtExpertisesTextIds;
+
+  final String? industryTextId;
+
+  final List<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      soughtExpertises;
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+      industry;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    _resultData['soughtExpertisesTextIds'] =
+        l$soughtExpertisesTextIds?.map((e) => e).toList();
+    final l$industryTextId = industryTextId;
+    _resultData['industryTextId'] = l$industryTextId;
+    final l$soughtExpertises = soughtExpertises;
+    _resultData['soughtExpertises'] =
+        l$soughtExpertises.map((e) => e.toJson()).toList();
+    final l$industry = industry;
+    _resultData['industry'] = l$industry?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final l$industryTextId = industryTextId;
+    final l$soughtExpertises = soughtExpertises;
+    final l$industry = industry;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      l$soughtExpertisesTextIds == null
+          ? null
+          : Object.hashAll(l$soughtExpertisesTextIds.map((v) => v)),
+      l$industryTextId,
+      Object.hashAll(l$soughtExpertises.map((v) => v)),
+      l$industry,
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final lOther$soughtExpertisesTextIds = other.soughtExpertisesTextIds;
+    if (l$soughtExpertisesTextIds != null &&
+        lOther$soughtExpertisesTextIds != null) {
+      if (l$soughtExpertisesTextIds.length !=
+          lOther$soughtExpertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$soughtExpertisesTextIds.length; i++) {
+        final l$soughtExpertisesTextIds$entry = l$soughtExpertisesTextIds[i];
+        final lOther$soughtExpertisesTextIds$entry =
+            lOther$soughtExpertisesTextIds[i];
+        if (l$soughtExpertisesTextIds$entry !=
+            lOther$soughtExpertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$soughtExpertisesTextIds != lOther$soughtExpertisesTextIds) {
+      return false;
+    }
+    final l$industryTextId = industryTextId;
+    final lOther$industryTextId = other.industryTextId;
+    if (l$industryTextId != lOther$industryTextId) {
+      return false;
+    }
+    final l$soughtExpertises = soughtExpertises;
+    final lOther$soughtExpertises = other.soughtExpertises;
+    if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$soughtExpertises.length; i++) {
+      final l$soughtExpertises$entry = l$soughtExpertises[i];
+      final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
+      if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+        return false;
+      }
+    }
+    final l$industry = industry;
+    final lOther$industry = other.industry;
+    if (l$industry != lOther$industry) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes soughtExpertises(
+      Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+              Iterable<
+                  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                      Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+          _fn);
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry;
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? soughtExpertisesTextIds = _undefined,
+    Object? industryTextId = _undefined,
+    Object? soughtExpertises = _undefined,
+    Object? industry = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+        soughtExpertisesTextIds: soughtExpertisesTextIds == _undefined
+            ? _instance.soughtExpertisesTextIds
+            : (soughtExpertisesTextIds as List<String>?),
+        industryTextId: industryTextId == _undefined
+            ? _instance.industryTextId
+            : (industryTextId as String?),
+        soughtExpertises: soughtExpertises == _undefined ||
+                soughtExpertises == null
+            ? _instance.soughtExpertises
+            : (soughtExpertises as List<
+                Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
+        industry: industry == _undefined
+            ? _instance.industry
+            : (industry
+                as Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes soughtExpertises(
+          Iterable<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+              _fn) =>
+      call(
+          soughtExpertises: _fn(_instance.soughtExpertises.map((e) =>
+              CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+                e,
+                (i) => i,
+              ))).toList());
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry {
+    final local$industry = _instance.industry;
+    return local$industry == null
+        ? CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+            .stub(_then(_instance))
+        : CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+            local$industry, (e) => call(industry: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
+    List<Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  soughtExpertises(_fn) => _res;
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+          TRes>
+      get industry =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+              .stub(_res);
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership
+    implements
+        Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership({
+    required this.groupIdent,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$companies({
+    required this.name,
+    this.companyStageTextId,
+    this.companyStage,
+    this.companyTypeTextId,
+    this.companyType,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$companyStageTextId = json['companyStageTextId'];
+    final l$companyStage = json['companyStage'];
+    final l$companyTypeTextId = json['companyTypeTextId'];
+    final l$companyType = json['companyType'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+      name: (l$name as String),
+      companyStageTextId: (l$companyStageTextId as String?),
+      companyStage: l$companyStage == null
+          ? null
+          : Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+              .fromJson((l$companyStage as Map<String, dynamic>)),
+      companyTypeTextId: (l$companyTypeTextId as String?),
+      companyType: l$companyType == null
+          ? null
+          : Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+              .fromJson((l$companyType as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String name;
+
+  final String? companyStageTextId;
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
+      companyStage;
+
+  final String? companyTypeTextId;
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
+      companyType;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$companyStageTextId = companyStageTextId;
+    _resultData['companyStageTextId'] = l$companyStageTextId;
+    final l$companyStage = companyStage;
+    _resultData['companyStage'] = l$companyStage?.toJson();
+    final l$companyTypeTextId = companyTypeTextId;
+    _resultData['companyTypeTextId'] = l$companyTypeTextId;
+    final l$companyType = companyType;
+    _resultData['companyType'] = l$companyType?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$companyStageTextId = companyStageTextId;
+    final l$companyStage = companyStage;
+    final l$companyTypeTextId = companyTypeTextId;
+    final l$companyType = companyType;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$companyStageTextId,
+      l$companyStage,
+      l$companyTypeTextId,
+      l$companyType,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$companyStageTextId = companyStageTextId;
+    final lOther$companyStageTextId = other.companyStageTextId;
+    if (l$companyStageTextId != lOther$companyStageTextId) {
+      return false;
+    }
+    final l$companyStage = companyStage;
+    final lOther$companyStage = other.companyStage;
+    if (l$companyStage != lOther$companyStage) {
+      return false;
+    }
+    final l$companyTypeTextId = companyTypeTextId;
+    final lOther$companyTypeTextId = other.companyTypeTextId;
+    if (l$companyTypeTextId != lOther$companyTypeTextId) {
+      return false;
+    }
+    final l$companyType = companyType;
+    final lOther$companyType = other.companyType;
+    if (l$companyType != lOther$companyType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$companies
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$companies {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies instance,
+    TRes Function(Query$MyUserSearches$myUserSearches$topFoundUsers$companies)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies;
+
+  TRes call({
+    String? name,
+    String? companyStageTextId,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
+        companyStage,
+    String? companyTypeTextId,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
+        companyType,
+    String? $__typename,
+  });
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+      TRes> get companyStage;
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+      TRes> get companyType;
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$companies _instance;
+
+  final TRes Function(
+      Query$MyUserSearches$myUserSearches$topFoundUsers$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? companyStageTextId = _undefined,
+    Object? companyStage = _undefined,
+    Object? companyTypeTextId = _undefined,
+    Object? companyType = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+        name: name == _undefined || name == null
+            ? _instance.name
+            : (name as String),
+        companyStageTextId: companyStageTextId == _undefined
+            ? _instance.companyStageTextId
+            : (companyStageTextId as String?),
+        companyStage: companyStage == _undefined
+            ? _instance.companyStage
+            : (companyStage
+                as Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?),
+        companyTypeTextId: companyTypeTextId == _undefined
+            ? _instance.companyTypeTextId
+            : (companyTypeTextId as String?),
+        companyType: companyType == _undefined
+            ? _instance.companyType
+            : (companyType
+                as Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+      TRes> get companyStage {
+    final local$companyStage = _instance.companyStage;
+    return local$companyStage == null
+        ? CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+            .stub(_then(_instance))
+        : CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+            local$companyStage, (e) => call(companyStage: e));
+  }
+
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+      TRes> get companyType {
+    final local$companyType = _instance.companyType;
+    return local$companyType == null
+        ? CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+            .stub(_then(_instance))
+        : CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+            local$companyType, (e) => call(companyType: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    String? companyStageTextId,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage?
+        companyStage,
+    String? companyTypeTextId,
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType?
+        companyType,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+          TRes>
+      get companyStage =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+              .stub(_res);
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+          TRes>
+      get companyType =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+              .stub(_res);
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage({
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyStage(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType {
+  Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType({
+    this.translatedValue,
+    this.$__typename = 'CompanyType',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+    on Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType {
+  CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType>
+      get copyWith =>
+          CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+    TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+    Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+        instance,
+    TRes Function(
+            Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType)
+        then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+            TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType
+      _instance;
+
+  final TRes Function(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType<
+            TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$topFoundUsers$companies$companyType(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$MyUserSearches$myUserSearches$runInfos {
+  Query$MyUserSearches$myUserSearches$runInfos({
+    required this.matchCount,
+    this.topUserIds,
+    this.$__typename = 'UserSearchRunInfo',
+  });
+
+  factory Query$MyUserSearches$myUserSearches$runInfos.fromJson(
+      Map<String, dynamic> json) {
+    final l$matchCount = json['matchCount'];
+    final l$topUserIds = json['topUserIds'];
+    final l$$__typename = json['__typename'];
+    return Query$MyUserSearches$myUserSearches$runInfos(
+      matchCount: (l$matchCount as int),
+      topUserIds:
+          (l$topUserIds as List<dynamic>?)?.map((e) => (e as String)).toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final int matchCount;
+
+  final List<String>? topUserIds;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$matchCount = matchCount;
+    _resultData['matchCount'] = l$matchCount;
+    final l$topUserIds = topUserIds;
+    _resultData['topUserIds'] = l$topUserIds?.map((e) => e).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$matchCount = matchCount;
+    final l$topUserIds = topUserIds;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$matchCount,
+      l$topUserIds == null ? null : Object.hashAll(l$topUserIds.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$MyUserSearches$myUserSearches$runInfos) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$matchCount = matchCount;
+    final lOther$matchCount = other.matchCount;
+    if (l$matchCount != lOther$matchCount) {
+      return false;
+    }
+    final l$topUserIds = topUserIds;
+    final lOther$topUserIds = other.topUserIds;
+    if (l$topUserIds != null && lOther$topUserIds != null) {
+      if (l$topUserIds.length != lOther$topUserIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$topUserIds.length; i++) {
+        final l$topUserIds$entry = l$topUserIds[i];
+        final lOther$topUserIds$entry = lOther$topUserIds[i];
+        if (l$topUserIds$entry != lOther$topUserIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$topUserIds != lOther$topUserIds) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$MyUserSearches$myUserSearches$runInfos
+    on Query$MyUserSearches$myUserSearches$runInfos {
+  CopyWith$Query$MyUserSearches$myUserSearches$runInfos<
+          Query$MyUserSearches$myUserSearches$runInfos>
+      get copyWith => CopyWith$Query$MyUserSearches$myUserSearches$runInfos(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$MyUserSearches$myUserSearches$runInfos<TRes> {
+  factory CopyWith$Query$MyUserSearches$myUserSearches$runInfos(
+    Query$MyUserSearches$myUserSearches$runInfos instance,
+    TRes Function(Query$MyUserSearches$myUserSearches$runInfos) then,
+  ) = _CopyWithImpl$Query$MyUserSearches$myUserSearches$runInfos;
+
+  factory CopyWith$Query$MyUserSearches$myUserSearches$runInfos.stub(TRes res) =
+      _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$runInfos;
+
+  TRes call({
+    int? matchCount,
+    List<String>? topUserIds,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$MyUserSearches$myUserSearches$runInfos<TRes>
+    implements CopyWith$Query$MyUserSearches$myUserSearches$runInfos<TRes> {
+  _CopyWithImpl$Query$MyUserSearches$myUserSearches$runInfos(
+    this._instance,
+    this._then,
+  );
+
+  final Query$MyUserSearches$myUserSearches$runInfos _instance;
+
+  final TRes Function(Query$MyUserSearches$myUserSearches$runInfos) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? matchCount = _undefined,
+    Object? topUserIds = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$MyUserSearches$myUserSearches$runInfos(
+        matchCount: matchCount == _undefined || matchCount == null
+            ? _instance.matchCount
+            : (matchCount as int),
+        topUserIds: topUserIds == _undefined
+            ? _instance.topUserIds
+            : (topUserIds as List<String>?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$runInfos<TRes>
+    implements CopyWith$Query$MyUserSearches$myUserSearches$runInfos<TRes> {
+  _CopyWithStubImpl$Query$MyUserSearches$myUserSearches$runInfos(this._res);
+
+  TRes _res;
+
+  call({
+    int? matchCount,
+    List<String>? topUserIds,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindUserSearch {
+  factory Variables$Query$FindUserSearch({required String userSearchId}) =>
+      Variables$Query$FindUserSearch._({
+        r'userSearchId': userSearchId,
+      });
+
+  Variables$Query$FindUserSearch._(this._$data);
+
+  factory Variables$Query$FindUserSearch.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$userSearchId = data['userSearchId'];
+    result$data['userSearchId'] = (l$userSearchId as String);
+    return Variables$Query$FindUserSearch._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String get userSearchId => (_$data['userSearchId'] as String);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$userSearchId = userSearchId;
+    result$data['userSearchId'] = l$userSearchId;
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindUserSearch<Variables$Query$FindUserSearch>
+      get copyWith => CopyWith$Variables$Query$FindUserSearch(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindUserSearch) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$userSearchId = userSearchId;
+    final lOther$userSearchId = other.userSearchId;
+    if (l$userSearchId != lOther$userSearchId) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$userSearchId = userSearchId;
+    return Object.hashAll([l$userSearchId]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindUserSearch<TRes> {
+  factory CopyWith$Variables$Query$FindUserSearch(
+    Variables$Query$FindUserSearch instance,
+    TRes Function(Variables$Query$FindUserSearch) then,
+  ) = _CopyWithImpl$Variables$Query$FindUserSearch;
+
+  factory CopyWith$Variables$Query$FindUserSearch.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindUserSearch;
+
+  TRes call({String? userSearchId});
+}
+
+class _CopyWithImpl$Variables$Query$FindUserSearch<TRes>
+    implements CopyWith$Variables$Query$FindUserSearch<TRes> {
+  _CopyWithImpl$Variables$Query$FindUserSearch(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindUserSearch _instance;
+
+  final TRes Function(Variables$Query$FindUserSearch) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? userSearchId = _undefined}) =>
+      _then(Variables$Query$FindUserSearch._({
+        ..._instance._$data,
+        if (userSearchId != _undefined && userSearchId != null)
+          'userSearchId': (userSearchId as String),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindUserSearch<TRes>
+    implements CopyWith$Variables$Query$FindUserSearch<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindUserSearch(this._res);
+
+  TRes _res;
+
+  call({String? userSearchId}) => _res;
+}
+
+class Query$FindUserSearch {
+  Query$FindUserSearch({
+    required this.findUserSearchById,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindUserSearch.fromJson(Map<String, dynamic> json) {
+    final l$findUserSearchById = json['findUserSearchById'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch(
+      findUserSearchById: Query$FindUserSearch$findUserSearchById.fromJson(
+          (l$findUserSearchById as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final Query$FindUserSearch$findUserSearchById findUserSearchById;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUserSearchById = findUserSearchById;
+    _resultData['findUserSearchById'] = l$findUserSearchById.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUserSearchById = findUserSearchById;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$findUserSearchById,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearch) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUserSearchById = findUserSearchById;
+    final lOther$findUserSearchById = other.findUserSearchById;
+    if (l$findUserSearchById != lOther$findUserSearchById) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch on Query$FindUserSearch {
+  CopyWith$Query$FindUserSearch<Query$FindUserSearch> get copyWith =>
+      CopyWith$Query$FindUserSearch(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindUserSearch<TRes> {
+  factory CopyWith$Query$FindUserSearch(
+    Query$FindUserSearch instance,
+    TRes Function(Query$FindUserSearch) then,
+  ) = _CopyWithImpl$Query$FindUserSearch;
+
+  factory CopyWith$Query$FindUserSearch.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch;
+
+  TRes call({
+    Query$FindUserSearch$findUserSearchById? findUserSearchById,
+    String? $__typename,
+  });
+  CopyWith$Query$FindUserSearch$findUserSearchById<TRes> get findUserSearchById;
+}
+
+class _CopyWithImpl$Query$FindUserSearch<TRes>
+    implements CopyWith$Query$FindUserSearch<TRes> {
+  _CopyWithImpl$Query$FindUserSearch(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch _instance;
+
+  final TRes Function(Query$FindUserSearch) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUserSearchById = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearch(
+        findUserSearchById: findUserSearchById == _undefined ||
+                findUserSearchById == null
+            ? _instance.findUserSearchById
+            : (findUserSearchById as Query$FindUserSearch$findUserSearchById),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindUserSearch$findUserSearchById<TRes>
+      get findUserSearchById {
+    final local$findUserSearchById = _instance.findUserSearchById;
+    return CopyWith$Query$FindUserSearch$findUserSearchById(
+        local$findUserSearchById, (e) => call(findUserSearchById: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch<TRes>
+    implements CopyWith$Query$FindUserSearch<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch(this._res);
+
+  TRes _res;
+
+  call({
+    Query$FindUserSearch$findUserSearchById? findUserSearchById,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindUserSearch$findUserSearchById<TRes>
+      get findUserSearchById =>
+          CopyWith$Query$FindUserSearch$findUserSearchById.stub(_res);
+}
+
+const documentNodeQueryFindUserSearch = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindUserSearch'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'userSearchId')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUserSearchById'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'userSearchId'),
+            value: VariableNode(name: NameNode(value: 'userSearchId')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'topFoundUsers'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'id'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'email'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'firstName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'lastName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'fullName'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'avatarUrl'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'userHandle'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'countryOfResidence'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'translatedValue'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'textId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'groupMemberships'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'groupIdent'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  InlineFragmentNode(
+                    typeCondition: TypeConditionNode(
+                        on: NamedTypeNode(
+                      name: NameNode(value: 'MentorsGroupMembership'),
+                      isNonNull: false,
+                    )),
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'expertisesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industriesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'expertises'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industries'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'endorsements'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  InlineFragmentNode(
+                    typeCondition: TypeConditionNode(
+                        on: NamedTypeNode(
+                      name: NameNode(value: 'MenteesGroupMembership'),
+                      isNonNull: false,
+                    )),
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'soughtExpertisesTextIds'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industryTextId'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'soughtExpertises'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: 'industry'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: SelectionSetNode(selections: [
+                          FieldNode(
+                            name: NameNode(value: 'translatedValue'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                          FieldNode(
+                            name: NameNode(value: '__typename'),
+                            alias: null,
+                            arguments: [],
+                            directives: [],
+                            selectionSet: null,
+                          ),
+                        ]),
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: 'companies'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'name'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyStageTextId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyStage'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyTypeTextId'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'companyType'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'runInfos'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'matchCount'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: 'topUserIds'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'updatedAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindUserSearch$findUserSearchById {
+  Query$FindUserSearch$findUserSearchById({
+    required this.topFoundUsers,
+    this.runInfos,
+    this.updatedAt,
+    this.$__typename = 'UserSearch',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById.fromJson(
+      Map<String, dynamic> json) {
+    final l$topFoundUsers = json['topFoundUsers'];
+    final l$runInfos = json['runInfos'];
+    final l$updatedAt = json['updatedAt'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById(
+      topFoundUsers: (l$topFoundUsers as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
+      runInfos: (l$runInfos as List<dynamic>?)
+          ?.map((e) =>
+              Query$FindUserSearch$findUserSearchById$runInfos.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
+      updatedAt:
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindUserSearch$findUserSearchById$topFoundUsers>
+      topFoundUsers;
+
+  final List<Query$FindUserSearch$findUserSearchById$runInfos>? runInfos;
+
+  final DateTime? updatedAt;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$topFoundUsers = topFoundUsers;
+    _resultData['topFoundUsers'] =
+        l$topFoundUsers.map((e) => e.toJson()).toList();
+    final l$runInfos = runInfos;
+    _resultData['runInfos'] = l$runInfos?.map((e) => e.toJson()).toList();
+    final l$updatedAt = updatedAt;
+    _resultData['updatedAt'] = l$updatedAt?.toIso8601String();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$topFoundUsers = topFoundUsers;
+    final l$runInfos = runInfos;
+    final l$updatedAt = updatedAt;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$topFoundUsers.map((v) => v)),
+      l$runInfos == null ? null : Object.hashAll(l$runInfos.map((v) => v)),
+      l$updatedAt,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearch$findUserSearchById) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$topFoundUsers = topFoundUsers;
+    final lOther$topFoundUsers = other.topFoundUsers;
+    if (l$topFoundUsers.length != lOther$topFoundUsers.length) {
+      return false;
+    }
+    for (int i = 0; i < l$topFoundUsers.length; i++) {
+      final l$topFoundUsers$entry = l$topFoundUsers[i];
+      final lOther$topFoundUsers$entry = lOther$topFoundUsers[i];
+      if (l$topFoundUsers$entry != lOther$topFoundUsers$entry) {
+        return false;
+      }
+    }
+    final l$runInfos = runInfos;
+    final lOther$runInfos = other.runInfos;
+    if (l$runInfos != null && lOther$runInfos != null) {
+      if (l$runInfos.length != lOther$runInfos.length) {
+        return false;
+      }
+      for (int i = 0; i < l$runInfos.length; i++) {
+        final l$runInfos$entry = l$runInfos[i];
+        final lOther$runInfos$entry = lOther$runInfos[i];
+        if (l$runInfos$entry != lOther$runInfos$entry) {
+          return false;
+        }
+      }
+    } else if (l$runInfos != lOther$runInfos) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById
+    on Query$FindUserSearch$findUserSearchById {
+  CopyWith$Query$FindUserSearch$findUserSearchById<
+          Query$FindUserSearch$findUserSearchById>
+      get copyWith => CopyWith$Query$FindUserSearch$findUserSearchById(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById<TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById(
+    Query$FindUserSearch$findUserSearchById instance,
+    TRes Function(Query$FindUserSearch$findUserSearchById) then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById;
+
+  TRes call({
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers>? topFoundUsers,
+    List<Query$FindUserSearch$findUserSearchById$runInfos>? runInfos,
+    DateTime? updatedAt,
+    String? $__typename,
+  });
+  TRes topFoundUsers(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers>>)
+          _fn);
+  TRes runInfos(
+      Iterable<Query$FindUserSearch$findUserSearchById$runInfos>? Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<
+                      Query$FindUserSearch$findUserSearchById$runInfos>>?)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById<TRes>
+    implements CopyWith$Query$FindUserSearch$findUserSearchById<TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById _instance;
+
+  final TRes Function(Query$FindUserSearch$findUserSearchById) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? topFoundUsers = _undefined,
+    Object? runInfos = _undefined,
+    Object? updatedAt = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearch$findUserSearchById(
+        topFoundUsers: topFoundUsers == _undefined || topFoundUsers == null
+            ? _instance.topFoundUsers
+            : (topFoundUsers
+                as List<Query$FindUserSearch$findUserSearchById$topFoundUsers>),
+        runInfos: runInfos == _undefined
+            ? _instance.runInfos
+            : (runInfos
+                as List<Query$FindUserSearch$findUserSearchById$runInfos>?),
+        updatedAt: updatedAt == _undefined
+            ? _instance.updatedAt
+            : (updatedAt as DateTime?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes topFoundUsers(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers>>)
+              _fn) =>
+      call(
+          topFoundUsers: _fn(_instance.topFoundUsers.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes runInfos(
+          Iterable<Query$FindUserSearch$findUserSearchById$runInfos>? Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<
+                          Query$FindUserSearch$findUserSearchById$runInfos>>?)
+              _fn) =>
+      call(
+          runInfos: _fn(_instance.runInfos?.map(
+              (e) => CopyWith$Query$FindUserSearch$findUserSearchById$runInfos(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById<TRes>
+    implements CopyWith$Query$FindUserSearch$findUserSearchById<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers>? topFoundUsers,
+    List<Query$FindUserSearch$findUserSearchById$runInfos>? runInfos,
+    DateTime? updatedAt,
+    String? $__typename,
+  }) =>
+      _res;
+  topFoundUsers(_fn) => _res;
+  runInfos(_fn) => _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers({
+    required this.id,
+    this.email,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    this.countryOfResidence,
+    required this.groupMemberships,
+    required this.companies,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$companies = json['companies'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers(
+      id: (l$id as String),
+      email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+              .fromJson((l$countryOfResidence as Map<String, dynamic>)),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      companies: (l$companies as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers$companies
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
+      countryOfResidence;
+
+  final List<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>
+      groupMemberships;
+
+  final List<Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>
+      companies;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$countryOfResidence = countryOfResidence;
+    final l$groupMemberships = groupMemberships;
+    final l$companies = companies;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$countryOfResidence,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      Object.hashAll(l$companies.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearch$findUserSearchById$topFoundUsers) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers instance,
+    TRes Function(Query$FindUserSearch$findUserSearchById$topFoundUsers) then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
+        countryOfResidence,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
+        groupMemberships,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>?
+        companies,
+    String? $__typename,
+  });
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+      TRes> get countryOfResidence;
+  TRes groupMemberships(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>>)
+          _fn);
+  TRes companies(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$companies> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers _instance;
+
+  final TRes Function(Query$FindUserSearch$findUserSearchById$topFoundUsers)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? companies = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearch$findUserSearchById$topFoundUsers(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?),
+        groupMemberships: groupMemberships == _undefined ||
+                groupMemberships == null
+            ? _instance.groupMemberships
+            : (groupMemberships as List<
+                Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<
+                Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+      TRes> get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+            .stub(_then(_instance))
+        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  TRes groupMemberships(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes companies(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$companies> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence?
+        countryOfResidence,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>?
+        groupMemberships,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>?
+        companies,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+          TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+              .stub(_res);
+  groupMemberships(_fn) => _res;
+  companies(_fn) => _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence({
+    this.translatedValue,
+    required this.textId,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$textId = json['textId'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      textId: (l$textId as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String textId;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$textId = textId;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$textId,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? textId,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? textId = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? textId,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships({
+    required this.groupIdent,
+    required this.$__typename,
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MentorsGroupMembership":
+        return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      case "MenteesGroupMembership":
+        return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupIdent = json['groupIdent'];
+        final l$$__typename = json['__typename'];
+        return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+          groupIdent: (l$groupIdent as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership);
+
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    _T Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership)?
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership
+    implements
+        Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership({
+    this.expertisesTextIds,
+    this.industriesTextIds,
+    required this.expertises,
+    required this.industries,
+    this.endorsements,
+    this.$__typename = 'MentorsGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$expertisesTextIds = json['expertisesTextIds'];
+    final l$industriesTextIds = json['industriesTextIds'];
+    final l$expertises = json['expertises'];
+    final l$industries = json['industries'];
+    final l$endorsements = json['endorsements'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+      expertisesTextIds: (l$expertisesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      industriesTextIds: (l$industriesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      expertises: (l$expertises as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industries: (l$industries as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      endorsements: (l$endorsements as int?),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<String>? expertisesTextIds;
+
+  final List<String>? industriesTextIds;
+
+  final List<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      expertises;
+
+  final List<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
+      industries;
+
+  final int? endorsements;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$expertisesTextIds = expertisesTextIds;
+    _resultData['expertisesTextIds'] =
+        l$expertisesTextIds?.map((e) => e).toList();
+    final l$industriesTextIds = industriesTextIds;
+    _resultData['industriesTextIds'] =
+        l$industriesTextIds?.map((e) => e).toList();
+    final l$expertises = expertises;
+    _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
+    final l$industries = industries;
+    _resultData['industries'] = l$industries.map((e) => e.toJson()).toList();
+    final l$endorsements = endorsements;
+    _resultData['endorsements'] = l$endorsements;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$expertisesTextIds = expertisesTextIds;
+    final l$industriesTextIds = industriesTextIds;
+    final l$expertises = expertises;
+    final l$industries = industries;
+    final l$endorsements = endorsements;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      l$expertisesTextIds == null
+          ? null
+          : Object.hashAll(l$expertisesTextIds.map((v) => v)),
+      l$industriesTextIds == null
+          ? null
+          : Object.hashAll(l$industriesTextIds.map((v) => v)),
+      Object.hashAll(l$expertises.map((v) => v)),
+      Object.hashAll(l$industries.map((v) => v)),
+      l$endorsements,
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$expertisesTextIds = expertisesTextIds;
+    final lOther$expertisesTextIds = other.expertisesTextIds;
+    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
+      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$expertisesTextIds.length; i++) {
+        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
+        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
+        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
+      return false;
+    }
+    final l$industriesTextIds = industriesTextIds;
+    final lOther$industriesTextIds = other.industriesTextIds;
+    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
+      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$industriesTextIds.length; i++) {
+        final l$industriesTextIds$entry = l$industriesTextIds[i];
+        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
+        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$industriesTextIds != lOther$industriesTextIds) {
+      return false;
+    }
+    final l$expertises = expertises;
+    final lOther$expertises = other.expertises;
+    if (l$expertises.length != lOther$expertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$expertises.length; i++) {
+      final l$expertises$entry = l$expertises[i];
+      final lOther$expertises$entry = lOther$expertises[i];
+      if (l$expertises$entry != lOther$expertises$entry) {
+        return false;
+      }
+    }
+    final l$industries = industries;
+    final lOther$industries = other.industries;
+    if (l$industries.length != lOther$industries.length) {
+      return false;
+    }
+    for (int i = 0; i < l$industries.length; i++) {
+      final l$industries$entry = l$industries[i];
+      final lOther$industries$entry = lOther$industries[i];
+      if (l$industries$entry != lOther$industries$entry) {
+        return false;
+      }
+    }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes expertises(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+          _fn);
+  TRes industries(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? expertisesTextIds = _undefined,
+    Object? industriesTextIds = _undefined,
+    Object? expertises = _undefined,
+    Object? industries = _undefined,
+    Object? endorsements = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+        expertisesTextIds: expertisesTextIds == _undefined
+            ? _instance.expertisesTextIds
+            : (expertisesTextIds as List<String>?),
+        industriesTextIds: industriesTextIds == _undefined
+            ? _instance.industriesTextIds
+            : (industriesTextIds as List<String>?),
+        expertises: expertises == _undefined || expertises == null
+            ? _instance.expertises
+            : (expertises as List<
+                Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>),
+        industries: industries == _undefined || industries == null
+            ? _instance.industries
+            : (industries as List<
+                Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>),
+        endorsements: endorsements == _undefined
+            ? _instance.endorsements
+            : (endorsements as int?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes expertises(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>>)
+              _fn) =>
+      call(
+          expertises: _fn(_instance.expertises.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes industries(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>>)
+              _fn) =>
+      call(
+          industries: _fn(_instance.industries.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>?
+        industries,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  expertises(_fn) => _res;
+  industries(_fn) => _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$expertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MentorsGroupMembership$industries(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
+    implements
+        Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership({
+    this.soughtExpertisesTextIds,
+    this.industryTextId,
+    required this.soughtExpertises,
+    this.industry,
+    this.$__typename = 'MenteesGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$soughtExpertisesTextIds = json['soughtExpertisesTextIds'];
+    final l$industryTextId = json['industryTextId'];
+    final l$soughtExpertises = json['soughtExpertises'];
+    final l$industry = json['industry'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+      soughtExpertisesTextIds: (l$soughtExpertisesTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList(),
+      industryTextId: (l$industryTextId as String?),
+      soughtExpertises: (l$soughtExpertises as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      industry: l$industry == null
+          ? null
+          : Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+              .fromJson((l$industry as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<String>? soughtExpertisesTextIds;
+
+  final String? industryTextId;
+
+  final List<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      soughtExpertises;
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+      industry;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    _resultData['soughtExpertisesTextIds'] =
+        l$soughtExpertisesTextIds?.map((e) => e).toList();
+    final l$industryTextId = industryTextId;
+    _resultData['industryTextId'] = l$industryTextId;
+    final l$soughtExpertises = soughtExpertises;
+    _resultData['soughtExpertises'] =
+        l$soughtExpertises.map((e) => e.toJson()).toList();
+    final l$industry = industry;
+    _resultData['industry'] = l$industry?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final l$industryTextId = industryTextId;
+    final l$soughtExpertises = soughtExpertises;
+    final l$industry = industry;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      l$soughtExpertisesTextIds == null
+          ? null
+          : Object.hashAll(l$soughtExpertisesTextIds.map((v) => v)),
+      l$industryTextId,
+      Object.hashAll(l$soughtExpertises.map((v) => v)),
+      l$industry,
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$soughtExpertisesTextIds = soughtExpertisesTextIds;
+    final lOther$soughtExpertisesTextIds = other.soughtExpertisesTextIds;
+    if (l$soughtExpertisesTextIds != null &&
+        lOther$soughtExpertisesTextIds != null) {
+      if (l$soughtExpertisesTextIds.length !=
+          lOther$soughtExpertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$soughtExpertisesTextIds.length; i++) {
+        final l$soughtExpertisesTextIds$entry = l$soughtExpertisesTextIds[i];
+        final lOther$soughtExpertisesTextIds$entry =
+            lOther$soughtExpertisesTextIds[i];
+        if (l$soughtExpertisesTextIds$entry !=
+            lOther$soughtExpertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$soughtExpertisesTextIds != lOther$soughtExpertisesTextIds) {
+      return false;
+    }
+    final l$industryTextId = industryTextId;
+    final lOther$industryTextId = other.industryTextId;
+    if (l$industryTextId != lOther$industryTextId) {
+      return false;
+    }
+    final l$soughtExpertises = soughtExpertises;
+    final lOther$soughtExpertises = other.soughtExpertises;
+    if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$soughtExpertises.length; i++) {
+      final l$soughtExpertises$entry = l$soughtExpertises[i];
+      final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
+      if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+        return false;
+      }
+    }
+    final l$industry = industry;
+    final lOther$industry = other.industry;
+    if (l$industry != lOther$industry) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes soughtExpertises(
+      Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                      Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+          _fn);
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry;
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? soughtExpertisesTextIds = _undefined,
+    Object? industryTextId = _undefined,
+    Object? soughtExpertises = _undefined,
+    Object? industry = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+        soughtExpertisesTextIds: soughtExpertisesTextIds == _undefined
+            ? _instance.soughtExpertisesTextIds
+            : (soughtExpertisesTextIds as List<String>?),
+        industryTextId: industryTextId == _undefined
+            ? _instance.industryTextId
+            : (industryTextId as String?),
+        soughtExpertises: soughtExpertises == _undefined ||
+                soughtExpertises == null
+            ? _instance.soughtExpertises
+            : (soughtExpertises as List<
+                Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
+        industry: industry == _undefined
+            ? _instance.industry
+            : (industry
+                as Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes soughtExpertises(
+          Iterable<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+              _fn) =>
+      call(
+          soughtExpertises: _fn(_instance.soughtExpertises.map((e) =>
+              CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+                e,
+                (i) => i,
+              ))).toList());
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+      TRes> get industry {
+    final local$industry = _instance.industry;
+    return local$industry == null
+        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+            .stub(_then(_instance))
+        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+            local$industry, (e) => call(industry: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<String>? soughtExpertisesTextIds,
+    String? industryTextId,
+    List<Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry?
+        industry,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  soughtExpertises(_fn) => _res;
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+          TRes>
+      get industry =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+              .stub(_res);
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry({
+    this.translatedValue,
+    this.$__typename = 'Industry',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$MenteesGroupMembership$industry(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership
+    implements
+        Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership({
+    required this.groupIdent,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$companies({
+    required this.name,
+    this.companyStageTextId,
+    this.companyStage,
+    this.companyTypeTextId,
+    this.companyType,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$companyStageTextId = json['companyStageTextId'];
+    final l$companyStage = json['companyStage'];
+    final l$companyTypeTextId = json['companyTypeTextId'];
+    final l$companyType = json['companyType'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+      name: (l$name as String),
+      companyStageTextId: (l$companyStageTextId as String?),
+      companyStage: l$companyStage == null
+          ? null
+          : Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+              .fromJson((l$companyStage as Map<String, dynamic>)),
+      companyTypeTextId: (l$companyTypeTextId as String?),
+      companyType: l$companyType == null
+          ? null
+          : Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+              .fromJson((l$companyType as Map<String, dynamic>)),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String name;
+
+  final String? companyStageTextId;
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
+      companyStage;
+
+  final String? companyTypeTextId;
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
+      companyType;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$companyStageTextId = companyStageTextId;
+    _resultData['companyStageTextId'] = l$companyStageTextId;
+    final l$companyStage = companyStage;
+    _resultData['companyStage'] = l$companyStage?.toJson();
+    final l$companyTypeTextId = companyTypeTextId;
+    _resultData['companyTypeTextId'] = l$companyTypeTextId;
+    final l$companyType = companyType;
+    _resultData['companyType'] = l$companyType?.toJson();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$companyStageTextId = companyStageTextId;
+    final l$companyStage = companyStage;
+    final l$companyTypeTextId = companyTypeTextId;
+    final l$companyType = companyType;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$companyStageTextId,
+      l$companyStage,
+      l$companyTypeTextId,
+      l$companyType,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$companyStageTextId = companyStageTextId;
+    final lOther$companyStageTextId = other.companyStageTextId;
+    if (l$companyStageTextId != lOther$companyStageTextId) {
+      return false;
+    }
+    final l$companyStage = companyStage;
+    final lOther$companyStage = other.companyStage;
+    if (l$companyStage != lOther$companyStage) {
+      return false;
+    }
+    final l$companyTypeTextId = companyTypeTextId;
+    final lOther$companyTypeTextId = other.companyTypeTextId;
+    if (l$companyTypeTextId != lOther$companyTypeTextId) {
+      return false;
+    }
+    final l$companyType = companyType;
+    final lOther$companyType = other.companyType;
+    if (l$companyType != lOther$companyType) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$companies {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$companies)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies;
+
+  TRes call({
+    String? name,
+    String? companyStageTextId,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
+        companyStage,
+    String? companyTypeTextId,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
+        companyType,
+    String? $__typename,
+  });
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+      TRes> get companyStage;
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+      TRes> get companyType;
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies
+      _instance;
+
+  final TRes Function(
+      Query$FindUserSearch$findUserSearchById$topFoundUsers$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? companyStageTextId = _undefined,
+    Object? companyStage = _undefined,
+    Object? companyTypeTextId = _undefined,
+    Object? companyType = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+        name: name == _undefined || name == null
+            ? _instance.name
+            : (name as String),
+        companyStageTextId: companyStageTextId == _undefined
+            ? _instance.companyStageTextId
+            : (companyStageTextId as String?),
+        companyStage: companyStage == _undefined
+            ? _instance.companyStage
+            : (companyStage
+                as Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?),
+        companyTypeTextId: companyTypeTextId == _undefined
+            ? _instance.companyTypeTextId
+            : (companyTypeTextId as String?),
+        companyType: companyType == _undefined
+            ? _instance.companyType
+            : (companyType
+                as Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+      TRes> get companyStage {
+    final local$companyStage = _instance.companyStage;
+    return local$companyStage == null
+        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+            .stub(_then(_instance))
+        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+            local$companyStage, (e) => call(companyStage: e));
+  }
+
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+      TRes> get companyType {
+    final local$companyType = _instance.companyType;
+    return local$companyType == null
+        ? CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+            .stub(_then(_instance))
+        : CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+            local$companyType, (e) => call(companyType: e));
+  }
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    String? companyStageTextId,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage?
+        companyStage,
+    String? companyTypeTextId,
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType?
+        companyType,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+          TRes>
+      get companyStage =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+              .stub(_res);
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+          TRes>
+      get companyType =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+              .stub(_res);
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage({
+    this.translatedValue,
+    this.$__typename = 'CompanyStage',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyStage(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType {
+  Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType({
+    this.translatedValue,
+    this.$__typename = 'CompanyType',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+    on Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType {
+  CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType>
+      get copyWith =>
+          CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+    TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+    Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+        instance,
+    TRes Function(
+            Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$topFoundUsers$companies$companyType(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearch$findUserSearchById$runInfos {
+  Query$FindUserSearch$findUserSearchById$runInfos({
+    required this.matchCount,
+    this.topUserIds,
+    this.$__typename = 'UserSearchRunInfo',
+  });
+
+  factory Query$FindUserSearch$findUserSearchById$runInfos.fromJson(
+      Map<String, dynamic> json) {
+    final l$matchCount = json['matchCount'];
+    final l$topUserIds = json['topUserIds'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearch$findUserSearchById$runInfos(
+      matchCount: (l$matchCount as int),
+      topUserIds:
+          (l$topUserIds as List<dynamic>?)?.map((e) => (e as String)).toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final int matchCount;
+
+  final List<String>? topUserIds;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$matchCount = matchCount;
+    _resultData['matchCount'] = l$matchCount;
+    final l$topUserIds = topUserIds;
+    _resultData['topUserIds'] = l$topUserIds?.map((e) => e).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$matchCount = matchCount;
+    final l$topUserIds = topUserIds;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$matchCount,
+      l$topUserIds == null ? null : Object.hashAll(l$topUserIds.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearch$findUserSearchById$runInfos) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$matchCount = matchCount;
+    final lOther$matchCount = other.matchCount;
+    if (l$matchCount != lOther$matchCount) {
+      return false;
+    }
+    final l$topUserIds = topUserIds;
+    final lOther$topUserIds = other.topUserIds;
+    if (l$topUserIds != null && lOther$topUserIds != null) {
+      if (l$topUserIds.length != lOther$topUserIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$topUserIds.length; i++) {
+        final l$topUserIds$entry = l$topUserIds[i];
+        final lOther$topUserIds$entry = lOther$topUserIds[i];
+        if (l$topUserIds$entry != lOther$topUserIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$topUserIds != lOther$topUserIds) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearch$findUserSearchById$runInfos
+    on Query$FindUserSearch$findUserSearchById$runInfos {
+  CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<
+          Query$FindUserSearch$findUserSearchById$runInfos>
+      get copyWith => CopyWith$Query$FindUserSearch$findUserSearchById$runInfos(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<TRes> {
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$runInfos(
+    Query$FindUserSearch$findUserSearchById$runInfos instance,
+    TRes Function(Query$FindUserSearch$findUserSearchById$runInfos) then,
+  ) = _CopyWithImpl$Query$FindUserSearch$findUserSearchById$runInfos;
+
+  factory CopyWith$Query$FindUserSearch$findUserSearchById$runInfos.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos;
+
+  TRes call({
+    int? matchCount,
+    List<String>? topUserIds,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearch$findUserSearchById$runInfos<TRes>
+    implements CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<TRes> {
+  _CopyWithImpl$Query$FindUserSearch$findUserSearchById$runInfos(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearch$findUserSearchById$runInfos _instance;
+
+  final TRes Function(Query$FindUserSearch$findUserSearchById$runInfos) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? matchCount = _undefined,
+    Object? topUserIds = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearch$findUserSearchById$runInfos(
+        matchCount: matchCount == _undefined || matchCount == null
+            ? _instance.matchCount
+            : (matchCount as int),
+        topUserIds: topUserIds == _undefined
+            ? _instance.topUserIds
+            : (topUserIds as List<String>?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos<TRes>
+    implements CopyWith$Query$FindUserSearch$findUserSearchById$runInfos<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos(this._res);
+
+  TRes _res;
+
+  call({
+    int? matchCount,
+    List<String>? topUserIds,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
 class Variables$Query$FindMenteeUsers {
   factory Variables$Query$FindMenteeUsers({
     Input$FindObjectsOptions? options,

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -12314,6 +12314,11 @@ class Input$UserSearchInput {
     String? searchText,
     Enum$UserSearchFieldPreference? seeksHelp,
     Enum$UserSearchFieldPreference? offersHelp,
+    List<String>? languagesTextIds,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<String>? countryTextIds,
+    List<String>? companyStagesTextIds,
     int? maxResultCount,
     Enum$UserSearchSubscriptionType? subscription,
     DateTime? expiresAt,
@@ -12339,6 +12344,12 @@ class Input$UserSearchInput {
         if (searchText != null) r'searchText': searchText,
         if (seeksHelp != null) r'seeksHelp': seeksHelp,
         if (offersHelp != null) r'offersHelp': offersHelp,
+        if (languagesTextIds != null) r'languagesTextIds': languagesTextIds,
+        if (expertisesTextIds != null) r'expertisesTextIds': expertisesTextIds,
+        if (industriesTextIds != null) r'industriesTextIds': industriesTextIds,
+        if (countryTextIds != null) r'countryTextIds': countryTextIds,
+        if (companyStagesTextIds != null)
+          r'companyStagesTextIds': companyStagesTextIds,
         if (maxResultCount != null) r'maxResultCount': maxResultCount,
         if (subscription != null) r'subscription': subscription,
         if (expiresAt != null) r'expiresAt': expiresAt,
@@ -12439,6 +12450,37 @@ class Input$UserSearchInput {
           ? null
           : fromJson$Enum$UserSearchFieldPreference((l$offersHelp as String));
     }
+    if (data.containsKey('languagesTextIds')) {
+      final l$languagesTextIds = data['languagesTextIds'];
+      result$data['languagesTextIds'] = (l$languagesTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
+    }
+    if (data.containsKey('expertisesTextIds')) {
+      final l$expertisesTextIds = data['expertisesTextIds'];
+      result$data['expertisesTextIds'] = (l$expertisesTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
+    }
+    if (data.containsKey('industriesTextIds')) {
+      final l$industriesTextIds = data['industriesTextIds'];
+      result$data['industriesTextIds'] = (l$industriesTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
+    }
+    if (data.containsKey('countryTextIds')) {
+      final l$countryTextIds = data['countryTextIds'];
+      result$data['countryTextIds'] = (l$countryTextIds as List<dynamic>)
+          .map((e) => (e as String))
+          .toList();
+    }
+    if (data.containsKey('companyStagesTextIds')) {
+      final l$companyStagesTextIds = data['companyStagesTextIds'];
+      result$data['companyStagesTextIds'] =
+          (l$companyStagesTextIds as List<dynamic>)
+              .map((e) => (e as String))
+              .toList();
+    }
     if (data.containsKey('maxResultCount')) {
       final l$maxResultCount = data['maxResultCount'];
       result$data['maxResultCount'] = (l$maxResultCount as int);
@@ -12494,6 +12536,16 @@ class Input$UserSearchInput {
       (_$data['seeksHelp'] as Enum$UserSearchFieldPreference?);
   Enum$UserSearchFieldPreference? get offersHelp =>
       (_$data['offersHelp'] as Enum$UserSearchFieldPreference?);
+  List<String>? get languagesTextIds =>
+      (_$data['languagesTextIds'] as List<String>?);
+  List<String>? get expertisesTextIds =>
+      (_$data['expertisesTextIds'] as List<String>?);
+  List<String>? get industriesTextIds =>
+      (_$data['industriesTextIds'] as List<String>?);
+  List<String>? get countryTextIds =>
+      (_$data['countryTextIds'] as List<String>?);
+  List<String>? get companyStagesTextIds =>
+      (_$data['companyStagesTextIds'] as List<String>?);
   int? get maxResultCount => (_$data['maxResultCount'] as int?);
   Enum$UserSearchSubscriptionType? get subscription =>
       (_$data['subscription'] as Enum$UserSearchSubscriptionType?);
@@ -12580,6 +12632,31 @@ class Input$UserSearchInput {
       result$data['offersHelp'] = l$offersHelp == null
           ? null
           : toJson$Enum$UserSearchFieldPreference(l$offersHelp);
+    }
+    if (_$data.containsKey('languagesTextIds')) {
+      final l$languagesTextIds = languagesTextIds;
+      result$data['languagesTextIds'] =
+          (l$languagesTextIds as List<String>).map((e) => e).toList();
+    }
+    if (_$data.containsKey('expertisesTextIds')) {
+      final l$expertisesTextIds = expertisesTextIds;
+      result$data['expertisesTextIds'] =
+          (l$expertisesTextIds as List<String>).map((e) => e).toList();
+    }
+    if (_$data.containsKey('industriesTextIds')) {
+      final l$industriesTextIds = industriesTextIds;
+      result$data['industriesTextIds'] =
+          (l$industriesTextIds as List<String>).map((e) => e).toList();
+    }
+    if (_$data.containsKey('countryTextIds')) {
+      final l$countryTextIds = countryTextIds;
+      result$data['countryTextIds'] =
+          (l$countryTextIds as List<String>).map((e) => e).toList();
+    }
+    if (_$data.containsKey('companyStagesTextIds')) {
+      final l$companyStagesTextIds = companyStagesTextIds;
+      result$data['companyStagesTextIds'] =
+          (l$companyStagesTextIds as List<String>).map((e) => e).toList();
     }
     if (_$data.containsKey('maxResultCount')) {
       final l$maxResultCount = maxResultCount;
@@ -12788,6 +12865,107 @@ class Input$UserSearchInput {
     if (l$offersHelp != lOther$offersHelp) {
       return false;
     }
+    final l$languagesTextIds = languagesTextIds;
+    final lOther$languagesTextIds = other.languagesTextIds;
+    if (_$data.containsKey('languagesTextIds') !=
+        other._$data.containsKey('languagesTextIds')) {
+      return false;
+    }
+    if (l$languagesTextIds != null && lOther$languagesTextIds != null) {
+      if (l$languagesTextIds.length != lOther$languagesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$languagesTextIds.length; i++) {
+        final l$languagesTextIds$entry = l$languagesTextIds[i];
+        final lOther$languagesTextIds$entry = lOther$languagesTextIds[i];
+        if (l$languagesTextIds$entry != lOther$languagesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$languagesTextIds != lOther$languagesTextIds) {
+      return false;
+    }
+    final l$expertisesTextIds = expertisesTextIds;
+    final lOther$expertisesTextIds = other.expertisesTextIds;
+    if (_$data.containsKey('expertisesTextIds') !=
+        other._$data.containsKey('expertisesTextIds')) {
+      return false;
+    }
+    if (l$expertisesTextIds != null && lOther$expertisesTextIds != null) {
+      if (l$expertisesTextIds.length != lOther$expertisesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$expertisesTextIds.length; i++) {
+        final l$expertisesTextIds$entry = l$expertisesTextIds[i];
+        final lOther$expertisesTextIds$entry = lOther$expertisesTextIds[i];
+        if (l$expertisesTextIds$entry != lOther$expertisesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$expertisesTextIds != lOther$expertisesTextIds) {
+      return false;
+    }
+    final l$industriesTextIds = industriesTextIds;
+    final lOther$industriesTextIds = other.industriesTextIds;
+    if (_$data.containsKey('industriesTextIds') !=
+        other._$data.containsKey('industriesTextIds')) {
+      return false;
+    }
+    if (l$industriesTextIds != null && lOther$industriesTextIds != null) {
+      if (l$industriesTextIds.length != lOther$industriesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$industriesTextIds.length; i++) {
+        final l$industriesTextIds$entry = l$industriesTextIds[i];
+        final lOther$industriesTextIds$entry = lOther$industriesTextIds[i];
+        if (l$industriesTextIds$entry != lOther$industriesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$industriesTextIds != lOther$industriesTextIds) {
+      return false;
+    }
+    final l$countryTextIds = countryTextIds;
+    final lOther$countryTextIds = other.countryTextIds;
+    if (_$data.containsKey('countryTextIds') !=
+        other._$data.containsKey('countryTextIds')) {
+      return false;
+    }
+    if (l$countryTextIds != null && lOther$countryTextIds != null) {
+      if (l$countryTextIds.length != lOther$countryTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$countryTextIds.length; i++) {
+        final l$countryTextIds$entry = l$countryTextIds[i];
+        final lOther$countryTextIds$entry = lOther$countryTextIds[i];
+        if (l$countryTextIds$entry != lOther$countryTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$countryTextIds != lOther$countryTextIds) {
+      return false;
+    }
+    final l$companyStagesTextIds = companyStagesTextIds;
+    final lOther$companyStagesTextIds = other.companyStagesTextIds;
+    if (_$data.containsKey('companyStagesTextIds') !=
+        other._$data.containsKey('companyStagesTextIds')) {
+      return false;
+    }
+    if (l$companyStagesTextIds != null && lOther$companyStagesTextIds != null) {
+      if (l$companyStagesTextIds.length != lOther$companyStagesTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$companyStagesTextIds.length; i++) {
+        final l$companyStagesTextIds$entry = l$companyStagesTextIds[i];
+        final lOther$companyStagesTextIds$entry =
+            lOther$companyStagesTextIds[i];
+        if (l$companyStagesTextIds$entry != lOther$companyStagesTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$companyStagesTextIds != lOther$companyStagesTextIds) {
+      return false;
+    }
     final l$maxResultCount = maxResultCount;
     final lOther$maxResultCount = other.maxResultCount;
     if (_$data.containsKey('maxResultCount') !=
@@ -12856,6 +13034,11 @@ class Input$UserSearchInput {
     final l$searchText = searchText;
     final l$seeksHelp = seeksHelp;
     final l$offersHelp = offersHelp;
+    final l$languagesTextIds = languagesTextIds;
+    final l$expertisesTextIds = expertisesTextIds;
+    final l$industriesTextIds = industriesTextIds;
+    final l$countryTextIds = countryTextIds;
+    final l$companyStagesTextIds = companyStagesTextIds;
     final l$maxResultCount = maxResultCount;
     final l$subscription = subscription;
     final l$expiresAt = expiresAt;
@@ -12884,6 +13067,31 @@ class Input$UserSearchInput {
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('seeksHelp') ? l$seeksHelp : const {},
       _$data.containsKey('offersHelp') ? l$offersHelp : const {},
+      _$data.containsKey('languagesTextIds')
+          ? l$languagesTextIds == null
+              ? null
+              : Object.hashAll(l$languagesTextIds.map((v) => v))
+          : const {},
+      _$data.containsKey('expertisesTextIds')
+          ? l$expertisesTextIds == null
+              ? null
+              : Object.hashAll(l$expertisesTextIds.map((v) => v))
+          : const {},
+      _$data.containsKey('industriesTextIds')
+          ? l$industriesTextIds == null
+              ? null
+              : Object.hashAll(l$industriesTextIds.map((v) => v))
+          : const {},
+      _$data.containsKey('countryTextIds')
+          ? l$countryTextIds == null
+              ? null
+              : Object.hashAll(l$countryTextIds.map((v) => v))
+          : const {},
+      _$data.containsKey('companyStagesTextIds')
+          ? l$companyStagesTextIds == null
+              ? null
+              : Object.hashAll(l$companyStagesTextIds.map((v) => v))
+          : const {},
       _$data.containsKey('maxResultCount') ? l$maxResultCount : const {},
       _$data.containsKey('subscription') ? l$subscription : const {},
       _$data.containsKey('expiresAt') ? l$expiresAt : const {},
@@ -12921,6 +13129,11 @@ abstract class CopyWith$Input$UserSearchInput<TRes> {
     String? searchText,
     Enum$UserSearchFieldPreference? seeksHelp,
     Enum$UserSearchFieldPreference? offersHelp,
+    List<String>? languagesTextIds,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<String>? countryTextIds,
+    List<String>? companyStagesTextIds,
     int? maxResultCount,
     Enum$UserSearchSubscriptionType? subscription,
     DateTime? expiresAt,
@@ -12966,6 +13179,11 @@ class _CopyWithImpl$Input$UserSearchInput<TRes>
     Object? searchText = _undefined,
     Object? seeksHelp = _undefined,
     Object? offersHelp = _undefined,
+    Object? languagesTextIds = _undefined,
+    Object? expertisesTextIds = _undefined,
+    Object? industriesTextIds = _undefined,
+    Object? countryTextIds = _undefined,
+    Object? companyStagesTextIds = _undefined,
     Object? maxResultCount = _undefined,
     Object? subscription = _undefined,
     Object? expiresAt = _undefined,
@@ -12999,6 +13217,16 @@ class _CopyWithImpl$Input$UserSearchInput<TRes>
           'seeksHelp': (seeksHelp as Enum$UserSearchFieldPreference?),
         if (offersHelp != _undefined)
           'offersHelp': (offersHelp as Enum$UserSearchFieldPreference?),
+        if (languagesTextIds != _undefined && languagesTextIds != null)
+          'languagesTextIds': (languagesTextIds as List<String>),
+        if (expertisesTextIds != _undefined && expertisesTextIds != null)
+          'expertisesTextIds': (expertisesTextIds as List<String>),
+        if (industriesTextIds != _undefined && industriesTextIds != null)
+          'industriesTextIds': (industriesTextIds as List<String>),
+        if (countryTextIds != _undefined && countryTextIds != null)
+          'countryTextIds': (countryTextIds as List<String>),
+        if (companyStagesTextIds != _undefined && companyStagesTextIds != null)
+          'companyStagesTextIds': (companyStagesTextIds as List<String>),
         if (maxResultCount != _undefined && maxResultCount != null)
           'maxResultCount': (maxResultCount as int),
         if (subscription != _undefined)
@@ -13054,6 +13282,11 @@ class _CopyWithStubImpl$Input$UserSearchInput<TRes>
     String? searchText,
     Enum$UserSearchFieldPreference? seeksHelp,
     Enum$UserSearchFieldPreference? offersHelp,
+    List<String>? languagesTextIds,
+    List<String>? expertisesTextIds,
+    List<String>? industriesTextIds,
+    List<String>? countryTextIds,
+    List<String>? companyStagesTextIds,
     int? maxResultCount,
     Enum$UserSearchSubscriptionType? subscription,
     DateTime? expiresAt,
@@ -16359,6 +16592,3161 @@ class _CopyWithStubImpl$Input$ContentTagInput<TRes>
     String? childContentTagTypeTextId,
     String? messageText,
     DateTime? approvedByRecipientAt,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+}
+
+class Input$GenRequest {
+  factory Input$GenRequest({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? clearDb,
+    int? conversationCount,
+    int? messageCount,
+    Input$GenUserInput? users,
+    Input$GenGroupsInput? groups,
+    bool? publishAppEvents,
+  }) =>
+      Input$GenRequest._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (clearDb != null) r'clearDb': clearDb,
+        if (conversationCount != null) r'conversationCount': conversationCount,
+        if (messageCount != null) r'messageCount': messageCount,
+        if (users != null) r'users': users,
+        if (groups != null) r'groups': groups,
+        if (publishAppEvents != null) r'publishAppEvents': publishAppEvents,
+      });
+
+  Input$GenRequest._(this._$data);
+
+  factory Input$GenRequest.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('clearDb')) {
+      final l$clearDb = data['clearDb'];
+      result$data['clearDb'] = (l$clearDb as bool);
+    }
+    if (data.containsKey('conversationCount')) {
+      final l$conversationCount = data['conversationCount'];
+      result$data['conversationCount'] = (l$conversationCount as int);
+    }
+    if (data.containsKey('messageCount')) {
+      final l$messageCount = data['messageCount'];
+      result$data['messageCount'] = (l$messageCount as int);
+    }
+    if (data.containsKey('users')) {
+      final l$users = data['users'];
+      result$data['users'] =
+          Input$GenUserInput.fromJson((l$users as Map<String, dynamic>));
+    }
+    if (data.containsKey('groups')) {
+      final l$groups = data['groups'];
+      result$data['groups'] =
+          Input$GenGroupsInput.fromJson((l$groups as Map<String, dynamic>));
+    }
+    if (data.containsKey('publishAppEvents')) {
+      final l$publishAppEvents = data['publishAppEvents'];
+      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
+    }
+    return Input$GenRequest._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  bool? get clearDb => (_$data['clearDb'] as bool?);
+  int? get conversationCount => (_$data['conversationCount'] as int?);
+  int? get messageCount => (_$data['messageCount'] as int?);
+  Input$GenUserInput? get users => (_$data['users'] as Input$GenUserInput?);
+  Input$GenGroupsInput? get groups =>
+      (_$data['groups'] as Input$GenGroupsInput?);
+  bool? get publishAppEvents => (_$data['publishAppEvents'] as bool?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('clearDb')) {
+      final l$clearDb = clearDb;
+      result$data['clearDb'] = (l$clearDb as bool);
+    }
+    if (_$data.containsKey('conversationCount')) {
+      final l$conversationCount = conversationCount;
+      result$data['conversationCount'] = (l$conversationCount as int);
+    }
+    if (_$data.containsKey('messageCount')) {
+      final l$messageCount = messageCount;
+      result$data['messageCount'] = (l$messageCount as int);
+    }
+    if (_$data.containsKey('users')) {
+      final l$users = users;
+      result$data['users'] = (l$users as Input$GenUserInput).toJson();
+    }
+    if (_$data.containsKey('groups')) {
+      final l$groups = groups;
+      result$data['groups'] = (l$groups as Input$GenGroupsInput).toJson();
+    }
+    if (_$data.containsKey('publishAppEvents')) {
+      final l$publishAppEvents = publishAppEvents;
+      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenRequest<Input$GenRequest> get copyWith =>
+      CopyWith$Input$GenRequest(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenRequest) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$clearDb = clearDb;
+    final lOther$clearDb = other.clearDb;
+    if (_$data.containsKey('clearDb') != other._$data.containsKey('clearDb')) {
+      return false;
+    }
+    if (l$clearDb != lOther$clearDb) {
+      return false;
+    }
+    final l$conversationCount = conversationCount;
+    final lOther$conversationCount = other.conversationCount;
+    if (_$data.containsKey('conversationCount') !=
+        other._$data.containsKey('conversationCount')) {
+      return false;
+    }
+    if (l$conversationCount != lOther$conversationCount) {
+      return false;
+    }
+    final l$messageCount = messageCount;
+    final lOther$messageCount = other.messageCount;
+    if (_$data.containsKey('messageCount') !=
+        other._$data.containsKey('messageCount')) {
+      return false;
+    }
+    if (l$messageCount != lOther$messageCount) {
+      return false;
+    }
+    final l$users = users;
+    final lOther$users = other.users;
+    if (_$data.containsKey('users') != other._$data.containsKey('users')) {
+      return false;
+    }
+    if (l$users != lOther$users) {
+      return false;
+    }
+    final l$groups = groups;
+    final lOther$groups = other.groups;
+    if (_$data.containsKey('groups') != other._$data.containsKey('groups')) {
+      return false;
+    }
+    if (l$groups != lOther$groups) {
+      return false;
+    }
+    final l$publishAppEvents = publishAppEvents;
+    final lOther$publishAppEvents = other.publishAppEvents;
+    if (_$data.containsKey('publishAppEvents') !=
+        other._$data.containsKey('publishAppEvents')) {
+      return false;
+    }
+    if (l$publishAppEvents != lOther$publishAppEvents) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$clearDb = clearDb;
+    final l$conversationCount = conversationCount;
+    final l$messageCount = messageCount;
+    final l$users = users;
+    final l$groups = groups;
+    final l$publishAppEvents = publishAppEvents;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('clearDb') ? l$clearDb : const {},
+      _$data.containsKey('conversationCount') ? l$conversationCount : const {},
+      _$data.containsKey('messageCount') ? l$messageCount : const {},
+      _$data.containsKey('users') ? l$users : const {},
+      _$data.containsKey('groups') ? l$groups : const {},
+      _$data.containsKey('publishAppEvents') ? l$publishAppEvents : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenRequest<TRes> {
+  factory CopyWith$Input$GenRequest(
+    Input$GenRequest instance,
+    TRes Function(Input$GenRequest) then,
+  ) = _CopyWithImpl$Input$GenRequest;
+
+  factory CopyWith$Input$GenRequest.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenRequest;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? clearDb,
+    int? conversationCount,
+    int? messageCount,
+    Input$GenUserInput? users,
+    Input$GenGroupsInput? groups,
+    bool? publishAppEvents,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+  CopyWith$Input$GenUserInput<TRes> get users;
+  CopyWith$Input$GenGroupsInput<TRes> get groups;
+}
+
+class _CopyWithImpl$Input$GenRequest<TRes>
+    implements CopyWith$Input$GenRequest<TRes> {
+  _CopyWithImpl$Input$GenRequest(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenRequest _instance;
+
+  final TRes Function(Input$GenRequest) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? clearDb = _undefined,
+    Object? conversationCount = _undefined,
+    Object? messageCount = _undefined,
+    Object? users = _undefined,
+    Object? groups = _undefined,
+    Object? publishAppEvents = _undefined,
+  }) =>
+      _then(Input$GenRequest._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (clearDb != _undefined && clearDb != null)
+          'clearDb': (clearDb as bool),
+        if (conversationCount != _undefined && conversationCount != null)
+          'conversationCount': (conversationCount as int),
+        if (messageCount != _undefined && messageCount != null)
+          'messageCount': (messageCount as int),
+        if (users != _undefined && users != null)
+          'users': (users as Input$GenUserInput),
+        if (groups != _undefined && groups != null)
+          'groups': (groups as Input$GenGroupsInput),
+        if (publishAppEvents != _undefined && publishAppEvents != null)
+          'publishAppEvents': (publishAppEvents as bool),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+
+  CopyWith$Input$GenUserInput<TRes> get users {
+    final local$users = _instance.users;
+    return local$users == null
+        ? CopyWith$Input$GenUserInput.stub(_then(_instance))
+        : CopyWith$Input$GenUserInput(local$users, (e) => call(users: e));
+  }
+
+  CopyWith$Input$GenGroupsInput<TRes> get groups {
+    final local$groups = _instance.groups;
+    return local$groups == null
+        ? CopyWith$Input$GenGroupsInput.stub(_then(_instance))
+        : CopyWith$Input$GenGroupsInput(local$groups, (e) => call(groups: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$GenRequest<TRes>
+    implements CopyWith$Input$GenRequest<TRes> {
+  _CopyWithStubImpl$Input$GenRequest(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? clearDb,
+    int? conversationCount,
+    int? messageCount,
+    Input$GenUserInput? users,
+    Input$GenGroupsInput? groups,
+    bool? publishAppEvents,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+  CopyWith$Input$GenUserInput<TRes> get users =>
+      CopyWith$Input$GenUserInput.stub(_res);
+  CopyWith$Input$GenGroupsInput<TRes> get groups =>
+      CopyWith$Input$GenGroupsInput.stub(_res);
+}
+
+class Input$GenUserInput {
+  factory Input$GenUserInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    int? dualRoleCount,
+    String? emailDomain,
+    String? emailPrefix,
+    int? mentorCount,
+    int? menteeCount,
+    double? mentorRatio,
+  }) =>
+      Input$GenUserInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (count != null) r'count': count,
+        if (dualRoleCount != null) r'dualRoleCount': dualRoleCount,
+        if (emailDomain != null) r'emailDomain': emailDomain,
+        if (emailPrefix != null) r'emailPrefix': emailPrefix,
+        if (mentorCount != null) r'mentorCount': mentorCount,
+        if (menteeCount != null) r'menteeCount': menteeCount,
+        if (mentorRatio != null) r'mentorRatio': mentorRatio,
+      });
+
+  Input$GenUserInput._(this._$data);
+
+  factory Input$GenUserInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('count')) {
+      final l$count = data['count'];
+      result$data['count'] = (l$count as int);
+    }
+    if (data.containsKey('dualRoleCount')) {
+      final l$dualRoleCount = data['dualRoleCount'];
+      result$data['dualRoleCount'] = (l$dualRoleCount as int?);
+    }
+    if (data.containsKey('emailDomain')) {
+      final l$emailDomain = data['emailDomain'];
+      result$data['emailDomain'] = (l$emailDomain as String);
+    }
+    if (data.containsKey('emailPrefix')) {
+      final l$emailPrefix = data['emailPrefix'];
+      result$data['emailPrefix'] = (l$emailPrefix as String?);
+    }
+    if (data.containsKey('mentorCount')) {
+      final l$mentorCount = data['mentorCount'];
+      result$data['mentorCount'] = (l$mentorCount as int?);
+    }
+    if (data.containsKey('menteeCount')) {
+      final l$menteeCount = data['menteeCount'];
+      result$data['menteeCount'] = (l$menteeCount as int?);
+    }
+    if (data.containsKey('mentorRatio')) {
+      final l$mentorRatio = data['mentorRatio'];
+      result$data['mentorRatio'] = (l$mentorRatio as num?)?.toDouble();
+    }
+    return Input$GenUserInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  int? get count => (_$data['count'] as int?);
+  int? get dualRoleCount => (_$data['dualRoleCount'] as int?);
+  String? get emailDomain => (_$data['emailDomain'] as String?);
+  String? get emailPrefix => (_$data['emailPrefix'] as String?);
+  int? get mentorCount => (_$data['mentorCount'] as int?);
+  int? get menteeCount => (_$data['menteeCount'] as int?);
+  double? get mentorRatio => (_$data['mentorRatio'] as double?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('count')) {
+      final l$count = count;
+      result$data['count'] = (l$count as int);
+    }
+    if (_$data.containsKey('dualRoleCount')) {
+      final l$dualRoleCount = dualRoleCount;
+      result$data['dualRoleCount'] = l$dualRoleCount;
+    }
+    if (_$data.containsKey('emailDomain')) {
+      final l$emailDomain = emailDomain;
+      result$data['emailDomain'] = (l$emailDomain as String);
+    }
+    if (_$data.containsKey('emailPrefix')) {
+      final l$emailPrefix = emailPrefix;
+      result$data['emailPrefix'] = l$emailPrefix;
+    }
+    if (_$data.containsKey('mentorCount')) {
+      final l$mentorCount = mentorCount;
+      result$data['mentorCount'] = l$mentorCount;
+    }
+    if (_$data.containsKey('menteeCount')) {
+      final l$menteeCount = menteeCount;
+      result$data['menteeCount'] = l$menteeCount;
+    }
+    if (_$data.containsKey('mentorRatio')) {
+      final l$mentorRatio = mentorRatio;
+      result$data['mentorRatio'] = l$mentorRatio;
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenUserInput<Input$GenUserInput> get copyWith =>
+      CopyWith$Input$GenUserInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenUserInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$count = count;
+    final lOther$count = other.count;
+    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
+      return false;
+    }
+    if (l$count != lOther$count) {
+      return false;
+    }
+    final l$dualRoleCount = dualRoleCount;
+    final lOther$dualRoleCount = other.dualRoleCount;
+    if (_$data.containsKey('dualRoleCount') !=
+        other._$data.containsKey('dualRoleCount')) {
+      return false;
+    }
+    if (l$dualRoleCount != lOther$dualRoleCount) {
+      return false;
+    }
+    final l$emailDomain = emailDomain;
+    final lOther$emailDomain = other.emailDomain;
+    if (_$data.containsKey('emailDomain') !=
+        other._$data.containsKey('emailDomain')) {
+      return false;
+    }
+    if (l$emailDomain != lOther$emailDomain) {
+      return false;
+    }
+    final l$emailPrefix = emailPrefix;
+    final lOther$emailPrefix = other.emailPrefix;
+    if (_$data.containsKey('emailPrefix') !=
+        other._$data.containsKey('emailPrefix')) {
+      return false;
+    }
+    if (l$emailPrefix != lOther$emailPrefix) {
+      return false;
+    }
+    final l$mentorCount = mentorCount;
+    final lOther$mentorCount = other.mentorCount;
+    if (_$data.containsKey('mentorCount') !=
+        other._$data.containsKey('mentorCount')) {
+      return false;
+    }
+    if (l$mentorCount != lOther$mentorCount) {
+      return false;
+    }
+    final l$menteeCount = menteeCount;
+    final lOther$menteeCount = other.menteeCount;
+    if (_$data.containsKey('menteeCount') !=
+        other._$data.containsKey('menteeCount')) {
+      return false;
+    }
+    if (l$menteeCount != lOther$menteeCount) {
+      return false;
+    }
+    final l$mentorRatio = mentorRatio;
+    final lOther$mentorRatio = other.mentorRatio;
+    if (_$data.containsKey('mentorRatio') !=
+        other._$data.containsKey('mentorRatio')) {
+      return false;
+    }
+    if (l$mentorRatio != lOther$mentorRatio) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$count = count;
+    final l$dualRoleCount = dualRoleCount;
+    final l$emailDomain = emailDomain;
+    final l$emailPrefix = emailPrefix;
+    final l$mentorCount = mentorCount;
+    final l$menteeCount = menteeCount;
+    final l$mentorRatio = mentorRatio;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('count') ? l$count : const {},
+      _$data.containsKey('dualRoleCount') ? l$dualRoleCount : const {},
+      _$data.containsKey('emailDomain') ? l$emailDomain : const {},
+      _$data.containsKey('emailPrefix') ? l$emailPrefix : const {},
+      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
+      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
+      _$data.containsKey('mentorRatio') ? l$mentorRatio : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenUserInput<TRes> {
+  factory CopyWith$Input$GenUserInput(
+    Input$GenUserInput instance,
+    TRes Function(Input$GenUserInput) then,
+  ) = _CopyWithImpl$Input$GenUserInput;
+
+  factory CopyWith$Input$GenUserInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenUserInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    int? dualRoleCount,
+    String? emailDomain,
+    String? emailPrefix,
+    int? mentorCount,
+    int? menteeCount,
+    double? mentorRatio,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+}
+
+class _CopyWithImpl$Input$GenUserInput<TRes>
+    implements CopyWith$Input$GenUserInput<TRes> {
+  _CopyWithImpl$Input$GenUserInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenUserInput _instance;
+
+  final TRes Function(Input$GenUserInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? count = _undefined,
+    Object? dualRoleCount = _undefined,
+    Object? emailDomain = _undefined,
+    Object? emailPrefix = _undefined,
+    Object? mentorCount = _undefined,
+    Object? menteeCount = _undefined,
+    Object? mentorRatio = _undefined,
+  }) =>
+      _then(Input$GenUserInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (count != _undefined && count != null) 'count': (count as int),
+        if (dualRoleCount != _undefined)
+          'dualRoleCount': (dualRoleCount as int?),
+        if (emailDomain != _undefined && emailDomain != null)
+          'emailDomain': (emailDomain as String),
+        if (emailPrefix != _undefined) 'emailPrefix': (emailPrefix as String?),
+        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
+        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
+        if (mentorRatio != _undefined) 'mentorRatio': (mentorRatio as double?),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$GenUserInput<TRes>
+    implements CopyWith$Input$GenUserInput<TRes> {
+  _CopyWithStubImpl$Input$GenUserInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    int? dualRoleCount,
+    String? emailDomain,
+    String? emailPrefix,
+    int? mentorCount,
+    int? menteeCount,
+    double? mentorRatio,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+}
+
+class Input$GenGroupsInput {
+  factory Input$GenGroupsInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    List<Input$GenSpecificGroupInput>? specificGroups,
+  }) =>
+      Input$GenGroupsInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (count != null) r'count': count,
+        if (specificGroups != null) r'specificGroups': specificGroups,
+      });
+
+  Input$GenGroupsInput._(this._$data);
+
+  factory Input$GenGroupsInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('count')) {
+      final l$count = data['count'];
+      result$data['count'] = (l$count as int);
+    }
+    if (data.containsKey('specificGroups')) {
+      final l$specificGroups = data['specificGroups'];
+      result$data['specificGroups'] = (l$specificGroups as List<dynamic>)
+          .map((e) =>
+              Input$GenSpecificGroupInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    return Input$GenGroupsInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  int? get count => (_$data['count'] as int?);
+  List<Input$GenSpecificGroupInput>? get specificGroups =>
+      (_$data['specificGroups'] as List<Input$GenSpecificGroupInput>?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('count')) {
+      final l$count = count;
+      result$data['count'] = (l$count as int);
+    }
+    if (_$data.containsKey('specificGroups')) {
+      final l$specificGroups = specificGroups;
+      result$data['specificGroups'] =
+          (l$specificGroups as List<Input$GenSpecificGroupInput>)
+              .map((e) => e.toJson())
+              .toList();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenGroupsInput<Input$GenGroupsInput> get copyWith =>
+      CopyWith$Input$GenGroupsInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenGroupsInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$count = count;
+    final lOther$count = other.count;
+    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
+      return false;
+    }
+    if (l$count != lOther$count) {
+      return false;
+    }
+    final l$specificGroups = specificGroups;
+    final lOther$specificGroups = other.specificGroups;
+    if (_$data.containsKey('specificGroups') !=
+        other._$data.containsKey('specificGroups')) {
+      return false;
+    }
+    if (l$specificGroups != null && lOther$specificGroups != null) {
+      if (l$specificGroups.length != lOther$specificGroups.length) {
+        return false;
+      }
+      for (int i = 0; i < l$specificGroups.length; i++) {
+        final l$specificGroups$entry = l$specificGroups[i];
+        final lOther$specificGroups$entry = lOther$specificGroups[i];
+        if (l$specificGroups$entry != lOther$specificGroups$entry) {
+          return false;
+        }
+      }
+    } else if (l$specificGroups != lOther$specificGroups) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$count = count;
+    final l$specificGroups = specificGroups;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('count') ? l$count : const {},
+      _$data.containsKey('specificGroups')
+          ? l$specificGroups == null
+              ? null
+              : Object.hashAll(l$specificGroups.map((v) => v))
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenGroupsInput<TRes> {
+  factory CopyWith$Input$GenGroupsInput(
+    Input$GenGroupsInput instance,
+    TRes Function(Input$GenGroupsInput) then,
+  ) = _CopyWithImpl$Input$GenGroupsInput;
+
+  factory CopyWith$Input$GenGroupsInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenGroupsInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    List<Input$GenSpecificGroupInput>? specificGroups,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+  TRes specificGroups(
+      Iterable<Input$GenSpecificGroupInput> Function(
+              Iterable<
+                  CopyWith$Input$GenSpecificGroupInput<
+                      Input$GenSpecificGroupInput>>)
+          _fn);
+}
+
+class _CopyWithImpl$Input$GenGroupsInput<TRes>
+    implements CopyWith$Input$GenGroupsInput<TRes> {
+  _CopyWithImpl$Input$GenGroupsInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenGroupsInput _instance;
+
+  final TRes Function(Input$GenGroupsInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? count = _undefined,
+    Object? specificGroups = _undefined,
+  }) =>
+      _then(Input$GenGroupsInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (count != _undefined && count != null) 'count': (count as int),
+        if (specificGroups != _undefined && specificGroups != null)
+          'specificGroups':
+              (specificGroups as List<Input$GenSpecificGroupInput>),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+
+  TRes specificGroups(
+          Iterable<Input$GenSpecificGroupInput> Function(
+                  Iterable<
+                      CopyWith$Input$GenSpecificGroupInput<
+                          Input$GenSpecificGroupInput>>)
+              _fn) =>
+      call(
+          specificGroups: _fn((_instance.specificGroups ?? [])
+              .map((e) => CopyWith$Input$GenSpecificGroupInput(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Input$GenGroupsInput<TRes>
+    implements CopyWith$Input$GenGroupsInput<TRes> {
+  _CopyWithStubImpl$Input$GenGroupsInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    int? count,
+    List<Input$GenSpecificGroupInput>? specificGroups,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+  specificGroups(_fn) => _res;
+}
+
+class Input$GenSpecificGroupInput {
+  factory Input$GenSpecificGroupInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? name,
+    int? mentorCount,
+    int? menteeCount,
+    List<Input$GenGroupRuleInput>? groupRules,
+    Input$GenMatchingEngineInput? matchingEngine,
+  }) =>
+      Input$GenSpecificGroupInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (name != null) r'name': name,
+        if (mentorCount != null) r'mentorCount': mentorCount,
+        if (menteeCount != null) r'menteeCount': menteeCount,
+        if (groupRules != null) r'groupRules': groupRules,
+        if (matchingEngine != null) r'matchingEngine': matchingEngine,
+      });
+
+  Input$GenSpecificGroupInput._(this._$data);
+
+  factory Input$GenSpecificGroupInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('name')) {
+      final l$name = data['name'];
+      result$data['name'] = (l$name as String);
+    }
+    if (data.containsKey('mentorCount')) {
+      final l$mentorCount = data['mentorCount'];
+      result$data['mentorCount'] = (l$mentorCount as int?);
+    }
+    if (data.containsKey('menteeCount')) {
+      final l$menteeCount = data['menteeCount'];
+      result$data['menteeCount'] = (l$menteeCount as int?);
+    }
+    if (data.containsKey('groupRules')) {
+      final l$groupRules = data['groupRules'];
+      result$data['groupRules'] = (l$groupRules as List<dynamic>?)
+          ?.map((e) =>
+              Input$GenGroupRuleInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('matchingEngine')) {
+      final l$matchingEngine = data['matchingEngine'];
+      result$data['matchingEngine'] = l$matchingEngine == null
+          ? null
+          : Input$GenMatchingEngineInput.fromJson(
+              (l$matchingEngine as Map<String, dynamic>));
+    }
+    return Input$GenSpecificGroupInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  String? get name => (_$data['name'] as String?);
+  int? get mentorCount => (_$data['mentorCount'] as int?);
+  int? get menteeCount => (_$data['menteeCount'] as int?);
+  List<Input$GenGroupRuleInput>? get groupRules =>
+      (_$data['groupRules'] as List<Input$GenGroupRuleInput>?);
+  Input$GenMatchingEngineInput? get matchingEngine =>
+      (_$data['matchingEngine'] as Input$GenMatchingEngineInput?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('name')) {
+      final l$name = name;
+      result$data['name'] = (l$name as String);
+    }
+    if (_$data.containsKey('mentorCount')) {
+      final l$mentorCount = mentorCount;
+      result$data['mentorCount'] = l$mentorCount;
+    }
+    if (_$data.containsKey('menteeCount')) {
+      final l$menteeCount = menteeCount;
+      result$data['menteeCount'] = l$menteeCount;
+    }
+    if (_$data.containsKey('groupRules')) {
+      final l$groupRules = groupRules;
+      result$data['groupRules'] = l$groupRules?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('matchingEngine')) {
+      final l$matchingEngine = matchingEngine;
+      result$data['matchingEngine'] = l$matchingEngine?.toJson();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenSpecificGroupInput<Input$GenSpecificGroupInput>
+      get copyWith => CopyWith$Input$GenSpecificGroupInput(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenSpecificGroupInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (_$data.containsKey('name') != other._$data.containsKey('name')) {
+      return false;
+    }
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$mentorCount = mentorCount;
+    final lOther$mentorCount = other.mentorCount;
+    if (_$data.containsKey('mentorCount') !=
+        other._$data.containsKey('mentorCount')) {
+      return false;
+    }
+    if (l$mentorCount != lOther$mentorCount) {
+      return false;
+    }
+    final l$menteeCount = menteeCount;
+    final lOther$menteeCount = other.menteeCount;
+    if (_$data.containsKey('menteeCount') !=
+        other._$data.containsKey('menteeCount')) {
+      return false;
+    }
+    if (l$menteeCount != lOther$menteeCount) {
+      return false;
+    }
+    final l$groupRules = groupRules;
+    final lOther$groupRules = other.groupRules;
+    if (_$data.containsKey('groupRules') !=
+        other._$data.containsKey('groupRules')) {
+      return false;
+    }
+    if (l$groupRules != null && lOther$groupRules != null) {
+      if (l$groupRules.length != lOther$groupRules.length) {
+        return false;
+      }
+      for (int i = 0; i < l$groupRules.length; i++) {
+        final l$groupRules$entry = l$groupRules[i];
+        final lOther$groupRules$entry = lOther$groupRules[i];
+        if (l$groupRules$entry != lOther$groupRules$entry) {
+          return false;
+        }
+      }
+    } else if (l$groupRules != lOther$groupRules) {
+      return false;
+    }
+    final l$matchingEngine = matchingEngine;
+    final lOther$matchingEngine = other.matchingEngine;
+    if (_$data.containsKey('matchingEngine') !=
+        other._$data.containsKey('matchingEngine')) {
+      return false;
+    }
+    if (l$matchingEngine != lOther$matchingEngine) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$name = name;
+    final l$mentorCount = mentorCount;
+    final l$menteeCount = menteeCount;
+    final l$groupRules = groupRules;
+    final l$matchingEngine = matchingEngine;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('name') ? l$name : const {},
+      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
+      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
+      _$data.containsKey('groupRules')
+          ? l$groupRules == null
+              ? null
+              : Object.hashAll(l$groupRules.map((v) => v))
+          : const {},
+      _$data.containsKey('matchingEngine') ? l$matchingEngine : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenSpecificGroupInput<TRes> {
+  factory CopyWith$Input$GenSpecificGroupInput(
+    Input$GenSpecificGroupInput instance,
+    TRes Function(Input$GenSpecificGroupInput) then,
+  ) = _CopyWithImpl$Input$GenSpecificGroupInput;
+
+  factory CopyWith$Input$GenSpecificGroupInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenSpecificGroupInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? name,
+    int? mentorCount,
+    int? menteeCount,
+    List<Input$GenGroupRuleInput>? groupRules,
+    Input$GenMatchingEngineInput? matchingEngine,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+  TRes groupRules(
+      Iterable<Input$GenGroupRuleInput>? Function(
+              Iterable<
+                  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput>>?)
+          _fn);
+  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine;
+}
+
+class _CopyWithImpl$Input$GenSpecificGroupInput<TRes>
+    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
+  _CopyWithImpl$Input$GenSpecificGroupInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenSpecificGroupInput _instance;
+
+  final TRes Function(Input$GenSpecificGroupInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? name = _undefined,
+    Object? mentorCount = _undefined,
+    Object? menteeCount = _undefined,
+    Object? groupRules = _undefined,
+    Object? matchingEngine = _undefined,
+  }) =>
+      _then(Input$GenSpecificGroupInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (name != _undefined && name != null) 'name': (name as String),
+        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
+        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
+        if (groupRules != _undefined)
+          'groupRules': (groupRules as List<Input$GenGroupRuleInput>?),
+        if (matchingEngine != _undefined)
+          'matchingEngine': (matchingEngine as Input$GenMatchingEngineInput?),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+
+  TRes groupRules(
+          Iterable<Input$GenGroupRuleInput>? Function(
+                  Iterable<
+                      CopyWith$Input$GenGroupRuleInput<
+                          Input$GenGroupRuleInput>>?)
+              _fn) =>
+      call(
+          groupRules: _fn(
+              _instance.groupRules?.map((e) => CopyWith$Input$GenGroupRuleInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine {
+    final local$matchingEngine = _instance.matchingEngine;
+    return local$matchingEngine == null
+        ? CopyWith$Input$GenMatchingEngineInput.stub(_then(_instance))
+        : CopyWith$Input$GenMatchingEngineInput(
+            local$matchingEngine, (e) => call(matchingEngine: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$GenSpecificGroupInput<TRes>
+    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
+  _CopyWithStubImpl$Input$GenSpecificGroupInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? name,
+    int? mentorCount,
+    int? menteeCount,
+    List<Input$GenGroupRuleInput>? groupRules,
+    Input$GenMatchingEngineInput? matchingEngine,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+  groupRules(_fn) => _res;
+  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine =>
+      CopyWith$Input$GenMatchingEngineInput.stub(_res);
+}
+
+class Input$GenGroupRuleInput {
+  factory Input$GenGroupRuleInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someGroupRule,
+    bool? someOtherGroupRule,
+  }) =>
+      Input$GenGroupRuleInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (someGroupRule != null) r'someGroupRule': someGroupRule,
+        if (someOtherGroupRule != null)
+          r'someOtherGroupRule': someOtherGroupRule,
+      });
+
+  Input$GenGroupRuleInput._(this._$data);
+
+  factory Input$GenGroupRuleInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('someGroupRule')) {
+      final l$someGroupRule = data['someGroupRule'];
+      result$data['someGroupRule'] = (l$someGroupRule as bool);
+    }
+    if (data.containsKey('someOtherGroupRule')) {
+      final l$someOtherGroupRule = data['someOtherGroupRule'];
+      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
+    }
+    return Input$GenGroupRuleInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  bool? get someGroupRule => (_$data['someGroupRule'] as bool?);
+  bool? get someOtherGroupRule => (_$data['someOtherGroupRule'] as bool?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('someGroupRule')) {
+      final l$someGroupRule = someGroupRule;
+      result$data['someGroupRule'] = (l$someGroupRule as bool);
+    }
+    if (_$data.containsKey('someOtherGroupRule')) {
+      final l$someOtherGroupRule = someOtherGroupRule;
+      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput> get copyWith =>
+      CopyWith$Input$GenGroupRuleInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenGroupRuleInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$someGroupRule = someGroupRule;
+    final lOther$someGroupRule = other.someGroupRule;
+    if (_$data.containsKey('someGroupRule') !=
+        other._$data.containsKey('someGroupRule')) {
+      return false;
+    }
+    if (l$someGroupRule != lOther$someGroupRule) {
+      return false;
+    }
+    final l$someOtherGroupRule = someOtherGroupRule;
+    final lOther$someOtherGroupRule = other.someOtherGroupRule;
+    if (_$data.containsKey('someOtherGroupRule') !=
+        other._$data.containsKey('someOtherGroupRule')) {
+      return false;
+    }
+    if (l$someOtherGroupRule != lOther$someOtherGroupRule) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$someGroupRule = someGroupRule;
+    final l$someOtherGroupRule = someOtherGroupRule;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('someGroupRule') ? l$someGroupRule : const {},
+      _$data.containsKey('someOtherGroupRule')
+          ? l$someOtherGroupRule
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenGroupRuleInput<TRes> {
+  factory CopyWith$Input$GenGroupRuleInput(
+    Input$GenGroupRuleInput instance,
+    TRes Function(Input$GenGroupRuleInput) then,
+  ) = _CopyWithImpl$Input$GenGroupRuleInput;
+
+  factory CopyWith$Input$GenGroupRuleInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenGroupRuleInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someGroupRule,
+    bool? someOtherGroupRule,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+}
+
+class _CopyWithImpl$Input$GenGroupRuleInput<TRes>
+    implements CopyWith$Input$GenGroupRuleInput<TRes> {
+  _CopyWithImpl$Input$GenGroupRuleInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenGroupRuleInput _instance;
+
+  final TRes Function(Input$GenGroupRuleInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? someGroupRule = _undefined,
+    Object? someOtherGroupRule = _undefined,
+  }) =>
+      _then(Input$GenGroupRuleInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (someGroupRule != _undefined && someGroupRule != null)
+          'someGroupRule': (someGroupRule as bool),
+        if (someOtherGroupRule != _undefined && someOtherGroupRule != null)
+          'someOtherGroupRule': (someOtherGroupRule as bool),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$GenGroupRuleInput<TRes>
+    implements CopyWith$Input$GenGroupRuleInput<TRes> {
+  _CopyWithStubImpl$Input$GenGroupRuleInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someGroupRule,
+    bool? someOtherGroupRule,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+}
+
+class Input$GenMatchingEngineInput {
+  factory Input$GenMatchingEngineInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someMatchingRule,
+    bool? someOtherMatchingRule,
+  }) =>
+      Input$GenMatchingEngineInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (someMatchingRule != null) r'someMatchingRule': someMatchingRule,
+        if (someOtherMatchingRule != null)
+          r'someOtherMatchingRule': someOtherMatchingRule,
+      });
+
+  Input$GenMatchingEngineInput._(this._$data);
+
+  factory Input$GenMatchingEngineInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('someMatchingRule')) {
+      final l$someMatchingRule = data['someMatchingRule'];
+      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
+    }
+    if (data.containsKey('someOtherMatchingRule')) {
+      final l$someOtherMatchingRule = data['someOtherMatchingRule'];
+      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
+    }
+    return Input$GenMatchingEngineInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  bool? get someMatchingRule => (_$data['someMatchingRule'] as bool?);
+  bool? get someOtherMatchingRule => (_$data['someOtherMatchingRule'] as bool?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('someMatchingRule')) {
+      final l$someMatchingRule = someMatchingRule;
+      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
+    }
+    if (_$data.containsKey('someOtherMatchingRule')) {
+      final l$someOtherMatchingRule = someOtherMatchingRule;
+      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$GenMatchingEngineInput<Input$GenMatchingEngineInput>
+      get copyWith => CopyWith$Input$GenMatchingEngineInput(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$GenMatchingEngineInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$someMatchingRule = someMatchingRule;
+    final lOther$someMatchingRule = other.someMatchingRule;
+    if (_$data.containsKey('someMatchingRule') !=
+        other._$data.containsKey('someMatchingRule')) {
+      return false;
+    }
+    if (l$someMatchingRule != lOther$someMatchingRule) {
+      return false;
+    }
+    final l$someOtherMatchingRule = someOtherMatchingRule;
+    final lOther$someOtherMatchingRule = other.someOtherMatchingRule;
+    if (_$data.containsKey('someOtherMatchingRule') !=
+        other._$data.containsKey('someOtherMatchingRule')) {
+      return false;
+    }
+    if (l$someOtherMatchingRule != lOther$someOtherMatchingRule) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$someMatchingRule = someMatchingRule;
+    final l$someOtherMatchingRule = someOtherMatchingRule;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('someMatchingRule') ? l$someMatchingRule : const {},
+      _$data.containsKey('someOtherMatchingRule')
+          ? l$someOtherMatchingRule
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$GenMatchingEngineInput<TRes> {
+  factory CopyWith$Input$GenMatchingEngineInput(
+    Input$GenMatchingEngineInput instance,
+    TRes Function(Input$GenMatchingEngineInput) then,
+  ) = _CopyWithImpl$Input$GenMatchingEngineInput;
+
+  factory CopyWith$Input$GenMatchingEngineInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$GenMatchingEngineInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someMatchingRule,
+    bool? someOtherMatchingRule,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+}
+
+class _CopyWithImpl$Input$GenMatchingEngineInput<TRes>
+    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
+  _CopyWithImpl$Input$GenMatchingEngineInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$GenMatchingEngineInput _instance;
+
+  final TRes Function(Input$GenMatchingEngineInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? someMatchingRule = _undefined,
+    Object? someOtherMatchingRule = _undefined,
+  }) =>
+      _then(Input$GenMatchingEngineInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (someMatchingRule != _undefined && someMatchingRule != null)
+          'someMatchingRule': (someMatchingRule as bool),
+        if (someOtherMatchingRule != _undefined &&
+            someOtherMatchingRule != null)
+          'someOtherMatchingRule': (someOtherMatchingRule as bool),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$GenMatchingEngineInput<TRes>
+    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
+  _CopyWithStubImpl$Input$GenMatchingEngineInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    bool? someMatchingRule,
+    bool? someOtherMatchingRule,
   }) =>
       _res;
   events(_fn) => _res;
@@ -23413,16 +26801,18 @@ Enum$ProfileType fromJson$Enum$ProfileType(String value) {
   }
 }
 
-enum Enum$UserSearchFieldPreference { mustMatch, match, mustNotMatch, $unknown }
+enum Enum$UserSearchFieldPreference { isTrue, isFalse, any, match, $unknown }
 
 String toJson$Enum$UserSearchFieldPreference(Enum$UserSearchFieldPreference e) {
   switch (e) {
-    case Enum$UserSearchFieldPreference.mustMatch:
-      return r'mustMatch';
+    case Enum$UserSearchFieldPreference.isTrue:
+      return r'isTrue';
+    case Enum$UserSearchFieldPreference.isFalse:
+      return r'isFalse';
+    case Enum$UserSearchFieldPreference.any:
+      return r'any';
     case Enum$UserSearchFieldPreference.match:
       return r'match';
-    case Enum$UserSearchFieldPreference.mustNotMatch:
-      return r'mustNotMatch';
     case Enum$UserSearchFieldPreference.$unknown:
       return r'$unknown';
   }
@@ -23431,12 +26821,14 @@ String toJson$Enum$UserSearchFieldPreference(Enum$UserSearchFieldPreference e) {
 Enum$UserSearchFieldPreference fromJson$Enum$UserSearchFieldPreference(
     String value) {
   switch (value) {
-    case r'mustMatch':
-      return Enum$UserSearchFieldPreference.mustMatch;
+    case r'isTrue':
+      return Enum$UserSearchFieldPreference.isTrue;
+    case r'isFalse':
+      return Enum$UserSearchFieldPreference.isFalse;
+    case r'any':
+      return Enum$UserSearchFieldPreference.any;
     case r'match':
       return Enum$UserSearchFieldPreference.match;
-    case r'mustNotMatch':
-      return Enum$UserSearchFieldPreference.mustNotMatch;
     default:
       return Enum$UserSearchFieldPreference.$unknown;
   }

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -919,12 +919,19 @@ class Input$UserInput {
     String? genderSelfDescribed,
     String? ethnicity,
     String? educationLevelTextId,
-    String? professionalBackground,
+    String? personalBio,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
-    String? oneLiner,
+    List<String>? pronounsTextIds,
     Input$CompanyInput? company,
+    List<Input$BusinessExperienceInput>? businessExperiences,
+    List<Input$AcademicExperienceInput>? academicExperiences,
+    List<String>? businessExperienceIds,
+    List<String>? academicExperienceIds,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
   }) =>
       Input$UserInput._({
         if (id != null) r'id': id,
@@ -996,15 +1003,26 @@ class Input$UserInput {
         if (ethnicity != null) r'ethnicity': ethnicity,
         if (educationLevelTextId != null)
           r'educationLevelTextId': educationLevelTextId,
-        if (professionalBackground != null)
-          r'professionalBackground': professionalBackground,
+        if (personalBio != null) r'personalBio': personalBio,
         if (yearsManagementExperience != null)
           r'yearsManagementExperience': yearsManagementExperience,
         if (yearsOwnershipExperience != null)
           r'yearsOwnershipExperience': yearsOwnershipExperience,
         if (ssoIdp != null) r'ssoIdp': ssoIdp,
-        if (oneLiner != null) r'oneLiner': oneLiner,
+        if (pronounsTextIds != null) r'pronounsTextIds': pronounsTextIds,
         if (company != null) r'company': company,
+        if (businessExperiences != null)
+          r'businessExperiences': businessExperiences,
+        if (academicExperiences != null)
+          r'academicExperiences': academicExperiences,
+        if (businessExperienceIds != null)
+          r'businessExperienceIds': businessExperienceIds,
+        if (academicExperienceIds != null)
+          r'academicExperienceIds': academicExperienceIds,
+        if (cityOfOrigin != null) r'cityOfOrigin': cityOfOrigin,
+        if (regionOfOrigin != null) r'regionOfOrigin': regionOfOrigin,
+        if (countryOfOriginTextId != null)
+          r'countryOfOriginTextId': countryOfOriginTextId,
       });
 
   Input$UserInput._(this._$data);
@@ -1305,10 +1323,9 @@ class Input$UserInput {
       final l$educationLevelTextId = data['educationLevelTextId'];
       result$data['educationLevelTextId'] = (l$educationLevelTextId as String?);
     }
-    if (data.containsKey('professionalBackground')) {
-      final l$professionalBackground = data['professionalBackground'];
-      result$data['professionalBackground'] =
-          (l$professionalBackground as String?);
+    if (data.containsKey('personalBio')) {
+      final l$personalBio = data['personalBio'];
+      result$data['personalBio'] = (l$personalBio as String?);
     }
     if (data.containsKey('yearsManagementExperience')) {
       final l$yearsManagementExperience = data['yearsManagementExperience'];
@@ -1324,15 +1341,60 @@ class Input$UserInput {
       final l$ssoIdp = data['ssoIdp'];
       result$data['ssoIdp'] = (l$ssoIdp as String?);
     }
-    if (data.containsKey('oneLiner')) {
-      final l$oneLiner = data['oneLiner'];
-      result$data['oneLiner'] = (l$oneLiner as String?);
+    if (data.containsKey('pronounsTextIds')) {
+      final l$pronounsTextIds = data['pronounsTextIds'];
+      result$data['pronounsTextIds'] = (l$pronounsTextIds as List<dynamic>?)
+          ?.map((e) => (e as String))
+          .toList();
     }
     if (data.containsKey('company')) {
       final l$company = data['company'];
       result$data['company'] = l$company == null
           ? null
           : Input$CompanyInput.fromJson((l$company as Map<String, dynamic>));
+    }
+    if (data.containsKey('businessExperiences')) {
+      final l$businessExperiences = data['businessExperiences'];
+      result$data['businessExperiences'] =
+          (l$businessExperiences as List<dynamic>?)
+              ?.map((e) => Input$BusinessExperienceInput.fromJson(
+                  (e as Map<String, dynamic>)))
+              .toList();
+    }
+    if (data.containsKey('academicExperiences')) {
+      final l$academicExperiences = data['academicExperiences'];
+      result$data['academicExperiences'] =
+          (l$academicExperiences as List<dynamic>?)
+              ?.map((e) => Input$AcademicExperienceInput.fromJson(
+                  (e as Map<String, dynamic>)))
+              .toList();
+    }
+    if (data.containsKey('businessExperienceIds')) {
+      final l$businessExperienceIds = data['businessExperienceIds'];
+      result$data['businessExperienceIds'] =
+          (l$businessExperienceIds as List<dynamic>?)
+              ?.map((e) => (e as String))
+              .toList();
+    }
+    if (data.containsKey('academicExperienceIds')) {
+      final l$academicExperienceIds = data['academicExperienceIds'];
+      result$data['academicExperienceIds'] =
+          (l$academicExperienceIds as List<dynamic>?)
+              ?.map((e) => (e as String))
+              .toList();
+    }
+    if (data.containsKey('cityOfOrigin')) {
+      final l$cityOfOrigin = data['cityOfOrigin'];
+      result$data['cityOfOrigin'] = (l$cityOfOrigin as String?);
+    }
+    if (data.containsKey('regionOfOrigin')) {
+      final l$regionOfOrigin = data['regionOfOrigin'];
+      result$data['regionOfOrigin'] = (l$regionOfOrigin as String?);
+    }
+    if (data.containsKey('countryOfOriginTextId')) {
+      final l$countryOfOriginTextId = data['countryOfOriginTextId'];
+      result$data['countryOfOriginTextId'] =
+          (l$countryOfOriginTextId as String?);
     }
     return Input$UserInput._(result$data);
   }
@@ -1414,15 +1476,27 @@ class Input$UserInput {
   String? get ethnicity => (_$data['ethnicity'] as String?);
   String? get educationLevelTextId =>
       (_$data['educationLevelTextId'] as String?);
-  String? get professionalBackground =>
-      (_$data['professionalBackground'] as String?);
+  String? get personalBio => (_$data['personalBio'] as String?);
   int? get yearsManagementExperience =>
       (_$data['yearsManagementExperience'] as int?);
   int? get yearsOwnershipExperience =>
       (_$data['yearsOwnershipExperience'] as int?);
   String? get ssoIdp => (_$data['ssoIdp'] as String?);
-  String? get oneLiner => (_$data['oneLiner'] as String?);
+  List<String>? get pronounsTextIds =>
+      (_$data['pronounsTextIds'] as List<String>?);
   Input$CompanyInput? get company => (_$data['company'] as Input$CompanyInput?);
+  List<Input$BusinessExperienceInput>? get businessExperiences =>
+      (_$data['businessExperiences'] as List<Input$BusinessExperienceInput>?);
+  List<Input$AcademicExperienceInput>? get academicExperiences =>
+      (_$data['academicExperiences'] as List<Input$AcademicExperienceInput>?);
+  List<String>? get businessExperienceIds =>
+      (_$data['businessExperienceIds'] as List<String>?);
+  List<String>? get academicExperienceIds =>
+      (_$data['academicExperienceIds'] as List<String>?);
+  String? get cityOfOrigin => (_$data['cityOfOrigin'] as String?);
+  String? get regionOfOrigin => (_$data['regionOfOrigin'] as String?);
+  String? get countryOfOriginTextId =>
+      (_$data['countryOfOriginTextId'] as String?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -1675,9 +1749,9 @@ class Input$UserInput {
       final l$educationLevelTextId = educationLevelTextId;
       result$data['educationLevelTextId'] = l$educationLevelTextId;
     }
-    if (_$data.containsKey('professionalBackground')) {
-      final l$professionalBackground = professionalBackground;
-      result$data['professionalBackground'] = l$professionalBackground;
+    if (_$data.containsKey('personalBio')) {
+      final l$personalBio = personalBio;
+      result$data['personalBio'] = l$personalBio;
     }
     if (_$data.containsKey('yearsManagementExperience')) {
       final l$yearsManagementExperience = yearsManagementExperience;
@@ -1691,13 +1765,46 @@ class Input$UserInput {
       final l$ssoIdp = ssoIdp;
       result$data['ssoIdp'] = l$ssoIdp;
     }
-    if (_$data.containsKey('oneLiner')) {
-      final l$oneLiner = oneLiner;
-      result$data['oneLiner'] = l$oneLiner;
+    if (_$data.containsKey('pronounsTextIds')) {
+      final l$pronounsTextIds = pronounsTextIds;
+      result$data['pronounsTextIds'] =
+          l$pronounsTextIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('company')) {
       final l$company = company;
       result$data['company'] = l$company?.toJson();
+    }
+    if (_$data.containsKey('businessExperiences')) {
+      final l$businessExperiences = businessExperiences;
+      result$data['businessExperiences'] =
+          l$businessExperiences?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('academicExperiences')) {
+      final l$academicExperiences = academicExperiences;
+      result$data['academicExperiences'] =
+          l$academicExperiences?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('businessExperienceIds')) {
+      final l$businessExperienceIds = businessExperienceIds;
+      result$data['businessExperienceIds'] =
+          l$businessExperienceIds?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('academicExperienceIds')) {
+      final l$academicExperienceIds = academicExperienceIds;
+      result$data['academicExperienceIds'] =
+          l$academicExperienceIds?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('cityOfOrigin')) {
+      final l$cityOfOrigin = cityOfOrigin;
+      result$data['cityOfOrigin'] = l$cityOfOrigin;
+    }
+    if (_$data.containsKey('regionOfOrigin')) {
+      final l$regionOfOrigin = regionOfOrigin;
+      result$data['regionOfOrigin'] = l$regionOfOrigin;
+    }
+    if (_$data.containsKey('countryOfOriginTextId')) {
+      final l$countryOfOriginTextId = countryOfOriginTextId;
+      result$data['countryOfOriginTextId'] = l$countryOfOriginTextId;
     }
     return result$data;
   }
@@ -2377,13 +2484,13 @@ class Input$UserInput {
     if (l$educationLevelTextId != lOther$educationLevelTextId) {
       return false;
     }
-    final l$professionalBackground = professionalBackground;
-    final lOther$professionalBackground = other.professionalBackground;
-    if (_$data.containsKey('professionalBackground') !=
-        other._$data.containsKey('professionalBackground')) {
+    final l$personalBio = personalBio;
+    final lOther$personalBio = other.personalBio;
+    if (_$data.containsKey('personalBio') !=
+        other._$data.containsKey('personalBio')) {
       return false;
     }
-    if (l$professionalBackground != lOther$professionalBackground) {
+    if (l$personalBio != lOther$personalBio) {
       return false;
     }
     final l$yearsManagementExperience = yearsManagementExperience;
@@ -2412,13 +2519,24 @@ class Input$UserInput {
     if (l$ssoIdp != lOther$ssoIdp) {
       return false;
     }
-    final l$oneLiner = oneLiner;
-    final lOther$oneLiner = other.oneLiner;
-    if (_$data.containsKey('oneLiner') !=
-        other._$data.containsKey('oneLiner')) {
+    final l$pronounsTextIds = pronounsTextIds;
+    final lOther$pronounsTextIds = other.pronounsTextIds;
+    if (_$data.containsKey('pronounsTextIds') !=
+        other._$data.containsKey('pronounsTextIds')) {
       return false;
     }
-    if (l$oneLiner != lOther$oneLiner) {
+    if (l$pronounsTextIds != null && lOther$pronounsTextIds != null) {
+      if (l$pronounsTextIds.length != lOther$pronounsTextIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$pronounsTextIds.length; i++) {
+        final l$pronounsTextIds$entry = l$pronounsTextIds[i];
+        final lOther$pronounsTextIds$entry = lOther$pronounsTextIds[i];
+        if (l$pronounsTextIds$entry != lOther$pronounsTextIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$pronounsTextIds != lOther$pronounsTextIds) {
       return false;
     }
     final l$company = company;
@@ -2427,6 +2545,121 @@ class Input$UserInput {
       return false;
     }
     if (l$company != lOther$company) {
+      return false;
+    }
+    final l$businessExperiences = businessExperiences;
+    final lOther$businessExperiences = other.businessExperiences;
+    if (_$data.containsKey('businessExperiences') !=
+        other._$data.containsKey('businessExperiences')) {
+      return false;
+    }
+    if (l$businessExperiences != null && lOther$businessExperiences != null) {
+      if (l$businessExperiences.length != lOther$businessExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$businessExperiences.length; i++) {
+        final l$businessExperiences$entry = l$businessExperiences[i];
+        final lOther$businessExperiences$entry = lOther$businessExperiences[i];
+        if (l$businessExperiences$entry != lOther$businessExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$businessExperiences != lOther$businessExperiences) {
+      return false;
+    }
+    final l$academicExperiences = academicExperiences;
+    final lOther$academicExperiences = other.academicExperiences;
+    if (_$data.containsKey('academicExperiences') !=
+        other._$data.containsKey('academicExperiences')) {
+      return false;
+    }
+    if (l$academicExperiences != null && lOther$academicExperiences != null) {
+      if (l$academicExperiences.length != lOther$academicExperiences.length) {
+        return false;
+      }
+      for (int i = 0; i < l$academicExperiences.length; i++) {
+        final l$academicExperiences$entry = l$academicExperiences[i];
+        final lOther$academicExperiences$entry = lOther$academicExperiences[i];
+        if (l$academicExperiences$entry != lOther$academicExperiences$entry) {
+          return false;
+        }
+      }
+    } else if (l$academicExperiences != lOther$academicExperiences) {
+      return false;
+    }
+    final l$businessExperienceIds = businessExperienceIds;
+    final lOther$businessExperienceIds = other.businessExperienceIds;
+    if (_$data.containsKey('businessExperienceIds') !=
+        other._$data.containsKey('businessExperienceIds')) {
+      return false;
+    }
+    if (l$businessExperienceIds != null &&
+        lOther$businessExperienceIds != null) {
+      if (l$businessExperienceIds.length !=
+          lOther$businessExperienceIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$businessExperienceIds.length; i++) {
+        final l$businessExperienceIds$entry = l$businessExperienceIds[i];
+        final lOther$businessExperienceIds$entry =
+            lOther$businessExperienceIds[i];
+        if (l$businessExperienceIds$entry !=
+            lOther$businessExperienceIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$businessExperienceIds != lOther$businessExperienceIds) {
+      return false;
+    }
+    final l$academicExperienceIds = academicExperienceIds;
+    final lOther$academicExperienceIds = other.academicExperienceIds;
+    if (_$data.containsKey('academicExperienceIds') !=
+        other._$data.containsKey('academicExperienceIds')) {
+      return false;
+    }
+    if (l$academicExperienceIds != null &&
+        lOther$academicExperienceIds != null) {
+      if (l$academicExperienceIds.length !=
+          lOther$academicExperienceIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$academicExperienceIds.length; i++) {
+        final l$academicExperienceIds$entry = l$academicExperienceIds[i];
+        final lOther$academicExperienceIds$entry =
+            lOther$academicExperienceIds[i];
+        if (l$academicExperienceIds$entry !=
+            lOther$academicExperienceIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$academicExperienceIds != lOther$academicExperienceIds) {
+      return false;
+    }
+    final l$cityOfOrigin = cityOfOrigin;
+    final lOther$cityOfOrigin = other.cityOfOrigin;
+    if (_$data.containsKey('cityOfOrigin') !=
+        other._$data.containsKey('cityOfOrigin')) {
+      return false;
+    }
+    if (l$cityOfOrigin != lOther$cityOfOrigin) {
+      return false;
+    }
+    final l$regionOfOrigin = regionOfOrigin;
+    final lOther$regionOfOrigin = other.regionOfOrigin;
+    if (_$data.containsKey('regionOfOrigin') !=
+        other._$data.containsKey('regionOfOrigin')) {
+      return false;
+    }
+    if (l$regionOfOrigin != lOther$regionOfOrigin) {
+      return false;
+    }
+    final l$countryOfOriginTextId = countryOfOriginTextId;
+    final lOther$countryOfOriginTextId = other.countryOfOriginTextId;
+    if (_$data.containsKey('countryOfOriginTextId') !=
+        other._$data.containsKey('countryOfOriginTextId')) {
+      return false;
+    }
+    if (l$countryOfOriginTextId != lOther$countryOfOriginTextId) {
       return false;
     }
     return true;
@@ -2493,12 +2726,19 @@ class Input$UserInput {
     final l$genderSelfDescribed = genderSelfDescribed;
     final l$ethnicity = ethnicity;
     final l$educationLevelTextId = educationLevelTextId;
-    final l$professionalBackground = professionalBackground;
+    final l$personalBio = personalBio;
     final l$yearsManagementExperience = yearsManagementExperience;
     final l$yearsOwnershipExperience = yearsOwnershipExperience;
     final l$ssoIdp = ssoIdp;
-    final l$oneLiner = oneLiner;
+    final l$pronounsTextIds = pronounsTextIds;
     final l$company = company;
+    final l$businessExperiences = businessExperiences;
+    final l$academicExperiences = academicExperiences;
+    final l$businessExperienceIds = businessExperienceIds;
+    final l$academicExperienceIds = academicExperienceIds;
+    final l$cityOfOrigin = cityOfOrigin;
+    final l$regionOfOrigin = regionOfOrigin;
+    final l$countryOfOriginTextId = countryOfOriginTextId;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -2623,9 +2863,7 @@ class Input$UserInput {
       _$data.containsKey('educationLevelTextId')
           ? l$educationLevelTextId
           : const {},
-      _$data.containsKey('professionalBackground')
-          ? l$professionalBackground
-          : const {},
+      _$data.containsKey('personalBio') ? l$personalBio : const {},
       _$data.containsKey('yearsManagementExperience')
           ? l$yearsManagementExperience
           : const {},
@@ -2633,8 +2871,37 @@ class Input$UserInput {
           ? l$yearsOwnershipExperience
           : const {},
       _$data.containsKey('ssoIdp') ? l$ssoIdp : const {},
-      _$data.containsKey('oneLiner') ? l$oneLiner : const {},
+      _$data.containsKey('pronounsTextIds')
+          ? l$pronounsTextIds == null
+              ? null
+              : Object.hashAll(l$pronounsTextIds.map((v) => v))
+          : const {},
       _$data.containsKey('company') ? l$company : const {},
+      _$data.containsKey('businessExperiences')
+          ? l$businessExperiences == null
+              ? null
+              : Object.hashAll(l$businessExperiences.map((v) => v))
+          : const {},
+      _$data.containsKey('academicExperiences')
+          ? l$academicExperiences == null
+              ? null
+              : Object.hashAll(l$academicExperiences.map((v) => v))
+          : const {},
+      _$data.containsKey('businessExperienceIds')
+          ? l$businessExperienceIds == null
+              ? null
+              : Object.hashAll(l$businessExperienceIds.map((v) => v))
+          : const {},
+      _$data.containsKey('academicExperienceIds')
+          ? l$academicExperienceIds == null
+              ? null
+              : Object.hashAll(l$academicExperienceIds.map((v) => v))
+          : const {},
+      _$data.containsKey('cityOfOrigin') ? l$cityOfOrigin : const {},
+      _$data.containsKey('regionOfOrigin') ? l$regionOfOrigin : const {},
+      _$data.containsKey('countryOfOriginTextId')
+          ? l$countryOfOriginTextId
+          : const {},
     ]);
   }
 }
@@ -2708,12 +2975,19 @@ abstract class CopyWith$Input$UserInput<TRes> {
     String? genderSelfDescribed,
     String? ethnicity,
     String? educationLevelTextId,
-    String? professionalBackground,
+    String? personalBio,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
-    String? oneLiner,
+    List<String>? pronounsTextIds,
     Input$CompanyInput? company,
+    List<Input$BusinessExperienceInput>? businessExperiences,
+    List<Input$AcademicExperienceInput>? academicExperiences,
+    List<String>? businessExperienceIds,
+    List<String>? academicExperienceIds,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -2734,6 +3008,18 @@ abstract class CopyWith$Input$UserInput<TRes> {
                       Input$GroupMembershipInput>>?)
           _fn);
   CopyWith$Input$CompanyInput<TRes> get company;
+  TRes businessExperiences(
+      Iterable<Input$BusinessExperienceInput>? Function(
+              Iterable<
+                  CopyWith$Input$BusinessExperienceInput<
+                      Input$BusinessExperienceInput>>?)
+          _fn);
+  TRes academicExperiences(
+      Iterable<Input$AcademicExperienceInput>? Function(
+              Iterable<
+                  CopyWith$Input$AcademicExperienceInput<
+                      Input$AcademicExperienceInput>>?)
+          _fn);
 }
 
 class _CopyWithImpl$Input$UserInput<TRes>
@@ -2809,12 +3095,19 @@ class _CopyWithImpl$Input$UserInput<TRes>
     Object? genderSelfDescribed = _undefined,
     Object? ethnicity = _undefined,
     Object? educationLevelTextId = _undefined,
-    Object? professionalBackground = _undefined,
+    Object? personalBio = _undefined,
     Object? yearsManagementExperience = _undefined,
     Object? yearsOwnershipExperience = _undefined,
     Object? ssoIdp = _undefined,
-    Object? oneLiner = _undefined,
+    Object? pronounsTextIds = _undefined,
     Object? company = _undefined,
+    Object? businessExperiences = _undefined,
+    Object? academicExperiences = _undefined,
+    Object? businessExperienceIds = _undefined,
+    Object? academicExperienceIds = _undefined,
+    Object? cityOfOrigin = _undefined,
+    Object? regionOfOrigin = _undefined,
+    Object? countryOfOriginTextId = _undefined,
   }) =>
       _then(Input$UserInput._({
         ..._instance._$data,
@@ -2910,15 +3203,31 @@ class _CopyWithImpl$Input$UserInput<TRes>
         if (ethnicity != _undefined) 'ethnicity': (ethnicity as String?),
         if (educationLevelTextId != _undefined)
           'educationLevelTextId': (educationLevelTextId as String?),
-        if (professionalBackground != _undefined)
-          'professionalBackground': (professionalBackground as String?),
+        if (personalBio != _undefined) 'personalBio': (personalBio as String?),
         if (yearsManagementExperience != _undefined)
           'yearsManagementExperience': (yearsManagementExperience as int?),
         if (yearsOwnershipExperience != _undefined)
           'yearsOwnershipExperience': (yearsOwnershipExperience as int?),
         if (ssoIdp != _undefined) 'ssoIdp': (ssoIdp as String?),
-        if (oneLiner != _undefined) 'oneLiner': (oneLiner as String?),
+        if (pronounsTextIds != _undefined)
+          'pronounsTextIds': (pronounsTextIds as List<String>?),
         if (company != _undefined) 'company': (company as Input$CompanyInput?),
+        if (businessExperiences != _undefined)
+          'businessExperiences':
+              (businessExperiences as List<Input$BusinessExperienceInput>?),
+        if (academicExperiences != _undefined)
+          'academicExperiences':
+              (academicExperiences as List<Input$AcademicExperienceInput>?),
+        if (businessExperienceIds != _undefined)
+          'businessExperienceIds': (businessExperienceIds as List<String>?),
+        if (academicExperienceIds != _undefined)
+          'academicExperienceIds': (academicExperienceIds as List<String>?),
+        if (cityOfOrigin != _undefined)
+          'cityOfOrigin': (cityOfOrigin as String?),
+        if (regionOfOrigin != _undefined)
+          'regionOfOrigin': (regionOfOrigin as String?),
+        if (countryOfOriginTextId != _undefined)
+          'countryOfOriginTextId': (countryOfOriginTextId as String?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -2977,6 +3286,31 @@ class _CopyWithImpl$Input$UserInput<TRes>
         ? CopyWith$Input$CompanyInput.stub(_then(_instance))
         : CopyWith$Input$CompanyInput(local$company, (e) => call(company: e));
   }
+
+  TRes businessExperiences(
+          Iterable<Input$BusinessExperienceInput>? Function(
+                  Iterable<
+                      CopyWith$Input$BusinessExperienceInput<
+                          Input$BusinessExperienceInput>>?)
+              _fn) =>
+      call(
+          businessExperiences: _fn(_instance.businessExperiences
+              ?.map((e) => CopyWith$Input$BusinessExperienceInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  TRes academicExperiences(
+          Iterable<Input$AcademicExperienceInput>? Function(
+                  Iterable<
+                      CopyWith$Input$AcademicExperienceInput<
+                          Input$AcademicExperienceInput>>?)
+              _fn) =>
+      call(
+          academicExperiences: _fn(_instance.academicExperiences
+              ?.map((e) => CopyWith$Input$AcademicExperienceInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
 }
 
 class _CopyWithStubImpl$Input$UserInput<TRes>
@@ -3045,12 +3379,19 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
     String? genderSelfDescribed,
     String? ethnicity,
     String? educationLevelTextId,
-    String? professionalBackground,
+    String? personalBio,
     int? yearsManagementExperience,
     int? yearsOwnershipExperience,
     String? ssoIdp,
-    String? oneLiner,
+    List<String>? pronounsTextIds,
     Input$CompanyInput? company,
+    List<Input$BusinessExperienceInput>? businessExperiences,
+    List<Input$AcademicExperienceInput>? academicExperiences,
+    List<String>? businessExperienceIds,
+    List<String>? academicExperienceIds,
+    String? cityOfOrigin,
+    String? regionOfOrigin,
+    String? countryOfOriginTextId,
   }) =>
       _res;
   events(_fn) => _res;
@@ -3062,6 +3403,8 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
   groupMemberships(_fn) => _res;
   CopyWith$Input$CompanyInput<TRes> get company =>
       CopyWith$Input$CompanyInput.stub(_res);
+  businessExperiences(_fn) => _res;
+  academicExperiences(_fn) => _res;
 }
 
 class Input$ModelEventInput {
@@ -5312,6 +5655,1170 @@ class _CopyWithStubImpl$Input$CompanyInput<TRes>
   CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
   websites(_fn) => _res;
+}
+
+class Input$BusinessExperienceInput {
+  factory Input$BusinessExperienceInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? businessName,
+    String? jobTitle,
+    String? city,
+    String? state,
+    String? country,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  }) =>
+      Input$BusinessExperienceInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (businessName != null) r'businessName': businessName,
+        if (jobTitle != null) r'jobTitle': jobTitle,
+        if (city != null) r'city': city,
+        if (state != null) r'state': state,
+        if (country != null) r'country': country,
+        if (startDate != null) r'startDate': startDate,
+        if (endDate != null) r'endDate': endDate,
+        if (userId != null) r'userId': userId,
+      });
+
+  Input$BusinessExperienceInput._(this._$data);
+
+  factory Input$BusinessExperienceInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('businessName')) {
+      final l$businessName = data['businessName'];
+      result$data['businessName'] = (l$businessName as String?);
+    }
+    if (data.containsKey('jobTitle')) {
+      final l$jobTitle = data['jobTitle'];
+      result$data['jobTitle'] = (l$jobTitle as String?);
+    }
+    if (data.containsKey('city')) {
+      final l$city = data['city'];
+      result$data['city'] = (l$city as String?);
+    }
+    if (data.containsKey('state')) {
+      final l$state = data['state'];
+      result$data['state'] = (l$state as String?);
+    }
+    if (data.containsKey('country')) {
+      final l$country = data['country'];
+      result$data['country'] = (l$country as String?);
+    }
+    if (data.containsKey('startDate')) {
+      final l$startDate = data['startDate'];
+      result$data['startDate'] =
+          l$startDate == null ? null : DateTime.parse((l$startDate as String));
+    }
+    if (data.containsKey('endDate')) {
+      final l$endDate = data['endDate'];
+      result$data['endDate'] =
+          l$endDate == null ? null : DateTime.parse((l$endDate as String));
+    }
+    if (data.containsKey('userId')) {
+      final l$userId = data['userId'];
+      result$data['userId'] = (l$userId as String?);
+    }
+    return Input$BusinessExperienceInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  String? get businessName => (_$data['businessName'] as String?);
+  String? get jobTitle => (_$data['jobTitle'] as String?);
+  String? get city => (_$data['city'] as String?);
+  String? get state => (_$data['state'] as String?);
+  String? get country => (_$data['country'] as String?);
+  DateTime? get startDate => (_$data['startDate'] as DateTime?);
+  DateTime? get endDate => (_$data['endDate'] as DateTime?);
+  String? get userId => (_$data['userId'] as String?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('businessName')) {
+      final l$businessName = businessName;
+      result$data['businessName'] = l$businessName;
+    }
+    if (_$data.containsKey('jobTitle')) {
+      final l$jobTitle = jobTitle;
+      result$data['jobTitle'] = l$jobTitle;
+    }
+    if (_$data.containsKey('city')) {
+      final l$city = city;
+      result$data['city'] = l$city;
+    }
+    if (_$data.containsKey('state')) {
+      final l$state = state;
+      result$data['state'] = l$state;
+    }
+    if (_$data.containsKey('country')) {
+      final l$country = country;
+      result$data['country'] = l$country;
+    }
+    if (_$data.containsKey('startDate')) {
+      final l$startDate = startDate;
+      result$data['startDate'] = l$startDate?.toIso8601String();
+    }
+    if (_$data.containsKey('endDate')) {
+      final l$endDate = endDate;
+      result$data['endDate'] = l$endDate?.toIso8601String();
+    }
+    if (_$data.containsKey('userId')) {
+      final l$userId = userId;
+      result$data['userId'] = l$userId;
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$BusinessExperienceInput<Input$BusinessExperienceInput>
+      get copyWith => CopyWith$Input$BusinessExperienceInput(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$BusinessExperienceInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$businessName = businessName;
+    final lOther$businessName = other.businessName;
+    if (_$data.containsKey('businessName') !=
+        other._$data.containsKey('businessName')) {
+      return false;
+    }
+    if (l$businessName != lOther$businessName) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (_$data.containsKey('jobTitle') !=
+        other._$data.containsKey('jobTitle')) {
+      return false;
+    }
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$city = city;
+    final lOther$city = other.city;
+    if (_$data.containsKey('city') != other._$data.containsKey('city')) {
+      return false;
+    }
+    if (l$city != lOther$city) {
+      return false;
+    }
+    final l$state = state;
+    final lOther$state = other.state;
+    if (_$data.containsKey('state') != other._$data.containsKey('state')) {
+      return false;
+    }
+    if (l$state != lOther$state) {
+      return false;
+    }
+    final l$country = country;
+    final lOther$country = other.country;
+    if (_$data.containsKey('country') != other._$data.containsKey('country')) {
+      return false;
+    }
+    if (l$country != lOther$country) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (_$data.containsKey('startDate') !=
+        other._$data.containsKey('startDate')) {
+      return false;
+    }
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (_$data.containsKey('endDate') != other._$data.containsKey('endDate')) {
+      return false;
+    }
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$userId = userId;
+    final lOther$userId = other.userId;
+    if (_$data.containsKey('userId') != other._$data.containsKey('userId')) {
+      return false;
+    }
+    if (l$userId != lOther$userId) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$businessName = businessName;
+    final l$jobTitle = jobTitle;
+    final l$city = city;
+    final l$state = state;
+    final l$country = country;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$userId = userId;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('businessName') ? l$businessName : const {},
+      _$data.containsKey('jobTitle') ? l$jobTitle : const {},
+      _$data.containsKey('city') ? l$city : const {},
+      _$data.containsKey('state') ? l$state : const {},
+      _$data.containsKey('country') ? l$country : const {},
+      _$data.containsKey('startDate') ? l$startDate : const {},
+      _$data.containsKey('endDate') ? l$endDate : const {},
+      _$data.containsKey('userId') ? l$userId : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$BusinessExperienceInput<TRes> {
+  factory CopyWith$Input$BusinessExperienceInput(
+    Input$BusinessExperienceInput instance,
+    TRes Function(Input$BusinessExperienceInput) then,
+  ) = _CopyWithImpl$Input$BusinessExperienceInput;
+
+  factory CopyWith$Input$BusinessExperienceInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$BusinessExperienceInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? businessName,
+    String? jobTitle,
+    String? city,
+    String? state,
+    String? country,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+}
+
+class _CopyWithImpl$Input$BusinessExperienceInput<TRes>
+    implements CopyWith$Input$BusinessExperienceInput<TRes> {
+  _CopyWithImpl$Input$BusinessExperienceInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$BusinessExperienceInput _instance;
+
+  final TRes Function(Input$BusinessExperienceInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? businessName = _undefined,
+    Object? jobTitle = _undefined,
+    Object? city = _undefined,
+    Object? state = _undefined,
+    Object? country = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? userId = _undefined,
+  }) =>
+      _then(Input$BusinessExperienceInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (businessName != _undefined)
+          'businessName': (businessName as String?),
+        if (jobTitle != _undefined) 'jobTitle': (jobTitle as String?),
+        if (city != _undefined) 'city': (city as String?),
+        if (state != _undefined) 'state': (state as String?),
+        if (country != _undefined) 'country': (country as String?),
+        if (startDate != _undefined) 'startDate': (startDate as DateTime?),
+        if (endDate != _undefined) 'endDate': (endDate as DateTime?),
+        if (userId != _undefined) 'userId': (userId as String?),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$BusinessExperienceInput<TRes>
+    implements CopyWith$Input$BusinessExperienceInput<TRes> {
+  _CopyWithStubImpl$Input$BusinessExperienceInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? businessName,
+    String? jobTitle,
+    String? city,
+    String? state,
+    String? country,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
+}
+
+class Input$AcademicExperienceInput {
+  factory Input$AcademicExperienceInput({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  }) =>
+      Input$AcademicExperienceInput._({
+        if (id != null) r'id': id,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (institutionName != null) r'institutionName': institutionName,
+        if (degreeType != null) r'degreeType': degreeType,
+        if (fieldOfStudy != null) r'fieldOfStudy': fieldOfStudy,
+        if (startDate != null) r'startDate': startDate,
+        if (endDate != null) r'endDate': endDate,
+        if (userId != null) r'userId': userId,
+      });
+
+  Input$AcademicExperienceInput._(this._$data);
+
+  factory Input$AcademicExperienceInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String?);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
+    }
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('institutionName')) {
+      final l$institutionName = data['institutionName'];
+      result$data['institutionName'] = (l$institutionName as String?);
+    }
+    if (data.containsKey('degreeType')) {
+      final l$degreeType = data['degreeType'];
+      result$data['degreeType'] = (l$degreeType as String?);
+    }
+    if (data.containsKey('fieldOfStudy')) {
+      final l$fieldOfStudy = data['fieldOfStudy'];
+      result$data['fieldOfStudy'] = (l$fieldOfStudy as String?);
+    }
+    if (data.containsKey('startDate')) {
+      final l$startDate = data['startDate'];
+      result$data['startDate'] =
+          l$startDate == null ? null : DateTime.parse((l$startDate as String));
+    }
+    if (data.containsKey('endDate')) {
+      final l$endDate = data['endDate'];
+      result$data['endDate'] =
+          l$endDate == null ? null : DateTime.parse((l$endDate as String));
+    }
+    if (data.containsKey('userId')) {
+      final l$userId = data['userId'];
+      result$data['userId'] = (l$userId as String?);
+    }
+    return Input$AcademicExperienceInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  String? get institutionName => (_$data['institutionName'] as String?);
+  String? get degreeType => (_$data['degreeType'] as String?);
+  String? get fieldOfStudy => (_$data['fieldOfStudy'] as String?);
+  DateTime? get startDate => (_$data['startDate'] as DateTime?);
+  DateTime? get endDate => (_$data['endDate'] as DateTime?);
+  String? get userId => (_$data['userId'] as String?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = l$id;
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
+    }
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
+    }
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('institutionName')) {
+      final l$institutionName = institutionName;
+      result$data['institutionName'] = l$institutionName;
+    }
+    if (_$data.containsKey('degreeType')) {
+      final l$degreeType = degreeType;
+      result$data['degreeType'] = l$degreeType;
+    }
+    if (_$data.containsKey('fieldOfStudy')) {
+      final l$fieldOfStudy = fieldOfStudy;
+      result$data['fieldOfStudy'] = l$fieldOfStudy;
+    }
+    if (_$data.containsKey('startDate')) {
+      final l$startDate = startDate;
+      result$data['startDate'] = l$startDate?.toIso8601String();
+    }
+    if (_$data.containsKey('endDate')) {
+      final l$endDate = endDate;
+      result$data['endDate'] = l$endDate?.toIso8601String();
+    }
+    if (_$data.containsKey('userId')) {
+      final l$userId = userId;
+      result$data['userId'] = l$userId;
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$AcademicExperienceInput<Input$AcademicExperienceInput>
+      get copyWith => CopyWith$Input$AcademicExperienceInput(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$AcademicExperienceInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
+      return false;
+    }
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
+      return false;
+    }
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
+      return false;
+    }
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$institutionName = institutionName;
+    final lOther$institutionName = other.institutionName;
+    if (_$data.containsKey('institutionName') !=
+        other._$data.containsKey('institutionName')) {
+      return false;
+    }
+    if (l$institutionName != lOther$institutionName) {
+      return false;
+    }
+    final l$degreeType = degreeType;
+    final lOther$degreeType = other.degreeType;
+    if (_$data.containsKey('degreeType') !=
+        other._$data.containsKey('degreeType')) {
+      return false;
+    }
+    if (l$degreeType != lOther$degreeType) {
+      return false;
+    }
+    final l$fieldOfStudy = fieldOfStudy;
+    final lOther$fieldOfStudy = other.fieldOfStudy;
+    if (_$data.containsKey('fieldOfStudy') !=
+        other._$data.containsKey('fieldOfStudy')) {
+      return false;
+    }
+    if (l$fieldOfStudy != lOther$fieldOfStudy) {
+      return false;
+    }
+    final l$startDate = startDate;
+    final lOther$startDate = other.startDate;
+    if (_$data.containsKey('startDate') !=
+        other._$data.containsKey('startDate')) {
+      return false;
+    }
+    if (l$startDate != lOther$startDate) {
+      return false;
+    }
+    final l$endDate = endDate;
+    final lOther$endDate = other.endDate;
+    if (_$data.containsKey('endDate') != other._$data.containsKey('endDate')) {
+      return false;
+    }
+    if (l$endDate != lOther$endDate) {
+      return false;
+    }
+    final l$userId = userId;
+    final lOther$userId = other.userId;
+    if (_$data.containsKey('userId') != other._$data.containsKey('userId')) {
+      return false;
+    }
+    if (l$userId != lOther$userId) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$institutionName = institutionName;
+    final l$degreeType = degreeType;
+    final l$fieldOfStudy = fieldOfStudy;
+    final l$startDate = startDate;
+    final l$endDate = endDate;
+    final l$userId = userId;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('institutionName') ? l$institutionName : const {},
+      _$data.containsKey('degreeType') ? l$degreeType : const {},
+      _$data.containsKey('fieldOfStudy') ? l$fieldOfStudy : const {},
+      _$data.containsKey('startDate') ? l$startDate : const {},
+      _$data.containsKey('endDate') ? l$endDate : const {},
+      _$data.containsKey('userId') ? l$userId : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$AcademicExperienceInput<TRes> {
+  factory CopyWith$Input$AcademicExperienceInput(
+    Input$AcademicExperienceInput instance,
+    TRes Function(Input$AcademicExperienceInput) then,
+  ) = _CopyWithImpl$Input$AcademicExperienceInput;
+
+  factory CopyWith$Input$AcademicExperienceInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$AcademicExperienceInput;
+
+  TRes call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
+}
+
+class _CopyWithImpl$Input$AcademicExperienceInput<TRes>
+    implements CopyWith$Input$AcademicExperienceInput<TRes> {
+  _CopyWithImpl$Input$AcademicExperienceInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$AcademicExperienceInput _instance;
+
+  final TRes Function(Input$AcademicExperienceInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? institutionName = _undefined,
+    Object? degreeType = _undefined,
+    Object? fieldOfStudy = _undefined,
+    Object? startDate = _undefined,
+    Object? endDate = _undefined,
+    Object? userId = _undefined,
+  }) =>
+      _then(Input$AcademicExperienceInput._({
+        ..._instance._$data,
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (institutionName != _undefined)
+          'institutionName': (institutionName as String?),
+        if (degreeType != _undefined) 'degreeType': (degreeType as String?),
+        if (fieldOfStudy != _undefined)
+          'fieldOfStudy': (fieldOfStudy as String?),
+        if (startDate != _undefined) 'startDate': (startDate as DateTime?),
+        if (endDate != _undefined) 'endDate': (endDate as DateTime?),
+        if (userId != _undefined) 'userId': (userId as String?),
+      }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
+}
+
+class _CopyWithStubImpl$Input$AcademicExperienceInput<TRes>
+    implements CopyWith$Input$AcademicExperienceInput<TRes> {
+  _CopyWithStubImpl$Input$AcademicExperienceInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    String? institutionName,
+    String? degreeType,
+    String? fieldOfStudy,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? userId,
+  }) =>
+      _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
 class Input$UserListFilter {
@@ -16599,3161 +18106,6 @@ class _CopyWithStubImpl$Input$ContentTagInput<TRes>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
-class Input$GenRequest {
-  factory Input$GenRequest({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  }) =>
-      Input$GenRequest._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (clearDb != null) r'clearDb': clearDb,
-        if (conversationCount != null) r'conversationCount': conversationCount,
-        if (messageCount != null) r'messageCount': messageCount,
-        if (users != null) r'users': users,
-        if (groups != null) r'groups': groups,
-        if (publishAppEvents != null) r'publishAppEvents': publishAppEvents,
-      });
-
-  Input$GenRequest._(this._$data);
-
-  factory Input$GenRequest.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('clearDb')) {
-      final l$clearDb = data['clearDb'];
-      result$data['clearDb'] = (l$clearDb as bool);
-    }
-    if (data.containsKey('conversationCount')) {
-      final l$conversationCount = data['conversationCount'];
-      result$data['conversationCount'] = (l$conversationCount as int);
-    }
-    if (data.containsKey('messageCount')) {
-      final l$messageCount = data['messageCount'];
-      result$data['messageCount'] = (l$messageCount as int);
-    }
-    if (data.containsKey('users')) {
-      final l$users = data['users'];
-      result$data['users'] =
-          Input$GenUserInput.fromJson((l$users as Map<String, dynamic>));
-    }
-    if (data.containsKey('groups')) {
-      final l$groups = data['groups'];
-      result$data['groups'] =
-          Input$GenGroupsInput.fromJson((l$groups as Map<String, dynamic>));
-    }
-    if (data.containsKey('publishAppEvents')) {
-      final l$publishAppEvents = data['publishAppEvents'];
-      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
-    }
-    return Input$GenRequest._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get clearDb => (_$data['clearDb'] as bool?);
-  int? get conversationCount => (_$data['conversationCount'] as int?);
-  int? get messageCount => (_$data['messageCount'] as int?);
-  Input$GenUserInput? get users => (_$data['users'] as Input$GenUserInput?);
-  Input$GenGroupsInput? get groups =>
-      (_$data['groups'] as Input$GenGroupsInput?);
-  bool? get publishAppEvents => (_$data['publishAppEvents'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('clearDb')) {
-      final l$clearDb = clearDb;
-      result$data['clearDb'] = (l$clearDb as bool);
-    }
-    if (_$data.containsKey('conversationCount')) {
-      final l$conversationCount = conversationCount;
-      result$data['conversationCount'] = (l$conversationCount as int);
-    }
-    if (_$data.containsKey('messageCount')) {
-      final l$messageCount = messageCount;
-      result$data['messageCount'] = (l$messageCount as int);
-    }
-    if (_$data.containsKey('users')) {
-      final l$users = users;
-      result$data['users'] = (l$users as Input$GenUserInput).toJson();
-    }
-    if (_$data.containsKey('groups')) {
-      final l$groups = groups;
-      result$data['groups'] = (l$groups as Input$GenGroupsInput).toJson();
-    }
-    if (_$data.containsKey('publishAppEvents')) {
-      final l$publishAppEvents = publishAppEvents;
-      result$data['publishAppEvents'] = (l$publishAppEvents as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenRequest<Input$GenRequest> get copyWith =>
-      CopyWith$Input$GenRequest(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenRequest) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$clearDb = clearDb;
-    final lOther$clearDb = other.clearDb;
-    if (_$data.containsKey('clearDb') != other._$data.containsKey('clearDb')) {
-      return false;
-    }
-    if (l$clearDb != lOther$clearDb) {
-      return false;
-    }
-    final l$conversationCount = conversationCount;
-    final lOther$conversationCount = other.conversationCount;
-    if (_$data.containsKey('conversationCount') !=
-        other._$data.containsKey('conversationCount')) {
-      return false;
-    }
-    if (l$conversationCount != lOther$conversationCount) {
-      return false;
-    }
-    final l$messageCount = messageCount;
-    final lOther$messageCount = other.messageCount;
-    if (_$data.containsKey('messageCount') !=
-        other._$data.containsKey('messageCount')) {
-      return false;
-    }
-    if (l$messageCount != lOther$messageCount) {
-      return false;
-    }
-    final l$users = users;
-    final lOther$users = other.users;
-    if (_$data.containsKey('users') != other._$data.containsKey('users')) {
-      return false;
-    }
-    if (l$users != lOther$users) {
-      return false;
-    }
-    final l$groups = groups;
-    final lOther$groups = other.groups;
-    if (_$data.containsKey('groups') != other._$data.containsKey('groups')) {
-      return false;
-    }
-    if (l$groups != lOther$groups) {
-      return false;
-    }
-    final l$publishAppEvents = publishAppEvents;
-    final lOther$publishAppEvents = other.publishAppEvents;
-    if (_$data.containsKey('publishAppEvents') !=
-        other._$data.containsKey('publishAppEvents')) {
-      return false;
-    }
-    if (l$publishAppEvents != lOther$publishAppEvents) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$clearDb = clearDb;
-    final l$conversationCount = conversationCount;
-    final l$messageCount = messageCount;
-    final l$users = users;
-    final l$groups = groups;
-    final l$publishAppEvents = publishAppEvents;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('clearDb') ? l$clearDb : const {},
-      _$data.containsKey('conversationCount') ? l$conversationCount : const {},
-      _$data.containsKey('messageCount') ? l$messageCount : const {},
-      _$data.containsKey('users') ? l$users : const {},
-      _$data.containsKey('groups') ? l$groups : const {},
-      _$data.containsKey('publishAppEvents') ? l$publishAppEvents : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenRequest<TRes> {
-  factory CopyWith$Input$GenRequest(
-    Input$GenRequest instance,
-    TRes Function(Input$GenRequest) then,
-  ) = _CopyWithImpl$Input$GenRequest;
-
-  factory CopyWith$Input$GenRequest.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenRequest;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  CopyWith$Input$GenUserInput<TRes> get users;
-  CopyWith$Input$GenGroupsInput<TRes> get groups;
-}
-
-class _CopyWithImpl$Input$GenRequest<TRes>
-    implements CopyWith$Input$GenRequest<TRes> {
-  _CopyWithImpl$Input$GenRequest(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenRequest _instance;
-
-  final TRes Function(Input$GenRequest) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? clearDb = _undefined,
-    Object? conversationCount = _undefined,
-    Object? messageCount = _undefined,
-    Object? users = _undefined,
-    Object? groups = _undefined,
-    Object? publishAppEvents = _undefined,
-  }) =>
-      _then(Input$GenRequest._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (clearDb != _undefined && clearDb != null)
-          'clearDb': (clearDb as bool),
-        if (conversationCount != _undefined && conversationCount != null)
-          'conversationCount': (conversationCount as int),
-        if (messageCount != _undefined && messageCount != null)
-          'messageCount': (messageCount as int),
-        if (users != _undefined && users != null)
-          'users': (users as Input$GenUserInput),
-        if (groups != _undefined && groups != null)
-          'groups': (groups as Input$GenGroupsInput),
-        if (publishAppEvents != _undefined && publishAppEvents != null)
-          'publishAppEvents': (publishAppEvents as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  CopyWith$Input$GenUserInput<TRes> get users {
-    final local$users = _instance.users;
-    return local$users == null
-        ? CopyWith$Input$GenUserInput.stub(_then(_instance))
-        : CopyWith$Input$GenUserInput(local$users, (e) => call(users: e));
-  }
-
-  CopyWith$Input$GenGroupsInput<TRes> get groups {
-    final local$groups = _instance.groups;
-    return local$groups == null
-        ? CopyWith$Input$GenGroupsInput.stub(_then(_instance))
-        : CopyWith$Input$GenGroupsInput(local$groups, (e) => call(groups: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenRequest<TRes>
-    implements CopyWith$Input$GenRequest<TRes> {
-  _CopyWithStubImpl$Input$GenRequest(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? clearDb,
-    int? conversationCount,
-    int? messageCount,
-    Input$GenUserInput? users,
-    Input$GenGroupsInput? groups,
-    bool? publishAppEvents,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  CopyWith$Input$GenUserInput<TRes> get users =>
-      CopyWith$Input$GenUserInput.stub(_res);
-  CopyWith$Input$GenGroupsInput<TRes> get groups =>
-      CopyWith$Input$GenGroupsInput.stub(_res);
-}
-
-class Input$GenUserInput {
-  factory Input$GenUserInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  }) =>
-      Input$GenUserInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (count != null) r'count': count,
-        if (dualRoleCount != null) r'dualRoleCount': dualRoleCount,
-        if (emailDomain != null) r'emailDomain': emailDomain,
-        if (emailPrefix != null) r'emailPrefix': emailPrefix,
-        if (mentorCount != null) r'mentorCount': mentorCount,
-        if (menteeCount != null) r'menteeCount': menteeCount,
-        if (mentorRatio != null) r'mentorRatio': mentorRatio,
-      });
-
-  Input$GenUserInput._(this._$data);
-
-  factory Input$GenUserInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('count')) {
-      final l$count = data['count'];
-      result$data['count'] = (l$count as int);
-    }
-    if (data.containsKey('dualRoleCount')) {
-      final l$dualRoleCount = data['dualRoleCount'];
-      result$data['dualRoleCount'] = (l$dualRoleCount as int?);
-    }
-    if (data.containsKey('emailDomain')) {
-      final l$emailDomain = data['emailDomain'];
-      result$data['emailDomain'] = (l$emailDomain as String);
-    }
-    if (data.containsKey('emailPrefix')) {
-      final l$emailPrefix = data['emailPrefix'];
-      result$data['emailPrefix'] = (l$emailPrefix as String?);
-    }
-    if (data.containsKey('mentorCount')) {
-      final l$mentorCount = data['mentorCount'];
-      result$data['mentorCount'] = (l$mentorCount as int?);
-    }
-    if (data.containsKey('menteeCount')) {
-      final l$menteeCount = data['menteeCount'];
-      result$data['menteeCount'] = (l$menteeCount as int?);
-    }
-    if (data.containsKey('mentorRatio')) {
-      final l$mentorRatio = data['mentorRatio'];
-      result$data['mentorRatio'] = (l$mentorRatio as num?)?.toDouble();
-    }
-    return Input$GenUserInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  int? get count => (_$data['count'] as int?);
-  int? get dualRoleCount => (_$data['dualRoleCount'] as int?);
-  String? get emailDomain => (_$data['emailDomain'] as String?);
-  String? get emailPrefix => (_$data['emailPrefix'] as String?);
-  int? get mentorCount => (_$data['mentorCount'] as int?);
-  int? get menteeCount => (_$data['menteeCount'] as int?);
-  double? get mentorRatio => (_$data['mentorRatio'] as double?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('count')) {
-      final l$count = count;
-      result$data['count'] = (l$count as int);
-    }
-    if (_$data.containsKey('dualRoleCount')) {
-      final l$dualRoleCount = dualRoleCount;
-      result$data['dualRoleCount'] = l$dualRoleCount;
-    }
-    if (_$data.containsKey('emailDomain')) {
-      final l$emailDomain = emailDomain;
-      result$data['emailDomain'] = (l$emailDomain as String);
-    }
-    if (_$data.containsKey('emailPrefix')) {
-      final l$emailPrefix = emailPrefix;
-      result$data['emailPrefix'] = l$emailPrefix;
-    }
-    if (_$data.containsKey('mentorCount')) {
-      final l$mentorCount = mentorCount;
-      result$data['mentorCount'] = l$mentorCount;
-    }
-    if (_$data.containsKey('menteeCount')) {
-      final l$menteeCount = menteeCount;
-      result$data['menteeCount'] = l$menteeCount;
-    }
-    if (_$data.containsKey('mentorRatio')) {
-      final l$mentorRatio = mentorRatio;
-      result$data['mentorRatio'] = l$mentorRatio;
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenUserInput<Input$GenUserInput> get copyWith =>
-      CopyWith$Input$GenUserInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenUserInput) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$count = count;
-    final lOther$count = other.count;
-    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
-      return false;
-    }
-    if (l$count != lOther$count) {
-      return false;
-    }
-    final l$dualRoleCount = dualRoleCount;
-    final lOther$dualRoleCount = other.dualRoleCount;
-    if (_$data.containsKey('dualRoleCount') !=
-        other._$data.containsKey('dualRoleCount')) {
-      return false;
-    }
-    if (l$dualRoleCount != lOther$dualRoleCount) {
-      return false;
-    }
-    final l$emailDomain = emailDomain;
-    final lOther$emailDomain = other.emailDomain;
-    if (_$data.containsKey('emailDomain') !=
-        other._$data.containsKey('emailDomain')) {
-      return false;
-    }
-    if (l$emailDomain != lOther$emailDomain) {
-      return false;
-    }
-    final l$emailPrefix = emailPrefix;
-    final lOther$emailPrefix = other.emailPrefix;
-    if (_$data.containsKey('emailPrefix') !=
-        other._$data.containsKey('emailPrefix')) {
-      return false;
-    }
-    if (l$emailPrefix != lOther$emailPrefix) {
-      return false;
-    }
-    final l$mentorCount = mentorCount;
-    final lOther$mentorCount = other.mentorCount;
-    if (_$data.containsKey('mentorCount') !=
-        other._$data.containsKey('mentorCount')) {
-      return false;
-    }
-    if (l$mentorCount != lOther$mentorCount) {
-      return false;
-    }
-    final l$menteeCount = menteeCount;
-    final lOther$menteeCount = other.menteeCount;
-    if (_$data.containsKey('menteeCount') !=
-        other._$data.containsKey('menteeCount')) {
-      return false;
-    }
-    if (l$menteeCount != lOther$menteeCount) {
-      return false;
-    }
-    final l$mentorRatio = mentorRatio;
-    final lOther$mentorRatio = other.mentorRatio;
-    if (_$data.containsKey('mentorRatio') !=
-        other._$data.containsKey('mentorRatio')) {
-      return false;
-    }
-    if (l$mentorRatio != lOther$mentorRatio) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$count = count;
-    final l$dualRoleCount = dualRoleCount;
-    final l$emailDomain = emailDomain;
-    final l$emailPrefix = emailPrefix;
-    final l$mentorCount = mentorCount;
-    final l$menteeCount = menteeCount;
-    final l$mentorRatio = mentorRatio;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('count') ? l$count : const {},
-      _$data.containsKey('dualRoleCount') ? l$dualRoleCount : const {},
-      _$data.containsKey('emailDomain') ? l$emailDomain : const {},
-      _$data.containsKey('emailPrefix') ? l$emailPrefix : const {},
-      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
-      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
-      _$data.containsKey('mentorRatio') ? l$mentorRatio : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenUserInput<TRes> {
-  factory CopyWith$Input$GenUserInput(
-    Input$GenUserInput instance,
-    TRes Function(Input$GenUserInput) then,
-  ) = _CopyWithImpl$Input$GenUserInput;
-
-  factory CopyWith$Input$GenUserInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenUserInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenUserInput<TRes>
-    implements CopyWith$Input$GenUserInput<TRes> {
-  _CopyWithImpl$Input$GenUserInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenUserInput _instance;
-
-  final TRes Function(Input$GenUserInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? count = _undefined,
-    Object? dualRoleCount = _undefined,
-    Object? emailDomain = _undefined,
-    Object? emailPrefix = _undefined,
-    Object? mentorCount = _undefined,
-    Object? menteeCount = _undefined,
-    Object? mentorRatio = _undefined,
-  }) =>
-      _then(Input$GenUserInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (count != _undefined && count != null) 'count': (count as int),
-        if (dualRoleCount != _undefined)
-          'dualRoleCount': (dualRoleCount as int?),
-        if (emailDomain != _undefined && emailDomain != null)
-          'emailDomain': (emailDomain as String),
-        if (emailPrefix != _undefined) 'emailPrefix': (emailPrefix as String?),
-        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
-        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
-        if (mentorRatio != _undefined) 'mentorRatio': (mentorRatio as double?),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenUserInput<TRes>
-    implements CopyWith$Input$GenUserInput<TRes> {
-  _CopyWithStubImpl$Input$GenUserInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    int? dualRoleCount,
-    String? emailDomain,
-    String? emailPrefix,
-    int? mentorCount,
-    int? menteeCount,
-    double? mentorRatio,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
-class Input$GenGroupsInput {
-  factory Input$GenGroupsInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
-  }) =>
-      Input$GenGroupsInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (count != null) r'count': count,
-        if (specificGroups != null) r'specificGroups': specificGroups,
-      });
-
-  Input$GenGroupsInput._(this._$data);
-
-  factory Input$GenGroupsInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('count')) {
-      final l$count = data['count'];
-      result$data['count'] = (l$count as int);
-    }
-    if (data.containsKey('specificGroups')) {
-      final l$specificGroups = data['specificGroups'];
-      result$data['specificGroups'] = (l$specificGroups as List<dynamic>)
-          .map((e) =>
-              Input$GenSpecificGroupInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    return Input$GenGroupsInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  int? get count => (_$data['count'] as int?);
-  List<Input$GenSpecificGroupInput>? get specificGroups =>
-      (_$data['specificGroups'] as List<Input$GenSpecificGroupInput>?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('count')) {
-      final l$count = count;
-      result$data['count'] = (l$count as int);
-    }
-    if (_$data.containsKey('specificGroups')) {
-      final l$specificGroups = specificGroups;
-      result$data['specificGroups'] =
-          (l$specificGroups as List<Input$GenSpecificGroupInput>)
-              .map((e) => e.toJson())
-              .toList();
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenGroupsInput<Input$GenGroupsInput> get copyWith =>
-      CopyWith$Input$GenGroupsInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenGroupsInput) || runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$count = count;
-    final lOther$count = other.count;
-    if (_$data.containsKey('count') != other._$data.containsKey('count')) {
-      return false;
-    }
-    if (l$count != lOther$count) {
-      return false;
-    }
-    final l$specificGroups = specificGroups;
-    final lOther$specificGroups = other.specificGroups;
-    if (_$data.containsKey('specificGroups') !=
-        other._$data.containsKey('specificGroups')) {
-      return false;
-    }
-    if (l$specificGroups != null && lOther$specificGroups != null) {
-      if (l$specificGroups.length != lOther$specificGroups.length) {
-        return false;
-      }
-      for (int i = 0; i < l$specificGroups.length; i++) {
-        final l$specificGroups$entry = l$specificGroups[i];
-        final lOther$specificGroups$entry = lOther$specificGroups[i];
-        if (l$specificGroups$entry != lOther$specificGroups$entry) {
-          return false;
-        }
-      }
-    } else if (l$specificGroups != lOther$specificGroups) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$count = count;
-    final l$specificGroups = specificGroups;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('count') ? l$count : const {},
-      _$data.containsKey('specificGroups')
-          ? l$specificGroups == null
-              ? null
-              : Object.hashAll(l$specificGroups.map((v) => v))
-          : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenGroupsInput<TRes> {
-  factory CopyWith$Input$GenGroupsInput(
-    Input$GenGroupsInput instance,
-    TRes Function(Input$GenGroupsInput) then,
-  ) = _CopyWithImpl$Input$GenGroupsInput;
-
-  factory CopyWith$Input$GenGroupsInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenGroupsInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  TRes specificGroups(
-      Iterable<Input$GenSpecificGroupInput> Function(
-              Iterable<
-                  CopyWith$Input$GenSpecificGroupInput<
-                      Input$GenSpecificGroupInput>>)
-          _fn);
-}
-
-class _CopyWithImpl$Input$GenGroupsInput<TRes>
-    implements CopyWith$Input$GenGroupsInput<TRes> {
-  _CopyWithImpl$Input$GenGroupsInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenGroupsInput _instance;
-
-  final TRes Function(Input$GenGroupsInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? count = _undefined,
-    Object? specificGroups = _undefined,
-  }) =>
-      _then(Input$GenGroupsInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (count != _undefined && count != null) 'count': (count as int),
-        if (specificGroups != _undefined && specificGroups != null)
-          'specificGroups':
-              (specificGroups as List<Input$GenSpecificGroupInput>),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  TRes specificGroups(
-          Iterable<Input$GenSpecificGroupInput> Function(
-                  Iterable<
-                      CopyWith$Input$GenSpecificGroupInput<
-                          Input$GenSpecificGroupInput>>)
-              _fn) =>
-      call(
-          specificGroups: _fn((_instance.specificGroups ?? [])
-              .map((e) => CopyWith$Input$GenSpecificGroupInput(
-                    e,
-                    (i) => i,
-                  ))).toList());
-}
-
-class _CopyWithStubImpl$Input$GenGroupsInput<TRes>
-    implements CopyWith$Input$GenGroupsInput<TRes> {
-  _CopyWithStubImpl$Input$GenGroupsInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    int? count,
-    List<Input$GenSpecificGroupInput>? specificGroups,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  specificGroups(_fn) => _res;
-}
-
-class Input$GenSpecificGroupInput {
-  factory Input$GenSpecificGroupInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  }) =>
-      Input$GenSpecificGroupInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (name != null) r'name': name,
-        if (mentorCount != null) r'mentorCount': mentorCount,
-        if (menteeCount != null) r'menteeCount': menteeCount,
-        if (groupRules != null) r'groupRules': groupRules,
-        if (matchingEngine != null) r'matchingEngine': matchingEngine,
-      });
-
-  Input$GenSpecificGroupInput._(this._$data);
-
-  factory Input$GenSpecificGroupInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('name')) {
-      final l$name = data['name'];
-      result$data['name'] = (l$name as String);
-    }
-    if (data.containsKey('mentorCount')) {
-      final l$mentorCount = data['mentorCount'];
-      result$data['mentorCount'] = (l$mentorCount as int?);
-    }
-    if (data.containsKey('menteeCount')) {
-      final l$menteeCount = data['menteeCount'];
-      result$data['menteeCount'] = (l$menteeCount as int?);
-    }
-    if (data.containsKey('groupRules')) {
-      final l$groupRules = data['groupRules'];
-      result$data['groupRules'] = (l$groupRules as List<dynamic>?)
-          ?.map((e) =>
-              Input$GenGroupRuleInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('matchingEngine')) {
-      final l$matchingEngine = data['matchingEngine'];
-      result$data['matchingEngine'] = l$matchingEngine == null
-          ? null
-          : Input$GenMatchingEngineInput.fromJson(
-              (l$matchingEngine as Map<String, dynamic>));
-    }
-    return Input$GenSpecificGroupInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  String? get name => (_$data['name'] as String?);
-  int? get mentorCount => (_$data['mentorCount'] as int?);
-  int? get menteeCount => (_$data['menteeCount'] as int?);
-  List<Input$GenGroupRuleInput>? get groupRules =>
-      (_$data['groupRules'] as List<Input$GenGroupRuleInput>?);
-  Input$GenMatchingEngineInput? get matchingEngine =>
-      (_$data['matchingEngine'] as Input$GenMatchingEngineInput?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('name')) {
-      final l$name = name;
-      result$data['name'] = (l$name as String);
-    }
-    if (_$data.containsKey('mentorCount')) {
-      final l$mentorCount = mentorCount;
-      result$data['mentorCount'] = l$mentorCount;
-    }
-    if (_$data.containsKey('menteeCount')) {
-      final l$menteeCount = menteeCount;
-      result$data['menteeCount'] = l$menteeCount;
-    }
-    if (_$data.containsKey('groupRules')) {
-      final l$groupRules = groupRules;
-      result$data['groupRules'] = l$groupRules?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('matchingEngine')) {
-      final l$matchingEngine = matchingEngine;
-      result$data['matchingEngine'] = l$matchingEngine?.toJson();
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenSpecificGroupInput<Input$GenSpecificGroupInput>
-      get copyWith => CopyWith$Input$GenSpecificGroupInput(
-            this,
-            (i) => i,
-          );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenSpecificGroupInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$name = name;
-    final lOther$name = other.name;
-    if (_$data.containsKey('name') != other._$data.containsKey('name')) {
-      return false;
-    }
-    if (l$name != lOther$name) {
-      return false;
-    }
-    final l$mentorCount = mentorCount;
-    final lOther$mentorCount = other.mentorCount;
-    if (_$data.containsKey('mentorCount') !=
-        other._$data.containsKey('mentorCount')) {
-      return false;
-    }
-    if (l$mentorCount != lOther$mentorCount) {
-      return false;
-    }
-    final l$menteeCount = menteeCount;
-    final lOther$menteeCount = other.menteeCount;
-    if (_$data.containsKey('menteeCount') !=
-        other._$data.containsKey('menteeCount')) {
-      return false;
-    }
-    if (l$menteeCount != lOther$menteeCount) {
-      return false;
-    }
-    final l$groupRules = groupRules;
-    final lOther$groupRules = other.groupRules;
-    if (_$data.containsKey('groupRules') !=
-        other._$data.containsKey('groupRules')) {
-      return false;
-    }
-    if (l$groupRules != null && lOther$groupRules != null) {
-      if (l$groupRules.length != lOther$groupRules.length) {
-        return false;
-      }
-      for (int i = 0; i < l$groupRules.length; i++) {
-        final l$groupRules$entry = l$groupRules[i];
-        final lOther$groupRules$entry = lOther$groupRules[i];
-        if (l$groupRules$entry != lOther$groupRules$entry) {
-          return false;
-        }
-      }
-    } else if (l$groupRules != lOther$groupRules) {
-      return false;
-    }
-    final l$matchingEngine = matchingEngine;
-    final lOther$matchingEngine = other.matchingEngine;
-    if (_$data.containsKey('matchingEngine') !=
-        other._$data.containsKey('matchingEngine')) {
-      return false;
-    }
-    if (l$matchingEngine != lOther$matchingEngine) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$name = name;
-    final l$mentorCount = mentorCount;
-    final l$menteeCount = menteeCount;
-    final l$groupRules = groupRules;
-    final l$matchingEngine = matchingEngine;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('name') ? l$name : const {},
-      _$data.containsKey('mentorCount') ? l$mentorCount : const {},
-      _$data.containsKey('menteeCount') ? l$menteeCount : const {},
-      _$data.containsKey('groupRules')
-          ? l$groupRules == null
-              ? null
-              : Object.hashAll(l$groupRules.map((v) => v))
-          : const {},
-      _$data.containsKey('matchingEngine') ? l$matchingEngine : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenSpecificGroupInput<TRes> {
-  factory CopyWith$Input$GenSpecificGroupInput(
-    Input$GenSpecificGroupInput instance,
-    TRes Function(Input$GenSpecificGroupInput) then,
-  ) = _CopyWithImpl$Input$GenSpecificGroupInput;
-
-  factory CopyWith$Input$GenSpecificGroupInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenSpecificGroupInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-  TRes groupRules(
-      Iterable<Input$GenGroupRuleInput>? Function(
-              Iterable<
-                  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput>>?)
-          _fn);
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine;
-}
-
-class _CopyWithImpl$Input$GenSpecificGroupInput<TRes>
-    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
-  _CopyWithImpl$Input$GenSpecificGroupInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenSpecificGroupInput _instance;
-
-  final TRes Function(Input$GenSpecificGroupInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? name = _undefined,
-    Object? mentorCount = _undefined,
-    Object? menteeCount = _undefined,
-    Object? groupRules = _undefined,
-    Object? matchingEngine = _undefined,
-  }) =>
-      _then(Input$GenSpecificGroupInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (name != _undefined && name != null) 'name': (name as String),
-        if (mentorCount != _undefined) 'mentorCount': (mentorCount as int?),
-        if (menteeCount != _undefined) 'menteeCount': (menteeCount as int?),
-        if (groupRules != _undefined)
-          'groupRules': (groupRules as List<Input$GenGroupRuleInput>?),
-        if (matchingEngine != _undefined)
-          'matchingEngine': (matchingEngine as Input$GenMatchingEngineInput?),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-
-  TRes groupRules(
-          Iterable<Input$GenGroupRuleInput>? Function(
-                  Iterable<
-                      CopyWith$Input$GenGroupRuleInput<
-                          Input$GenGroupRuleInput>>?)
-              _fn) =>
-      call(
-          groupRules: _fn(
-              _instance.groupRules?.map((e) => CopyWith$Input$GenGroupRuleInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine {
-    final local$matchingEngine = _instance.matchingEngine;
-    return local$matchingEngine == null
-        ? CopyWith$Input$GenMatchingEngineInput.stub(_then(_instance))
-        : CopyWith$Input$GenMatchingEngineInput(
-            local$matchingEngine, (e) => call(matchingEngine: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenSpecificGroupInput<TRes>
-    implements CopyWith$Input$GenSpecificGroupInput<TRes> {
-  _CopyWithStubImpl$Input$GenSpecificGroupInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    String? name,
-    int? mentorCount,
-    int? menteeCount,
-    List<Input$GenGroupRuleInput>? groupRules,
-    Input$GenMatchingEngineInput? matchingEngine,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-  groupRules(_fn) => _res;
-  CopyWith$Input$GenMatchingEngineInput<TRes> get matchingEngine =>
-      CopyWith$Input$GenMatchingEngineInput.stub(_res);
-}
-
-class Input$GenGroupRuleInput {
-  factory Input$GenGroupRuleInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  }) =>
-      Input$GenGroupRuleInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (someGroupRule != null) r'someGroupRule': someGroupRule,
-        if (someOtherGroupRule != null)
-          r'someOtherGroupRule': someOtherGroupRule,
-      });
-
-  Input$GenGroupRuleInput._(this._$data);
-
-  factory Input$GenGroupRuleInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('someGroupRule')) {
-      final l$someGroupRule = data['someGroupRule'];
-      result$data['someGroupRule'] = (l$someGroupRule as bool);
-    }
-    if (data.containsKey('someOtherGroupRule')) {
-      final l$someOtherGroupRule = data['someOtherGroupRule'];
-      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
-    }
-    return Input$GenGroupRuleInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get someGroupRule => (_$data['someGroupRule'] as bool?);
-  bool? get someOtherGroupRule => (_$data['someOtherGroupRule'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('someGroupRule')) {
-      final l$someGroupRule = someGroupRule;
-      result$data['someGroupRule'] = (l$someGroupRule as bool);
-    }
-    if (_$data.containsKey('someOtherGroupRule')) {
-      final l$someOtherGroupRule = someOtherGroupRule;
-      result$data['someOtherGroupRule'] = (l$someOtherGroupRule as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenGroupRuleInput<Input$GenGroupRuleInput> get copyWith =>
-      CopyWith$Input$GenGroupRuleInput(
-        this,
-        (i) => i,
-      );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenGroupRuleInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$someGroupRule = someGroupRule;
-    final lOther$someGroupRule = other.someGroupRule;
-    if (_$data.containsKey('someGroupRule') !=
-        other._$data.containsKey('someGroupRule')) {
-      return false;
-    }
-    if (l$someGroupRule != lOther$someGroupRule) {
-      return false;
-    }
-    final l$someOtherGroupRule = someOtherGroupRule;
-    final lOther$someOtherGroupRule = other.someOtherGroupRule;
-    if (_$data.containsKey('someOtherGroupRule') !=
-        other._$data.containsKey('someOtherGroupRule')) {
-      return false;
-    }
-    if (l$someOtherGroupRule != lOther$someOtherGroupRule) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$someGroupRule = someGroupRule;
-    final l$someOtherGroupRule = someOtherGroupRule;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('someGroupRule') ? l$someGroupRule : const {},
-      _$data.containsKey('someOtherGroupRule')
-          ? l$someOtherGroupRule
-          : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenGroupRuleInput<TRes> {
-  factory CopyWith$Input$GenGroupRuleInput(
-    Input$GenGroupRuleInput instance,
-    TRes Function(Input$GenGroupRuleInput) then,
-  ) = _CopyWithImpl$Input$GenGroupRuleInput;
-
-  factory CopyWith$Input$GenGroupRuleInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenGroupRuleInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenGroupRuleInput<TRes>
-    implements CopyWith$Input$GenGroupRuleInput<TRes> {
-  _CopyWithImpl$Input$GenGroupRuleInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenGroupRuleInput _instance;
-
-  final TRes Function(Input$GenGroupRuleInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? someGroupRule = _undefined,
-    Object? someOtherGroupRule = _undefined,
-  }) =>
-      _then(Input$GenGroupRuleInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (someGroupRule != _undefined && someGroupRule != null)
-          'someGroupRule': (someGroupRule as bool),
-        if (someOtherGroupRule != _undefined && someOtherGroupRule != null)
-          'someOtherGroupRule': (someOtherGroupRule as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenGroupRuleInput<TRes>
-    implements CopyWith$Input$GenGroupRuleInput<TRes> {
-  _CopyWithStubImpl$Input$GenGroupRuleInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someGroupRule,
-    bool? someOtherGroupRule,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
-class Input$GenMatchingEngineInput {
-  factory Input$GenMatchingEngineInput({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  }) =>
-      Input$GenMatchingEngineInput._({
-        if (id != null) r'id': id,
-        if (adminNotes != null) r'adminNotes': adminNotes,
-        if (events != null) r'events': events,
-        if (metadata != null) r'metadata': metadata,
-        if (createdAt != null) r'createdAt': createdAt,
-        if (createdBy != null) r'createdBy': createdBy,
-        if (updatedAt != null) r'updatedAt': updatedAt,
-        if (updatedBy != null) r'updatedBy': updatedBy,
-        if (deletedAt != null) r'deletedAt': deletedAt,
-        if (deletedBy != null) r'deletedBy': deletedBy,
-        if (someMatchingRule != null) r'someMatchingRule': someMatchingRule,
-        if (someOtherMatchingRule != null)
-          r'someOtherMatchingRule': someOtherMatchingRule,
-      });
-
-  Input$GenMatchingEngineInput._(this._$data);
-
-  factory Input$GenMatchingEngineInput.fromJson(Map<String, dynamic> data) {
-    final result$data = <String, dynamic>{};
-    if (data.containsKey('id')) {
-      final l$id = data['id'];
-      result$data['id'] = (l$id as String?);
-    }
-    if (data.containsKey('adminNotes')) {
-      final l$adminNotes = data['adminNotes'];
-      result$data['adminNotes'] = (l$adminNotes as String?);
-    }
-    if (data.containsKey('events')) {
-      final l$events = data['events'];
-      result$data['events'] = (l$events as List<dynamic>?)
-          ?.map((e) =>
-              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
-          .toList();
-    }
-    if (data.containsKey('metadata')) {
-      final l$metadata = data['metadata'];
-      result$data['metadata'] = l$metadata == null
-          ? null
-          : Input$BaseModelMetadataInput.fromJson(
-              (l$metadata as Map<String, dynamic>));
-    }
-    if (data.containsKey('createdAt')) {
-      final l$createdAt = data['createdAt'];
-      result$data['createdAt'] =
-          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
-    }
-    if (data.containsKey('createdBy')) {
-      final l$createdBy = data['createdBy'];
-      result$data['createdBy'] = (l$createdBy as String?);
-    }
-    if (data.containsKey('updatedAt')) {
-      final l$updatedAt = data['updatedAt'];
-      result$data['updatedAt'] =
-          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
-    }
-    if (data.containsKey('updatedBy')) {
-      final l$updatedBy = data['updatedBy'];
-      result$data['updatedBy'] = (l$updatedBy as String?);
-    }
-    if (data.containsKey('deletedAt')) {
-      final l$deletedAt = data['deletedAt'];
-      result$data['deletedAt'] =
-          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
-    }
-    if (data.containsKey('deletedBy')) {
-      final l$deletedBy = data['deletedBy'];
-      result$data['deletedBy'] = (l$deletedBy as String?);
-    }
-    if (data.containsKey('someMatchingRule')) {
-      final l$someMatchingRule = data['someMatchingRule'];
-      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
-    }
-    if (data.containsKey('someOtherMatchingRule')) {
-      final l$someOtherMatchingRule = data['someOtherMatchingRule'];
-      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
-    }
-    return Input$GenMatchingEngineInput._(result$data);
-  }
-
-  Map<String, dynamic> _$data;
-
-  String? get id => (_$data['id'] as String?);
-  String? get adminNotes => (_$data['adminNotes'] as String?);
-  List<Input$ModelEventInput>? get events =>
-      (_$data['events'] as List<Input$ModelEventInput>?);
-  Input$BaseModelMetadataInput? get metadata =>
-      (_$data['metadata'] as Input$BaseModelMetadataInput?);
-  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
-  String? get createdBy => (_$data['createdBy'] as String?);
-  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
-  String? get updatedBy => (_$data['updatedBy'] as String?);
-  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
-  String? get deletedBy => (_$data['deletedBy'] as String?);
-  bool? get someMatchingRule => (_$data['someMatchingRule'] as bool?);
-  bool? get someOtherMatchingRule => (_$data['someOtherMatchingRule'] as bool?);
-  Map<String, dynamic> toJson() {
-    final result$data = <String, dynamic>{};
-    if (_$data.containsKey('id')) {
-      final l$id = id;
-      result$data['id'] = l$id;
-    }
-    if (_$data.containsKey('adminNotes')) {
-      final l$adminNotes = adminNotes;
-      result$data['adminNotes'] = l$adminNotes;
-    }
-    if (_$data.containsKey('events')) {
-      final l$events = events;
-      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
-    }
-    if (_$data.containsKey('metadata')) {
-      final l$metadata = metadata;
-      result$data['metadata'] = l$metadata?.toJson();
-    }
-    if (_$data.containsKey('createdAt')) {
-      final l$createdAt = createdAt;
-      result$data['createdAt'] = l$createdAt?.toIso8601String();
-    }
-    if (_$data.containsKey('createdBy')) {
-      final l$createdBy = createdBy;
-      result$data['createdBy'] = l$createdBy;
-    }
-    if (_$data.containsKey('updatedAt')) {
-      final l$updatedAt = updatedAt;
-      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('updatedBy')) {
-      final l$updatedBy = updatedBy;
-      result$data['updatedBy'] = l$updatedBy;
-    }
-    if (_$data.containsKey('deletedAt')) {
-      final l$deletedAt = deletedAt;
-      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
-    }
-    if (_$data.containsKey('deletedBy')) {
-      final l$deletedBy = deletedBy;
-      result$data['deletedBy'] = l$deletedBy;
-    }
-    if (_$data.containsKey('someMatchingRule')) {
-      final l$someMatchingRule = someMatchingRule;
-      result$data['someMatchingRule'] = (l$someMatchingRule as bool);
-    }
-    if (_$data.containsKey('someOtherMatchingRule')) {
-      final l$someOtherMatchingRule = someOtherMatchingRule;
-      result$data['someOtherMatchingRule'] = (l$someOtherMatchingRule as bool);
-    }
-    return result$data;
-  }
-
-  CopyWith$Input$GenMatchingEngineInput<Input$GenMatchingEngineInput>
-      get copyWith => CopyWith$Input$GenMatchingEngineInput(
-            this,
-            (i) => i,
-          );
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (!(other is Input$GenMatchingEngineInput) ||
-        runtimeType != other.runtimeType) {
-      return false;
-    }
-    final l$id = id;
-    final lOther$id = other.id;
-    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
-      return false;
-    }
-    if (l$id != lOther$id) {
-      return false;
-    }
-    final l$adminNotes = adminNotes;
-    final lOther$adminNotes = other.adminNotes;
-    if (_$data.containsKey('adminNotes') !=
-        other._$data.containsKey('adminNotes')) {
-      return false;
-    }
-    if (l$adminNotes != lOther$adminNotes) {
-      return false;
-    }
-    final l$events = events;
-    final lOther$events = other.events;
-    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
-      return false;
-    }
-    if (l$events != null && lOther$events != null) {
-      if (l$events.length != lOther$events.length) {
-        return false;
-      }
-      for (int i = 0; i < l$events.length; i++) {
-        final l$events$entry = l$events[i];
-        final lOther$events$entry = lOther$events[i];
-        if (l$events$entry != lOther$events$entry) {
-          return false;
-        }
-      }
-    } else if (l$events != lOther$events) {
-      return false;
-    }
-    final l$metadata = metadata;
-    final lOther$metadata = other.metadata;
-    if (_$data.containsKey('metadata') !=
-        other._$data.containsKey('metadata')) {
-      return false;
-    }
-    if (l$metadata != lOther$metadata) {
-      return false;
-    }
-    final l$createdAt = createdAt;
-    final lOther$createdAt = other.createdAt;
-    if (_$data.containsKey('createdAt') !=
-        other._$data.containsKey('createdAt')) {
-      return false;
-    }
-    if (l$createdAt != lOther$createdAt) {
-      return false;
-    }
-    final l$createdBy = createdBy;
-    final lOther$createdBy = other.createdBy;
-    if (_$data.containsKey('createdBy') !=
-        other._$data.containsKey('createdBy')) {
-      return false;
-    }
-    if (l$createdBy != lOther$createdBy) {
-      return false;
-    }
-    final l$updatedAt = updatedAt;
-    final lOther$updatedAt = other.updatedAt;
-    if (_$data.containsKey('updatedAt') !=
-        other._$data.containsKey('updatedAt')) {
-      return false;
-    }
-    if (l$updatedAt != lOther$updatedAt) {
-      return false;
-    }
-    final l$updatedBy = updatedBy;
-    final lOther$updatedBy = other.updatedBy;
-    if (_$data.containsKey('updatedBy') !=
-        other._$data.containsKey('updatedBy')) {
-      return false;
-    }
-    if (l$updatedBy != lOther$updatedBy) {
-      return false;
-    }
-    final l$deletedAt = deletedAt;
-    final lOther$deletedAt = other.deletedAt;
-    if (_$data.containsKey('deletedAt') !=
-        other._$data.containsKey('deletedAt')) {
-      return false;
-    }
-    if (l$deletedAt != lOther$deletedAt) {
-      return false;
-    }
-    final l$deletedBy = deletedBy;
-    final lOther$deletedBy = other.deletedBy;
-    if (_$data.containsKey('deletedBy') !=
-        other._$data.containsKey('deletedBy')) {
-      return false;
-    }
-    if (l$deletedBy != lOther$deletedBy) {
-      return false;
-    }
-    final l$someMatchingRule = someMatchingRule;
-    final lOther$someMatchingRule = other.someMatchingRule;
-    if (_$data.containsKey('someMatchingRule') !=
-        other._$data.containsKey('someMatchingRule')) {
-      return false;
-    }
-    if (l$someMatchingRule != lOther$someMatchingRule) {
-      return false;
-    }
-    final l$someOtherMatchingRule = someOtherMatchingRule;
-    final lOther$someOtherMatchingRule = other.someOtherMatchingRule;
-    if (_$data.containsKey('someOtherMatchingRule') !=
-        other._$data.containsKey('someOtherMatchingRule')) {
-      return false;
-    }
-    if (l$someOtherMatchingRule != lOther$someOtherMatchingRule) {
-      return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode {
-    final l$id = id;
-    final l$adminNotes = adminNotes;
-    final l$events = events;
-    final l$metadata = metadata;
-    final l$createdAt = createdAt;
-    final l$createdBy = createdBy;
-    final l$updatedAt = updatedAt;
-    final l$updatedBy = updatedBy;
-    final l$deletedAt = deletedAt;
-    final l$deletedBy = deletedBy;
-    final l$someMatchingRule = someMatchingRule;
-    final l$someOtherMatchingRule = someOtherMatchingRule;
-    return Object.hashAll([
-      _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
-      _$data.containsKey('events')
-          ? l$events == null
-              ? null
-              : Object.hashAll(l$events.map((v) => v))
-          : const {},
-      _$data.containsKey('metadata') ? l$metadata : const {},
-      _$data.containsKey('createdAt') ? l$createdAt : const {},
-      _$data.containsKey('createdBy') ? l$createdBy : const {},
-      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
-      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
-      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
-      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
-      _$data.containsKey('someMatchingRule') ? l$someMatchingRule : const {},
-      _$data.containsKey('someOtherMatchingRule')
-          ? l$someOtherMatchingRule
-          : const {},
-    ]);
-  }
-}
-
-abstract class CopyWith$Input$GenMatchingEngineInput<TRes> {
-  factory CopyWith$Input$GenMatchingEngineInput(
-    Input$GenMatchingEngineInput instance,
-    TRes Function(Input$GenMatchingEngineInput) then,
-  ) = _CopyWithImpl$Input$GenMatchingEngineInput;
-
-  factory CopyWith$Input$GenMatchingEngineInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$GenMatchingEngineInput;
-
-  TRes call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  });
-  TRes events(
-      Iterable<Input$ModelEventInput>? Function(
-              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-          _fn);
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
-}
-
-class _CopyWithImpl$Input$GenMatchingEngineInput<TRes>
-    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
-  _CopyWithImpl$Input$GenMatchingEngineInput(
-    this._instance,
-    this._then,
-  );
-
-  final Input$GenMatchingEngineInput _instance;
-
-  final TRes Function(Input$GenMatchingEngineInput) _then;
-
-  static const _undefined = <dynamic, dynamic>{};
-
-  TRes call({
-    Object? id = _undefined,
-    Object? adminNotes = _undefined,
-    Object? events = _undefined,
-    Object? metadata = _undefined,
-    Object? createdAt = _undefined,
-    Object? createdBy = _undefined,
-    Object? updatedAt = _undefined,
-    Object? updatedBy = _undefined,
-    Object? deletedAt = _undefined,
-    Object? deletedBy = _undefined,
-    Object? someMatchingRule = _undefined,
-    Object? someOtherMatchingRule = _undefined,
-  }) =>
-      _then(Input$GenMatchingEngineInput._({
-        ..._instance._$data,
-        if (id != _undefined) 'id': (id as String?),
-        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
-        if (events != _undefined)
-          'events': (events as List<Input$ModelEventInput>?),
-        if (metadata != _undefined)
-          'metadata': (metadata as Input$BaseModelMetadataInput?),
-        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
-        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
-        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
-        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
-        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
-        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
-        if (someMatchingRule != _undefined && someMatchingRule != null)
-          'someMatchingRule': (someMatchingRule as bool),
-        if (someOtherMatchingRule != _undefined &&
-            someOtherMatchingRule != null)
-          'someOtherMatchingRule': (someOtherMatchingRule as bool),
-      }));
-  TRes events(
-          Iterable<Input$ModelEventInput>? Function(
-                  Iterable<
-                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
-              _fn) =>
-      call(
-          events:
-              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
-                    e,
-                    (i) => i,
-                  )))?.toList());
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
-    final local$metadata = _instance.metadata;
-    return local$metadata == null
-        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
-        : CopyWith$Input$BaseModelMetadataInput(
-            local$metadata, (e) => call(metadata: e));
-  }
-}
-
-class _CopyWithStubImpl$Input$GenMatchingEngineInput<TRes>
-    implements CopyWith$Input$GenMatchingEngineInput<TRes> {
-  _CopyWithStubImpl$Input$GenMatchingEngineInput(this._res);
-
-  TRes _res;
-
-  call({
-    String? id,
-    String? adminNotes,
-    List<Input$ModelEventInput>? events,
-    Input$BaseModelMetadataInput? metadata,
-    DateTime? createdAt,
-    String? createdBy,
-    DateTime? updatedAt,
-    String? updatedBy,
-    DateTime? deletedAt,
-    String? deletedBy,
-    bool? someMatchingRule,
-    bool? someOtherMatchingRule,
-  }) =>
-      _res;
-  events(_fn) => _res;
-  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
-      CopyWith$Input$BaseModelMetadataInput.stub(_res);
-}
-
 class Input$MenteesGroupMembershipInput {
   factory Input$MenteesGroupMembershipInput({
     String? id,
@@ -19776,6 +18128,7 @@ class Input$MenteesGroupMembershipInput {
     String? currentChallenges,
     String? futureGoals,
     String? motivationsForMentorship,
+    String? reasonsForStartingBusiness,
   }) =>
       Input$MenteesGroupMembershipInput._({
         if (id != null) r'id': id,
@@ -19800,6 +18153,8 @@ class Input$MenteesGroupMembershipInput {
         if (futureGoals != null) r'futureGoals': futureGoals,
         if (motivationsForMentorship != null)
           r'motivationsForMentorship': motivationsForMentorship,
+        if (reasonsForStartingBusiness != null)
+          r'reasonsForStartingBusiness': reasonsForStartingBusiness,
       });
 
   Input$MenteesGroupMembershipInput._(this._$data);
@@ -19902,6 +18257,11 @@ class Input$MenteesGroupMembershipInput {
       result$data['motivationsForMentorship'] =
           (l$motivationsForMentorship as String?);
     }
+    if (data.containsKey('reasonsForStartingBusiness')) {
+      final l$reasonsForStartingBusiness = data['reasonsForStartingBusiness'];
+      result$data['reasonsForStartingBusiness'] =
+          (l$reasonsForStartingBusiness as String?);
+    }
     return Input$MenteesGroupMembershipInput._(result$data);
   }
 
@@ -19932,6 +18292,8 @@ class Input$MenteesGroupMembershipInput {
   String? get futureGoals => (_$data['futureGoals'] as String?);
   String? get motivationsForMentorship =>
       (_$data['motivationsForMentorship'] as String?);
+  String? get reasonsForStartingBusiness =>
+      (_$data['reasonsForStartingBusiness'] as String?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
@@ -20015,6 +18377,10 @@ class Input$MenteesGroupMembershipInput {
     if (_$data.containsKey('motivationsForMentorship')) {
       final l$motivationsForMentorship = motivationsForMentorship;
       result$data['motivationsForMentorship'] = l$motivationsForMentorship;
+    }
+    if (_$data.containsKey('reasonsForStartingBusiness')) {
+      final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
+      result$data['reasonsForStartingBusiness'] = l$reasonsForStartingBusiness;
     }
     return result$data;
   }
@@ -20245,6 +18611,15 @@ class Input$MenteesGroupMembershipInput {
     if (l$motivationsForMentorship != lOther$motivationsForMentorship) {
       return false;
     }
+    final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
+    final lOther$reasonsForStartingBusiness = other.reasonsForStartingBusiness;
+    if (_$data.containsKey('reasonsForStartingBusiness') !=
+        other._$data.containsKey('reasonsForStartingBusiness')) {
+      return false;
+    }
+    if (l$reasonsForStartingBusiness != lOther$reasonsForStartingBusiness) {
+      return false;
+    }
     return true;
   }
 
@@ -20270,6 +18645,7 @@ class Input$MenteesGroupMembershipInput {
     final l$currentChallenges = currentChallenges;
     final l$futureGoals = futureGoals;
     final l$motivationsForMentorship = motivationsForMentorship;
+    final l$reasonsForStartingBusiness = reasonsForStartingBusiness;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
       _$data.containsKey('adminNotes') ? l$adminNotes : const {},
@@ -20305,6 +18681,9 @@ class Input$MenteesGroupMembershipInput {
       _$data.containsKey('motivationsForMentorship')
           ? l$motivationsForMentorship
           : const {},
+      _$data.containsKey('reasonsForStartingBusiness')
+          ? l$reasonsForStartingBusiness
+          : const {},
     ]);
   }
 }
@@ -20339,6 +18718,7 @@ abstract class CopyWith$Input$MenteesGroupMembershipInput<TRes> {
     String? currentChallenges,
     String? futureGoals,
     String? motivationsForMentorship,
+    String? reasonsForStartingBusiness,
   });
   TRes events(
       Iterable<Input$ModelEventInput>? Function(
@@ -20381,6 +18761,7 @@ class _CopyWithImpl$Input$MenteesGroupMembershipInput<TRes>
     Object? currentChallenges = _undefined,
     Object? futureGoals = _undefined,
     Object? motivationsForMentorship = _undefined,
+    Object? reasonsForStartingBusiness = _undefined,
   }) =>
       _then(Input$MenteesGroupMembershipInput._({
         ..._instance._$data,
@@ -20413,6 +18794,8 @@ class _CopyWithImpl$Input$MenteesGroupMembershipInput<TRes>
         if (futureGoals != _undefined) 'futureGoals': (futureGoals as String?),
         if (motivationsForMentorship != _undefined)
           'motivationsForMentorship': (motivationsForMentorship as String?),
+        if (reasonsForStartingBusiness != _undefined)
+          'reasonsForStartingBusiness': (reasonsForStartingBusiness as String?),
       }));
   TRes events(
           Iterable<Input$ModelEventInput>? Function(
@@ -20461,6 +18844,7 @@ class _CopyWithStubImpl$Input$MenteesGroupMembershipInput<TRes>
     String? currentChallenges,
     String? futureGoals,
     String? motivationsForMentorship,
+    String? reasonsForStartingBusiness,
   }) =>
       _res;
   events(_fn) => _res;
@@ -23723,81 +22107,276 @@ class _CopyWithStubImpl$Input$NotificationTemplateInput<TRes>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
-class Input$NlpMessageInput {
-  factory Input$NlpMessageInput({
+class Input$Mm2SynchronizationInput {
+  factory Input$Mm2SynchronizationInput({
     String? id,
-    String? labelName,
-    String? labelProcessor,
-    int? labelProbability,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    Enum$Mm2SyncDirection? direction,
+    String? objectId,
+    Enum$Mm2ModelType? mm2ModelType,
+    Enum$Mm2SynchronizationMode? syncMode,
+    int? limit,
+    bool? autorun,
+    String? usersSinceUpdatedAt,
+    Enum$Mm2SynchronizerLogLevel? logLevel,
+    DateTime? expiresAt,
   }) =>
-      Input$NlpMessageInput._({
+      Input$Mm2SynchronizationInput._({
         if (id != null) r'id': id,
-        if (labelName != null) r'labelName': labelName,
-        if (labelProcessor != null) r'labelProcessor': labelProcessor,
-        if (labelProbability != null) r'labelProbability': labelProbability,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+        if (events != null) r'events': events,
+        if (metadata != null) r'metadata': metadata,
+        if (createdAt != null) r'createdAt': createdAt,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (updatedAt != null) r'updatedAt': updatedAt,
+        if (updatedBy != null) r'updatedBy': updatedBy,
+        if (deletedAt != null) r'deletedAt': deletedAt,
+        if (deletedBy != null) r'deletedBy': deletedBy,
+        if (direction != null) r'direction': direction,
+        if (objectId != null) r'objectId': objectId,
+        if (mm2ModelType != null) r'mm2ModelType': mm2ModelType,
+        if (syncMode != null) r'syncMode': syncMode,
+        if (limit != null) r'limit': limit,
+        if (autorun != null) r'autorun': autorun,
+        if (usersSinceUpdatedAt != null)
+          r'usersSinceUpdatedAt': usersSinceUpdatedAt,
+        if (logLevel != null) r'logLevel': logLevel,
+        if (expiresAt != null) r'expiresAt': expiresAt,
       });
 
-  Input$NlpMessageInput._(this._$data);
+  Input$Mm2SynchronizationInput._(this._$data);
 
-  factory Input$NlpMessageInput.fromJson(Map<String, dynamic> data) {
+  factory Input$Mm2SynchronizationInput.fromJson(Map<String, dynamic> data) {
     final result$data = <String, dynamic>{};
     if (data.containsKey('id')) {
       final l$id = data['id'];
-      result$data['id'] = (l$id as String);
+      result$data['id'] = (l$id as String?);
     }
-    if (data.containsKey('labelName')) {
-      final l$labelName = data['labelName'];
-      result$data['labelName'] = (l$labelName as String);
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String?);
     }
-    if (data.containsKey('labelProcessor')) {
-      final l$labelProcessor = data['labelProcessor'];
-      result$data['labelProcessor'] = (l$labelProcessor as String);
+    if (data.containsKey('events')) {
+      final l$events = data['events'];
+      result$data['events'] = (l$events as List<dynamic>?)
+          ?.map((e) =>
+              Input$ModelEventInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
     }
-    if (data.containsKey('labelProbability')) {
-      final l$labelProbability = data['labelProbability'];
-      result$data['labelProbability'] = (l$labelProbability as int);
+    if (data.containsKey('metadata')) {
+      final l$metadata = data['metadata'];
+      result$data['metadata'] = l$metadata == null
+          ? null
+          : Input$BaseModelMetadataInput.fromJson(
+              (l$metadata as Map<String, dynamic>));
     }
-    return Input$NlpMessageInput._(result$data);
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('updatedAt')) {
+      final l$updatedAt = data['updatedAt'];
+      result$data['updatedAt'] =
+          l$updatedAt == null ? null : DateTime.parse((l$updatedAt as String));
+    }
+    if (data.containsKey('updatedBy')) {
+      final l$updatedBy = data['updatedBy'];
+      result$data['updatedBy'] = (l$updatedBy as String?);
+    }
+    if (data.containsKey('deletedAt')) {
+      final l$deletedAt = data['deletedAt'];
+      result$data['deletedAt'] =
+          l$deletedAt == null ? null : DateTime.parse((l$deletedAt as String));
+    }
+    if (data.containsKey('deletedBy')) {
+      final l$deletedBy = data['deletedBy'];
+      result$data['deletedBy'] = (l$deletedBy as String?);
+    }
+    if (data.containsKey('direction')) {
+      final l$direction = data['direction'];
+      result$data['direction'] =
+          fromJson$Enum$Mm2SyncDirection((l$direction as String));
+    }
+    if (data.containsKey('objectId')) {
+      final l$objectId = data['objectId'];
+      result$data['objectId'] = (l$objectId as String?);
+    }
+    if (data.containsKey('mm2ModelType')) {
+      final l$mm2ModelType = data['mm2ModelType'];
+      result$data['mm2ModelType'] = l$mm2ModelType == null
+          ? null
+          : fromJson$Enum$Mm2ModelType((l$mm2ModelType as String));
+    }
+    if (data.containsKey('syncMode')) {
+      final l$syncMode = data['syncMode'];
+      result$data['syncMode'] =
+          fromJson$Enum$Mm2SynchronizationMode((l$syncMode as String));
+    }
+    if (data.containsKey('limit')) {
+      final l$limit = data['limit'];
+      result$data['limit'] = (l$limit as int?);
+    }
+    if (data.containsKey('autorun')) {
+      final l$autorun = data['autorun'];
+      result$data['autorun'] = (l$autorun as bool);
+    }
+    if (data.containsKey('usersSinceUpdatedAt')) {
+      final l$usersSinceUpdatedAt = data['usersSinceUpdatedAt'];
+      result$data['usersSinceUpdatedAt'] = (l$usersSinceUpdatedAt as String?);
+    }
+    if (data.containsKey('logLevel')) {
+      final l$logLevel = data['logLevel'];
+      result$data['logLevel'] = l$logLevel == null
+          ? null
+          : fromJson$Enum$Mm2SynchronizerLogLevel((l$logLevel as String));
+    }
+    if (data.containsKey('expiresAt')) {
+      final l$expiresAt = data['expiresAt'];
+      result$data['expiresAt'] =
+          l$expiresAt == null ? null : DateTime.parse((l$expiresAt as String));
+    }
+    return Input$Mm2SynchronizationInput._(result$data);
   }
 
   Map<String, dynamic> _$data;
 
   String? get id => (_$data['id'] as String?);
-  String? get labelName => (_$data['labelName'] as String?);
-  String? get labelProcessor => (_$data['labelProcessor'] as String?);
-  int? get labelProbability => (_$data['labelProbability'] as int?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  List<Input$ModelEventInput>? get events =>
+      (_$data['events'] as List<Input$ModelEventInput>?);
+  Input$BaseModelMetadataInput? get metadata =>
+      (_$data['metadata'] as Input$BaseModelMetadataInput?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get updatedAt => (_$data['updatedAt'] as DateTime?);
+  String? get updatedBy => (_$data['updatedBy'] as String?);
+  DateTime? get deletedAt => (_$data['deletedAt'] as DateTime?);
+  String? get deletedBy => (_$data['deletedBy'] as String?);
+  Enum$Mm2SyncDirection? get direction =>
+      (_$data['direction'] as Enum$Mm2SyncDirection?);
+  String? get objectId => (_$data['objectId'] as String?);
+  Enum$Mm2ModelType? get mm2ModelType =>
+      (_$data['mm2ModelType'] as Enum$Mm2ModelType?);
+  Enum$Mm2SynchronizationMode? get syncMode =>
+      (_$data['syncMode'] as Enum$Mm2SynchronizationMode?);
+  int? get limit => (_$data['limit'] as int?);
+  bool? get autorun => (_$data['autorun'] as bool?);
+  String? get usersSinceUpdatedAt => (_$data['usersSinceUpdatedAt'] as String?);
+  Enum$Mm2SynchronizerLogLevel? get logLevel =>
+      (_$data['logLevel'] as Enum$Mm2SynchronizerLogLevel?);
+  DateTime? get expiresAt => (_$data['expiresAt'] as DateTime?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('id')) {
       final l$id = id;
-      result$data['id'] = (l$id as String);
+      result$data['id'] = l$id;
     }
-    if (_$data.containsKey('labelName')) {
-      final l$labelName = labelName;
-      result$data['labelName'] = (l$labelName as String);
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = l$adminNotes;
     }
-    if (_$data.containsKey('labelProcessor')) {
-      final l$labelProcessor = labelProcessor;
-      result$data['labelProcessor'] = (l$labelProcessor as String);
+    if (_$data.containsKey('events')) {
+      final l$events = events;
+      result$data['events'] = l$events?.map((e) => e.toJson()).toList();
     }
-    if (_$data.containsKey('labelProbability')) {
-      final l$labelProbability = labelProbability;
-      result$data['labelProbability'] = (l$labelProbability as int);
+    if (_$data.containsKey('metadata')) {
+      final l$metadata = metadata;
+      result$data['metadata'] = l$metadata?.toJson();
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('updatedAt')) {
+      final l$updatedAt = updatedAt;
+      result$data['updatedAt'] = l$updatedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('updatedBy')) {
+      final l$updatedBy = updatedBy;
+      result$data['updatedBy'] = l$updatedBy;
+    }
+    if (_$data.containsKey('deletedAt')) {
+      final l$deletedAt = deletedAt;
+      result$data['deletedAt'] = l$deletedAt?.toIso8601String();
+    }
+    if (_$data.containsKey('deletedBy')) {
+      final l$deletedBy = deletedBy;
+      result$data['deletedBy'] = l$deletedBy;
+    }
+    if (_$data.containsKey('direction')) {
+      final l$direction = direction;
+      result$data['direction'] =
+          toJson$Enum$Mm2SyncDirection((l$direction as Enum$Mm2SyncDirection));
+    }
+    if (_$data.containsKey('objectId')) {
+      final l$objectId = objectId;
+      result$data['objectId'] = l$objectId;
+    }
+    if (_$data.containsKey('mm2ModelType')) {
+      final l$mm2ModelType = mm2ModelType;
+      result$data['mm2ModelType'] = l$mm2ModelType == null
+          ? null
+          : toJson$Enum$Mm2ModelType(l$mm2ModelType);
+    }
+    if (_$data.containsKey('syncMode')) {
+      final l$syncMode = syncMode;
+      result$data['syncMode'] = toJson$Enum$Mm2SynchronizationMode(
+          (l$syncMode as Enum$Mm2SynchronizationMode));
+    }
+    if (_$data.containsKey('limit')) {
+      final l$limit = limit;
+      result$data['limit'] = l$limit;
+    }
+    if (_$data.containsKey('autorun')) {
+      final l$autorun = autorun;
+      result$data['autorun'] = (l$autorun as bool);
+    }
+    if (_$data.containsKey('usersSinceUpdatedAt')) {
+      final l$usersSinceUpdatedAt = usersSinceUpdatedAt;
+      result$data['usersSinceUpdatedAt'] = l$usersSinceUpdatedAt;
+    }
+    if (_$data.containsKey('logLevel')) {
+      final l$logLevel = logLevel;
+      result$data['logLevel'] = l$logLevel == null
+          ? null
+          : toJson$Enum$Mm2SynchronizerLogLevel(l$logLevel);
+    }
+    if (_$data.containsKey('expiresAt')) {
+      final l$expiresAt = expiresAt;
+      result$data['expiresAt'] = l$expiresAt?.toIso8601String();
     }
     return result$data;
   }
 
-  CopyWith$Input$NlpMessageInput<Input$NlpMessageInput> get copyWith =>
-      CopyWith$Input$NlpMessageInput(
-        this,
-        (i) => i,
-      );
+  CopyWith$Input$Mm2SynchronizationInput<Input$Mm2SynchronizationInput>
+      get copyWith => CopyWith$Input$Mm2SynchronizationInput(
+            this,
+            (i) => i,
+          );
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }
-    if (!(other is Input$NlpMessageInput) || runtimeType != other.runtimeType) {
+    if (!(other is Input$Mm2SynchronizationInput) ||
+        runtimeType != other.runtimeType) {
       return false;
     }
     final l$id = id;
@@ -23808,31 +22387,174 @@ class Input$NlpMessageInput {
     if (l$id != lOther$id) {
       return false;
     }
-    final l$labelName = labelName;
-    final lOther$labelName = other.labelName;
-    if (_$data.containsKey('labelName') !=
-        other._$data.containsKey('labelName')) {
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
       return false;
     }
-    if (l$labelName != lOther$labelName) {
+    if (l$adminNotes != lOther$adminNotes) {
       return false;
     }
-    final l$labelProcessor = labelProcessor;
-    final lOther$labelProcessor = other.labelProcessor;
-    if (_$data.containsKey('labelProcessor') !=
-        other._$data.containsKey('labelProcessor')) {
+    final l$events = events;
+    final lOther$events = other.events;
+    if (_$data.containsKey('events') != other._$data.containsKey('events')) {
       return false;
     }
-    if (l$labelProcessor != lOther$labelProcessor) {
+    if (l$events != null && lOther$events != null) {
+      if (l$events.length != lOther$events.length) {
+        return false;
+      }
+      for (int i = 0; i < l$events.length; i++) {
+        final l$events$entry = l$events[i];
+        final lOther$events$entry = lOther$events[i];
+        if (l$events$entry != lOther$events$entry) {
+          return false;
+        }
+      }
+    } else if (l$events != lOther$events) {
       return false;
     }
-    final l$labelProbability = labelProbability;
-    final lOther$labelProbability = other.labelProbability;
-    if (_$data.containsKey('labelProbability') !=
-        other._$data.containsKey('labelProbability')) {
+    final l$metadata = metadata;
+    final lOther$metadata = other.metadata;
+    if (_$data.containsKey('metadata') !=
+        other._$data.containsKey('metadata')) {
       return false;
     }
-    if (l$labelProbability != lOther$labelProbability) {
+    if (l$metadata != lOther$metadata) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$updatedAt = updatedAt;
+    final lOther$updatedAt = other.updatedAt;
+    if (_$data.containsKey('updatedAt') !=
+        other._$data.containsKey('updatedAt')) {
+      return false;
+    }
+    if (l$updatedAt != lOther$updatedAt) {
+      return false;
+    }
+    final l$updatedBy = updatedBy;
+    final lOther$updatedBy = other.updatedBy;
+    if (_$data.containsKey('updatedBy') !=
+        other._$data.containsKey('updatedBy')) {
+      return false;
+    }
+    if (l$updatedBy != lOther$updatedBy) {
+      return false;
+    }
+    final l$deletedAt = deletedAt;
+    final lOther$deletedAt = other.deletedAt;
+    if (_$data.containsKey('deletedAt') !=
+        other._$data.containsKey('deletedAt')) {
+      return false;
+    }
+    if (l$deletedAt != lOther$deletedAt) {
+      return false;
+    }
+    final l$deletedBy = deletedBy;
+    final lOther$deletedBy = other.deletedBy;
+    if (_$data.containsKey('deletedBy') !=
+        other._$data.containsKey('deletedBy')) {
+      return false;
+    }
+    if (l$deletedBy != lOther$deletedBy) {
+      return false;
+    }
+    final l$direction = direction;
+    final lOther$direction = other.direction;
+    if (_$data.containsKey('direction') !=
+        other._$data.containsKey('direction')) {
+      return false;
+    }
+    if (l$direction != lOther$direction) {
+      return false;
+    }
+    final l$objectId = objectId;
+    final lOther$objectId = other.objectId;
+    if (_$data.containsKey('objectId') !=
+        other._$data.containsKey('objectId')) {
+      return false;
+    }
+    if (l$objectId != lOther$objectId) {
+      return false;
+    }
+    final l$mm2ModelType = mm2ModelType;
+    final lOther$mm2ModelType = other.mm2ModelType;
+    if (_$data.containsKey('mm2ModelType') !=
+        other._$data.containsKey('mm2ModelType')) {
+      return false;
+    }
+    if (l$mm2ModelType != lOther$mm2ModelType) {
+      return false;
+    }
+    final l$syncMode = syncMode;
+    final lOther$syncMode = other.syncMode;
+    if (_$data.containsKey('syncMode') !=
+        other._$data.containsKey('syncMode')) {
+      return false;
+    }
+    if (l$syncMode != lOther$syncMode) {
+      return false;
+    }
+    final l$limit = limit;
+    final lOther$limit = other.limit;
+    if (_$data.containsKey('limit') != other._$data.containsKey('limit')) {
+      return false;
+    }
+    if (l$limit != lOther$limit) {
+      return false;
+    }
+    final l$autorun = autorun;
+    final lOther$autorun = other.autorun;
+    if (_$data.containsKey('autorun') != other._$data.containsKey('autorun')) {
+      return false;
+    }
+    if (l$autorun != lOther$autorun) {
+      return false;
+    }
+    final l$usersSinceUpdatedAt = usersSinceUpdatedAt;
+    final lOther$usersSinceUpdatedAt = other.usersSinceUpdatedAt;
+    if (_$data.containsKey('usersSinceUpdatedAt') !=
+        other._$data.containsKey('usersSinceUpdatedAt')) {
+      return false;
+    }
+    if (l$usersSinceUpdatedAt != lOther$usersSinceUpdatedAt) {
+      return false;
+    }
+    final l$logLevel = logLevel;
+    final lOther$logLevel = other.logLevel;
+    if (_$data.containsKey('logLevel') !=
+        other._$data.containsKey('logLevel')) {
+      return false;
+    }
+    if (l$logLevel != lOther$logLevel) {
+      return false;
+    }
+    final l$expiresAt = expiresAt;
+    final lOther$expiresAt = other.expiresAt;
+    if (_$data.containsKey('expiresAt') !=
+        other._$data.containsKey('expiresAt')) {
+      return false;
+    }
+    if (l$expiresAt != lOther$expiresAt) {
       return false;
     }
     return true;
@@ -23841,79 +22563,206 @@ class Input$NlpMessageInput {
   @override
   int get hashCode {
     final l$id = id;
-    final l$labelName = labelName;
-    final l$labelProcessor = labelProcessor;
-    final l$labelProbability = labelProbability;
+    final l$adminNotes = adminNotes;
+    final l$events = events;
+    final l$metadata = metadata;
+    final l$createdAt = createdAt;
+    final l$createdBy = createdBy;
+    final l$updatedAt = updatedAt;
+    final l$updatedBy = updatedBy;
+    final l$deletedAt = deletedAt;
+    final l$deletedBy = deletedBy;
+    final l$direction = direction;
+    final l$objectId = objectId;
+    final l$mm2ModelType = mm2ModelType;
+    final l$syncMode = syncMode;
+    final l$limit = limit;
+    final l$autorun = autorun;
+    final l$usersSinceUpdatedAt = usersSinceUpdatedAt;
+    final l$logLevel = logLevel;
+    final l$expiresAt = expiresAt;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
-      _$data.containsKey('labelName') ? l$labelName : const {},
-      _$data.containsKey('labelProcessor') ? l$labelProcessor : const {},
-      _$data.containsKey('labelProbability') ? l$labelProbability : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+      _$data.containsKey('events')
+          ? l$events == null
+              ? null
+              : Object.hashAll(l$events.map((v) => v))
+          : const {},
+      _$data.containsKey('metadata') ? l$metadata : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('updatedAt') ? l$updatedAt : const {},
+      _$data.containsKey('updatedBy') ? l$updatedBy : const {},
+      _$data.containsKey('deletedAt') ? l$deletedAt : const {},
+      _$data.containsKey('deletedBy') ? l$deletedBy : const {},
+      _$data.containsKey('direction') ? l$direction : const {},
+      _$data.containsKey('objectId') ? l$objectId : const {},
+      _$data.containsKey('mm2ModelType') ? l$mm2ModelType : const {},
+      _$data.containsKey('syncMode') ? l$syncMode : const {},
+      _$data.containsKey('limit') ? l$limit : const {},
+      _$data.containsKey('autorun') ? l$autorun : const {},
+      _$data.containsKey('usersSinceUpdatedAt')
+          ? l$usersSinceUpdatedAt
+          : const {},
+      _$data.containsKey('logLevel') ? l$logLevel : const {},
+      _$data.containsKey('expiresAt') ? l$expiresAt : const {},
     ]);
   }
 }
 
-abstract class CopyWith$Input$NlpMessageInput<TRes> {
-  factory CopyWith$Input$NlpMessageInput(
-    Input$NlpMessageInput instance,
-    TRes Function(Input$NlpMessageInput) then,
-  ) = _CopyWithImpl$Input$NlpMessageInput;
+abstract class CopyWith$Input$Mm2SynchronizationInput<TRes> {
+  factory CopyWith$Input$Mm2SynchronizationInput(
+    Input$Mm2SynchronizationInput instance,
+    TRes Function(Input$Mm2SynchronizationInput) then,
+  ) = _CopyWithImpl$Input$Mm2SynchronizationInput;
 
-  factory CopyWith$Input$NlpMessageInput.stub(TRes res) =
-      _CopyWithStubImpl$Input$NlpMessageInput;
+  factory CopyWith$Input$Mm2SynchronizationInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$Mm2SynchronizationInput;
 
   TRes call({
     String? id,
-    String? labelName,
-    String? labelProcessor,
-    int? labelProbability,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    Enum$Mm2SyncDirection? direction,
+    String? objectId,
+    Enum$Mm2ModelType? mm2ModelType,
+    Enum$Mm2SynchronizationMode? syncMode,
+    int? limit,
+    bool? autorun,
+    String? usersSinceUpdatedAt,
+    Enum$Mm2SynchronizerLogLevel? logLevel,
+    DateTime? expiresAt,
   });
+  TRes events(
+      Iterable<Input$ModelEventInput>? Function(
+              Iterable<CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+          _fn);
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata;
 }
 
-class _CopyWithImpl$Input$NlpMessageInput<TRes>
-    implements CopyWith$Input$NlpMessageInput<TRes> {
-  _CopyWithImpl$Input$NlpMessageInput(
+class _CopyWithImpl$Input$Mm2SynchronizationInput<TRes>
+    implements CopyWith$Input$Mm2SynchronizationInput<TRes> {
+  _CopyWithImpl$Input$Mm2SynchronizationInput(
     this._instance,
     this._then,
   );
 
-  final Input$NlpMessageInput _instance;
+  final Input$Mm2SynchronizationInput _instance;
 
-  final TRes Function(Input$NlpMessageInput) _then;
+  final TRes Function(Input$Mm2SynchronizationInput) _then;
 
   static const _undefined = <dynamic, dynamic>{};
 
   TRes call({
     Object? id = _undefined,
-    Object? labelName = _undefined,
-    Object? labelProcessor = _undefined,
-    Object? labelProbability = _undefined,
+    Object? adminNotes = _undefined,
+    Object? events = _undefined,
+    Object? metadata = _undefined,
+    Object? createdAt = _undefined,
+    Object? createdBy = _undefined,
+    Object? updatedAt = _undefined,
+    Object? updatedBy = _undefined,
+    Object? deletedAt = _undefined,
+    Object? deletedBy = _undefined,
+    Object? direction = _undefined,
+    Object? objectId = _undefined,
+    Object? mm2ModelType = _undefined,
+    Object? syncMode = _undefined,
+    Object? limit = _undefined,
+    Object? autorun = _undefined,
+    Object? usersSinceUpdatedAt = _undefined,
+    Object? logLevel = _undefined,
+    Object? expiresAt = _undefined,
   }) =>
-      _then(Input$NlpMessageInput._({
+      _then(Input$Mm2SynchronizationInput._({
         ..._instance._$data,
-        if (id != _undefined && id != null) 'id': (id as String),
-        if (labelName != _undefined && labelName != null)
-          'labelName': (labelName as String),
-        if (labelProcessor != _undefined && labelProcessor != null)
-          'labelProcessor': (labelProcessor as String),
-        if (labelProbability != _undefined && labelProbability != null)
-          'labelProbability': (labelProbability as int),
+        if (id != _undefined) 'id': (id as String?),
+        if (adminNotes != _undefined) 'adminNotes': (adminNotes as String?),
+        if (events != _undefined)
+          'events': (events as List<Input$ModelEventInput>?),
+        if (metadata != _undefined)
+          'metadata': (metadata as Input$BaseModelMetadataInput?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (updatedAt != _undefined) 'updatedAt': (updatedAt as DateTime?),
+        if (updatedBy != _undefined) 'updatedBy': (updatedBy as String?),
+        if (deletedAt != _undefined) 'deletedAt': (deletedAt as DateTime?),
+        if (deletedBy != _undefined) 'deletedBy': (deletedBy as String?),
+        if (direction != _undefined && direction != null)
+          'direction': (direction as Enum$Mm2SyncDirection),
+        if (objectId != _undefined) 'objectId': (objectId as String?),
+        if (mm2ModelType != _undefined)
+          'mm2ModelType': (mm2ModelType as Enum$Mm2ModelType?),
+        if (syncMode != _undefined && syncMode != null)
+          'syncMode': (syncMode as Enum$Mm2SynchronizationMode),
+        if (limit != _undefined) 'limit': (limit as int?),
+        if (autorun != _undefined && autorun != null)
+          'autorun': (autorun as bool),
+        if (usersSinceUpdatedAt != _undefined)
+          'usersSinceUpdatedAt': (usersSinceUpdatedAt as String?),
+        if (logLevel != _undefined)
+          'logLevel': (logLevel as Enum$Mm2SynchronizerLogLevel?),
+        if (expiresAt != _undefined) 'expiresAt': (expiresAt as DateTime?),
       }));
+  TRes events(
+          Iterable<Input$ModelEventInput>? Function(
+                  Iterable<
+                      CopyWith$Input$ModelEventInput<Input$ModelEventInput>>?)
+              _fn) =>
+      call(
+          events:
+              _fn(_instance.events?.map((e) => CopyWith$Input$ModelEventInput(
+                    e,
+                    (i) => i,
+                  )))?.toList());
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata {
+    final local$metadata = _instance.metadata;
+    return local$metadata == null
+        ? CopyWith$Input$BaseModelMetadataInput.stub(_then(_instance))
+        : CopyWith$Input$BaseModelMetadataInput(
+            local$metadata, (e) => call(metadata: e));
+  }
 }
 
-class _CopyWithStubImpl$Input$NlpMessageInput<TRes>
-    implements CopyWith$Input$NlpMessageInput<TRes> {
-  _CopyWithStubImpl$Input$NlpMessageInput(this._res);
+class _CopyWithStubImpl$Input$Mm2SynchronizationInput<TRes>
+    implements CopyWith$Input$Mm2SynchronizationInput<TRes> {
+  _CopyWithStubImpl$Input$Mm2SynchronizationInput(this._res);
 
   TRes _res;
 
   call({
     String? id,
-    String? labelName,
-    String? labelProcessor,
-    int? labelProbability,
+    String? adminNotes,
+    List<Input$ModelEventInput>? events,
+    Input$BaseModelMetadataInput? metadata,
+    DateTime? createdAt,
+    String? createdBy,
+    DateTime? updatedAt,
+    String? updatedBy,
+    DateTime? deletedAt,
+    String? deletedBy,
+    Enum$Mm2SyncDirection? direction,
+    String? objectId,
+    Enum$Mm2ModelType? mm2ModelType,
+    Enum$Mm2SynchronizationMode? syncMode,
+    int? limit,
+    bool? autorun,
+    String? usersSinceUpdatedAt,
+    Enum$Mm2SynchronizerLogLevel? logLevel,
+    DateTime? expiresAt,
   }) =>
       _res;
+  events(_fn) => _res;
+  CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
+      CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
 class Input$SidMultiStepActionInput {
@@ -26188,6 +25037,7 @@ enum Enum$OptionType {
   educationLevel,
   expertise,
   gender,
+  pronoun,
   country,
   industry,
   language,
@@ -26208,6 +25058,8 @@ String toJson$Enum$OptionType(Enum$OptionType e) {
       return r'expertise';
     case Enum$OptionType.gender:
       return r'gender';
+    case Enum$OptionType.pronoun:
+      return r'pronoun';
     case Enum$OptionType.country:
       return r'country';
     case Enum$OptionType.industry:
@@ -26235,6 +25087,8 @@ Enum$OptionType fromJson$Enum$OptionType(String value) {
       return Enum$OptionType.expertise;
     case r'gender':
       return Enum$OptionType.gender;
+    case r'pronoun':
+      return Enum$OptionType.pronoun;
     case r'country':
       return Enum$OptionType.country;
     case r'industry':
@@ -26534,6 +25388,8 @@ Enum$ChannelParticipantRole fromJson$Enum$ChannelParticipantRole(String value) {
 }
 
 enum Enum$ModelType {
+  AcademicExperience,
+  BusinessExperience,
   Company,
   MentorBoard,
   MentoringSession,
@@ -26572,6 +25428,10 @@ enum Enum$ModelType {
 
 String toJson$Enum$ModelType(Enum$ModelType e) {
   switch (e) {
+    case Enum$ModelType.AcademicExperience:
+      return r'AcademicExperience';
+    case Enum$ModelType.BusinessExperience:
+      return r'BusinessExperience';
     case Enum$ModelType.Company:
       return r'Company';
     case Enum$ModelType.MentorBoard:
@@ -26645,6 +25505,10 @@ String toJson$Enum$ModelType(Enum$ModelType e) {
 
 Enum$ModelType fromJson$Enum$ModelType(String value) {
   switch (value) {
+    case r'AcademicExperience':
+      return Enum$ModelType.AcademicExperience;
+    case r'BusinessExperience':
+      return Enum$ModelType.BusinessExperience;
     case r'Company':
       return Enum$ModelType.Company;
     case r'MentorBoard':
@@ -27289,6 +26153,12 @@ Enum$MultiStepActionResult fromJson$Enum$MultiStepActionResult(String value) {
 enum Enum$ServiceRequestType {
   graphQlQueryUserInbox,
   graphQlQueryUserUserSearches,
+  graphQlMutationCreateAcademicExperience,
+  graphQlMutationDeleteAcademicExperience,
+  graphQlMutationUpdateAcademicExperience,
+  graphQlMutationCreateBusinessExperience,
+  graphQlMutationDeleteBusinessExperience,
+  graphQlMutationUpdateBusinessExperience,
   graphQlMutationCreateCompany,
   graphQlMutationDeleteCompany,
   graphQlMutationUpdateCompany,
@@ -27312,6 +26182,7 @@ enum Enum$ServiceRequestType {
   graphQlQueryChannelInvitations,
   graphQlQueryChannelParticipants,
   graphQlQueryFindChannelInvitationById,
+  graphQlQueryFindChannelInvitationsBetweenUsers,
   graphQlQueryFindChannelInvitationsForUser,
   graphQlQueryFindChannelMessageById,
   graphQlQueryFindChannelMessages,
@@ -27402,6 +26273,18 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryUserInbox';
     case Enum$ServiceRequestType.graphQlQueryUserUserSearches:
       return r'graphQlQueryUserUserSearches';
+    case Enum$ServiceRequestType.graphQlMutationCreateAcademicExperience:
+      return r'graphQlMutationCreateAcademicExperience';
+    case Enum$ServiceRequestType.graphQlMutationDeleteAcademicExperience:
+      return r'graphQlMutationDeleteAcademicExperience';
+    case Enum$ServiceRequestType.graphQlMutationUpdateAcademicExperience:
+      return r'graphQlMutationUpdateAcademicExperience';
+    case Enum$ServiceRequestType.graphQlMutationCreateBusinessExperience:
+      return r'graphQlMutationCreateBusinessExperience';
+    case Enum$ServiceRequestType.graphQlMutationDeleteBusinessExperience:
+      return r'graphQlMutationDeleteBusinessExperience';
+    case Enum$ServiceRequestType.graphQlMutationUpdateBusinessExperience:
+      return r'graphQlMutationUpdateBusinessExperience';
     case Enum$ServiceRequestType.graphQlMutationCreateCompany:
       return r'graphQlMutationCreateCompany';
     case Enum$ServiceRequestType.graphQlMutationDeleteCompany:
@@ -27448,6 +26331,8 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryChannelParticipants';
     case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationById:
       return r'graphQlQueryFindChannelInvitationById';
+    case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsBetweenUsers:
+      return r'graphQlQueryFindChannelInvitationsBetweenUsers';
     case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsForUser:
       return r'graphQlQueryFindChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryFindChannelMessageById:
@@ -27622,6 +26507,18 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryUserInbox;
     case r'graphQlQueryUserUserSearches':
       return Enum$ServiceRequestType.graphQlQueryUserUserSearches;
+    case r'graphQlMutationCreateAcademicExperience':
+      return Enum$ServiceRequestType.graphQlMutationCreateAcademicExperience;
+    case r'graphQlMutationDeleteAcademicExperience':
+      return Enum$ServiceRequestType.graphQlMutationDeleteAcademicExperience;
+    case r'graphQlMutationUpdateAcademicExperience':
+      return Enum$ServiceRequestType.graphQlMutationUpdateAcademicExperience;
+    case r'graphQlMutationCreateBusinessExperience':
+      return Enum$ServiceRequestType.graphQlMutationCreateBusinessExperience;
+    case r'graphQlMutationDeleteBusinessExperience':
+      return Enum$ServiceRequestType.graphQlMutationDeleteBusinessExperience;
+    case r'graphQlMutationUpdateBusinessExperience':
+      return Enum$ServiceRequestType.graphQlMutationUpdateBusinessExperience;
     case r'graphQlMutationCreateCompany':
       return Enum$ServiceRequestType.graphQlMutationCreateCompany;
     case r'graphQlMutationDeleteCompany':
@@ -27669,6 +26566,9 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryChannelParticipants;
     case r'graphQlQueryFindChannelInvitationById':
       return Enum$ServiceRequestType.graphQlQueryFindChannelInvitationById;
+    case r'graphQlQueryFindChannelInvitationsBetweenUsers':
+      return Enum$ServiceRequestType
+          .graphQlQueryFindChannelInvitationsBetweenUsers;
     case r'graphQlQueryFindChannelInvitationsForUser':
       return Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsForUser;
     case r'graphQlQueryFindChannelMessageById':
@@ -27906,6 +26806,10 @@ Enum$ServiceRequestMessageId fromJson$Enum$ServiceRequestMessageId(
 }
 
 enum Enum$ErrorCode {
+  academicExperienceNameMissing,
+  academicExperienceUserIdMissing,
+  businessExperienceNameMissing,
+  businessExperienceUserIdMissing,
   companyNameMissing,
   companyNameTaken,
   contentTagAlreadyExist,
@@ -27957,6 +26861,14 @@ enum Enum$ErrorCode {
 
 String toJson$Enum$ErrorCode(Enum$ErrorCode e) {
   switch (e) {
+    case Enum$ErrorCode.academicExperienceNameMissing:
+      return r'academicExperienceNameMissing';
+    case Enum$ErrorCode.academicExperienceUserIdMissing:
+      return r'academicExperienceUserIdMissing';
+    case Enum$ErrorCode.businessExperienceNameMissing:
+      return r'businessExperienceNameMissing';
+    case Enum$ErrorCode.businessExperienceUserIdMissing:
+      return r'businessExperienceUserIdMissing';
     case Enum$ErrorCode.companyNameMissing:
       return r'companyNameMissing';
     case Enum$ErrorCode.companyNameTaken:
@@ -28056,6 +26968,14 @@ String toJson$Enum$ErrorCode(Enum$ErrorCode e) {
 
 Enum$ErrorCode fromJson$Enum$ErrorCode(String value) {
   switch (value) {
+    case r'academicExperienceNameMissing':
+      return Enum$ErrorCode.academicExperienceNameMissing;
+    case r'academicExperienceUserIdMissing':
+      return Enum$ErrorCode.academicExperienceUserIdMissing;
+    case r'businessExperienceNameMissing':
+      return Enum$ErrorCode.businessExperienceNameMissing;
+    case r'businessExperienceUserIdMissing':
+      return Enum$ErrorCode.businessExperienceUserIdMissing;
     case r'companyNameMissing':
       return Enum$ErrorCode.companyNameMissing;
     case r'companyNameTaken':
@@ -28239,6 +27159,198 @@ Enum$NotificationTemplateName fromJson$Enum$NotificationTemplateName(
       return Enum$NotificationTemplateName.welcome;
     default:
       return Enum$NotificationTemplateName.$unknown;
+  }
+}
+
+enum Enum$Mm2SyncDirection { mm2ToMm3, mm3ToMm2, $unknown }
+
+String toJson$Enum$Mm2SyncDirection(Enum$Mm2SyncDirection e) {
+  switch (e) {
+    case Enum$Mm2SyncDirection.mm2ToMm3:
+      return r'mm2ToMm3';
+    case Enum$Mm2SyncDirection.mm3ToMm2:
+      return r'mm3ToMm2';
+    case Enum$Mm2SyncDirection.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$Mm2SyncDirection fromJson$Enum$Mm2SyncDirection(String value) {
+  switch (value) {
+    case r'mm2ToMm3':
+      return Enum$Mm2SyncDirection.mm2ToMm3;
+    case r'mm3ToMm2':
+      return Enum$Mm2SyncDirection.mm3ToMm2;
+    default:
+      return Enum$Mm2SyncDirection.$unknown;
+  }
+}
+
+enum Enum$Mm2ModelType {
+  Community,
+  Organization,
+  Conversation,
+  Message,
+  User,
+  MenteeExpertise,
+  MenteeWebsite,
+  MentorExpertise,
+  Profile,
+  SpokenLanguage,
+  $unknown
+}
+
+String toJson$Enum$Mm2ModelType(Enum$Mm2ModelType e) {
+  switch (e) {
+    case Enum$Mm2ModelType.Community:
+      return r'Community';
+    case Enum$Mm2ModelType.Organization:
+      return r'Organization';
+    case Enum$Mm2ModelType.Conversation:
+      return r'Conversation';
+    case Enum$Mm2ModelType.Message:
+      return r'Message';
+    case Enum$Mm2ModelType.User:
+      return r'User';
+    case Enum$Mm2ModelType.MenteeExpertise:
+      return r'MenteeExpertise';
+    case Enum$Mm2ModelType.MenteeWebsite:
+      return r'MenteeWebsite';
+    case Enum$Mm2ModelType.MentorExpertise:
+      return r'MentorExpertise';
+    case Enum$Mm2ModelType.Profile:
+      return r'Profile';
+    case Enum$Mm2ModelType.SpokenLanguage:
+      return r'SpokenLanguage';
+    case Enum$Mm2ModelType.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$Mm2ModelType fromJson$Enum$Mm2ModelType(String value) {
+  switch (value) {
+    case r'Community':
+      return Enum$Mm2ModelType.Community;
+    case r'Organization':
+      return Enum$Mm2ModelType.Organization;
+    case r'Conversation':
+      return Enum$Mm2ModelType.Conversation;
+    case r'Message':
+      return Enum$Mm2ModelType.Message;
+    case r'User':
+      return Enum$Mm2ModelType.User;
+    case r'MenteeExpertise':
+      return Enum$Mm2ModelType.MenteeExpertise;
+    case r'MenteeWebsite':
+      return Enum$Mm2ModelType.MenteeWebsite;
+    case r'MentorExpertise':
+      return Enum$Mm2ModelType.MentorExpertise;
+    case r'Profile':
+      return Enum$Mm2ModelType.Profile;
+    case r'SpokenLanguage':
+      return Enum$Mm2ModelType.SpokenLanguage;
+    default:
+      return Enum$Mm2ModelType.$unknown;
+  }
+}
+
+enum Enum$Mm2SynchronizationMode { full, incremental, updated, $unknown }
+
+String toJson$Enum$Mm2SynchronizationMode(Enum$Mm2SynchronizationMode e) {
+  switch (e) {
+    case Enum$Mm2SynchronizationMode.full:
+      return r'full';
+    case Enum$Mm2SynchronizationMode.incremental:
+      return r'incremental';
+    case Enum$Mm2SynchronizationMode.updated:
+      return r'updated';
+    case Enum$Mm2SynchronizationMode.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$Mm2SynchronizationMode fromJson$Enum$Mm2SynchronizationMode(String value) {
+  switch (value) {
+    case r'full':
+      return Enum$Mm2SynchronizationMode.full;
+    case r'incremental':
+      return Enum$Mm2SynchronizationMode.incremental;
+    case r'updated':
+      return Enum$Mm2SynchronizationMode.updated;
+    default:
+      return Enum$Mm2SynchronizationMode.$unknown;
+  }
+}
+
+enum Enum$SyncActionTaken {
+  created,
+  updated,
+  deleted,
+  skipped,
+  unset,
+  $unknown
+}
+
+String toJson$Enum$SyncActionTaken(Enum$SyncActionTaken e) {
+  switch (e) {
+    case Enum$SyncActionTaken.created:
+      return r'created';
+    case Enum$SyncActionTaken.updated:
+      return r'updated';
+    case Enum$SyncActionTaken.deleted:
+      return r'deleted';
+    case Enum$SyncActionTaken.skipped:
+      return r'skipped';
+    case Enum$SyncActionTaken.unset:
+      return r'unset';
+    case Enum$SyncActionTaken.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$SyncActionTaken fromJson$Enum$SyncActionTaken(String value) {
+  switch (value) {
+    case r'created':
+      return Enum$SyncActionTaken.created;
+    case r'updated':
+      return Enum$SyncActionTaken.updated;
+    case r'deleted':
+      return Enum$SyncActionTaken.deleted;
+    case r'skipped':
+      return Enum$SyncActionTaken.skipped;
+    case r'unset':
+      return Enum$SyncActionTaken.unset;
+    default:
+      return Enum$SyncActionTaken.$unknown;
+  }
+}
+
+enum Enum$Mm2SynchronizerLogLevel { none, info, error, $unknown }
+
+String toJson$Enum$Mm2SynchronizerLogLevel(Enum$Mm2SynchronizerLogLevel e) {
+  switch (e) {
+    case Enum$Mm2SynchronizerLogLevel.none:
+      return r'none';
+    case Enum$Mm2SynchronizerLogLevel.info:
+      return r'info';
+    case Enum$Mm2SynchronizerLogLevel.error:
+      return r'error';
+    case Enum$Mm2SynchronizerLogLevel.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$Mm2SynchronizerLogLevel fromJson$Enum$Mm2SynchronizerLogLevel(
+    String value) {
+  switch (value) {
+    case r'none':
+      return Enum$Mm2SynchronizerLogLevel.none;
+    case r'info':
+      return Enum$Mm2SynchronizerLogLevel.info;
+    case r'error':
+      return Enum$Mm2SynchronizerLogLevel.error;
+    default:
+      return Enum$Mm2SynchronizerLogLevel.$unknown;
   }
 }
 

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -10,6 +10,10 @@ import 'base/operation_result.dart';
 
 typedef AuthenticatedUser = Query$GetAuthenticatedUser$getAuthenticatedUser;
 
+typedef MentorUserDetailedProfile
+    = Query$FindMentorUserDetailedProfile$findUserById;
+typedef MenteeUserDetailedProfile
+    = Query$FindMenteeUserDetailedProfile$findUserById;
 typedef UserDetailedProfile = Query$FindUserDetailedProfile$findUserById;
 typedef UserQuickViewProfile = Query$FindUserQuickViewProfile$findUserById;
 // findAllUsers queries
@@ -55,7 +59,7 @@ class UserProvider extends BaseProvider with ChangeNotifier {
   AuthenticatedUser? get user {
     return _user;
   }
-
+  
   // userSearch mutation
   Future<OperationResult<CreateUserSearchResponse>> createUserSearch({
     required Input$UserSearchInput searchInput,
@@ -170,6 +174,66 @@ class UserProvider extends BaseProvider with ChangeNotifier {
             }).toList()
           : null,
     );
+  }
+
+  Future<OperationResult<MenteeUserDetailedProfile>>
+      findMenteeUserDetailedProfile({
+    required String userId,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindMenteeUserDetailedProfile,
+        fetchPolicy: FetchPolicy.networkOnly,
+        variables: Variables$Query$FindMenteeUserDetailedProfile(
+          id: userId,
+        ).toJson(),
+      ),
+    );
+
+    final operationResult = OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data == null
+          ? null
+          : Query$FindMenteeUserDetailedProfile.fromJson(
+              queryResult.data!,
+            ).findUserById,
+    );
+    if (operationResult.response?.avatarUrl == "") {
+      operationResult.response = operationResult.response!.copyWith(
+        avatarUrl: null,
+      );
+    }
+    return operationResult;
+  }
+
+  Future<OperationResult<MentorUserDetailedProfile>>
+      findMentorUserDetailedProfile({
+    required String userId,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindMentorUserDetailedProfile,
+        fetchPolicy: FetchPolicy.networkOnly,
+        variables: Variables$Query$FindMentorUserDetailedProfile(
+          id: userId,
+        ).toJson(),
+      ),
+    );
+
+    final operationResult = OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data == null
+          ? null
+          : Query$FindMentorUserDetailedProfile.fromJson(
+              queryResult.data!,
+            ).findUserById,
+    );
+    if (operationResult.response?.avatarUrl == "") {
+      operationResult.response = operationResult.response!.copyWith(
+        avatarUrl: null,
+      );
+    }
+    return operationResult;
   }
 
   Future<OperationResult<UserDetailedProfile>> findUserDetailedProfile({

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -59,7 +59,7 @@ class UserProvider extends BaseProvider with ChangeNotifier {
   AuthenticatedUser? get user {
     return _user;
   }
-  
+
   // userSearch mutation
   Future<OperationResult<CreateUserSearchResponse>> createUserSearch({
     required Input$UserSearchInput searchInput,

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -20,6 +20,7 @@ typedef MentorUser = Query$FindMentorUsers$findUsers;
 // UserSearch queries and mutation
 typedef CreateUserSearchResponse = Mutation$CreateUserSearch$createUserSearch;
 typedef UserSearch = Query$FindUserSearch$findUserSearchById;
+typedef TopFoundUser = Query$FindUserSearch$findUserSearchById$topFoundUsers;
 
 class UserProvider extends BaseProvider with ChangeNotifier {
   AuthenticatedUser? _user;

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -43,13 +43,10 @@ query MyUserSearches {
         jobTitle
         countryOfResidence {
             translatedValue
-            textId
         }
         groupMemberships {
             groupIdent
             ... on MentorsGroupMembership {
-                expertisesTextIds
-                industriesTextIds
                 expertises {
                     translatedValue
                 }
@@ -59,8 +56,6 @@ query MyUserSearches {
                 endorsements
             }
             ... on MenteesGroupMembership {
-                soughtExpertisesTextIds
-                industryTextId
                 soughtExpertises {
                     translatedValue
                 }
@@ -71,11 +66,9 @@ query MyUserSearches {
         }
         companies {
             name
-            companyStageTextId
             companyStage {
                 translatedValue
             }
-            companyTypeTextId
             companyType {
                 translatedValue
             }
@@ -103,44 +96,27 @@ query FindUserSearch($userSearchId: String!) {
         offersHelp
         seeksHelp
         jobTitle
+        cityOfResidence
+        regionOfResidence
         countryOfResidence {
             translatedValue
-            textId
         }
         groupMemberships {
             groupIdent
             ... on MentorsGroupMembership {
-                expertisesTextIds
-                industriesTextIds
                 expertises {
-                    translatedValue
-                }
-                industries {
                     translatedValue
                 }
                 endorsements
             }
             ... on MenteesGroupMembership {
-                soughtExpertisesTextIds
-                industryTextId
                 soughtExpertises {
-                    translatedValue
-                }
-                industry {
                     translatedValue
                 }
             }
         }
         companies {
             name
-            companyStageTextId
-            companyStage {
-                translatedValue
-            }
-            companyTypeTextId
-            companyType {
-                translatedValue
-            }
         }
     }
     runInfos {
@@ -285,6 +261,167 @@ query FindUserDetailedProfile($userId: String!) {
             }
         }
     }
+}
+
+query FindMentorUserDetailedProfile($id: String!) {
+  findUserById(id: $id) {
+    id
+    firstName
+    lastName
+    fullName
+    offersHelp
+    seeksHelp
+    websites {
+        value
+        label # label == "linkedin" for the linkedin button
+    }
+    spokenLanguages {
+      translatedValue
+    }
+    avatarUrl # not yet functional
+    groupMemberships {
+      groupId
+      groupIdent
+      ... on MentorsGroupMembership {
+        expertisesTextIds
+        industriesTextIds
+        expertises {
+          translatedValue
+          # icon not yet defined, coming later
+        }
+        industries {
+          translatedValue
+          # icon not yet defined, coming later
+        }
+        endorsements # just a number for now, not yet defined as an object
+        expectationsForMentees
+        # TODO: implement mentoring preferences
+      }
+    }
+    pronounsDisplay # this handles some display logic, "she/they" for a user with both "they/them" and "she/her" pronouns
+    pronouns {
+      translatedValue # e.g. "she/her"
+    }
+    businessExperiences {
+      businessName
+      jobTitle
+      startDate
+      endDate
+      city
+      state
+      country
+    }
+    academicExperiences {
+      institutionName
+      degreeType
+      fieldOfStudy
+      startDate
+      endDate
+    }
+    cityOfResidence
+    regionOfResidence
+    countryOfResidenceTextId
+    countryOfResidence {
+      translatedValue
+    }
+    cityOfOrigin
+    regionOfOrigin
+    countryOfOriginTextId
+    countryOfOrigin {
+      translatedValue
+    }
+    # these last 2 fields were created for the top area of the profile page (job title and company name). 
+    # maybe we'll switch this to businessExperiences later - depends on the onboarding process
+    jobTitle
+    companies {
+      name
+    }
+  }
+}
+
+
+query FindMenteeUserDetailedProfile($id: String!) {
+  findUserById(id: $id) {
+    id
+    firstName
+    lastName
+    fullName
+    email
+    userHandle
+    offersHelp
+    seeksHelp
+    websites {
+        value
+        label # label == "linkedin" for the linkedin button
+    }
+    spokenLanguages {
+      translatedValue
+    }
+    avatarUrl # not yet functional
+    groupMemberships {
+      groupId
+      groupIdent
+      # group name isn't served with this (used in the chip below "ENTREPRENEUR" or "MENTOR"). TBD how it'll be accessed
+        ... on MenteesGroupMembership {
+            soughtExpertises {
+                translatedValue
+            }
+            industry {
+                translatedValue
+            }
+            reasonsForStartingBusiness
+            # business mission not defined, use companies[0].description instead
+        }
+    }
+    jobTitle
+    companies {
+      name # venture name
+      description # "business mission" can be drawn from here for now
+      websites {
+        value # url
+        label # type of website. might not be relevant
+      }
+      companyStage {
+        translatedValue
+      }
+      companyType {
+        translatedValue
+      }
+      # we may need to add city/state/country to this model for the mentee
+    }
+    pronounsDisplay # this handles some display logic, "she/they" for a user with both "they/them" and "she/her" pronouns
+    pronouns {
+      translatedValue # e.g. "she/her"
+    }
+    businessExperiences {
+      businessName
+      jobTitle
+      startDate
+      endDate
+      city
+      state
+      country
+    }
+    academicExperiences {
+      institutionName
+      degreeType
+      fieldOfStudy
+      startDate
+      endDate
+    }
+    cityOfResidence
+    regionOfResidence
+    countryOfResidenceTextId
+    countryOfResidence {
+      translatedValue
+    }
+    cityOfOrigin
+    regionOfOrigin
+    countryOfOriginTextId
+    countryOfOrigin {
+      translatedValue
+    }
+  }
 }
 
 query FindUserQuickViewProfile($userId: String!) {

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -21,6 +21,10 @@ mutation CreateUserSearch($input: UserSearchInput!) {
         expiresAt
         userId
         updatedAt
+        runInfos {
+            finishedAt
+            matchCount
+        }
     }
 }
 
@@ -34,6 +38,9 @@ query MyUserSearches {
         fullName
         avatarUrl
         userHandle
+        offersHelp
+        seeksHelp
+        jobTitle
         countryOfResidence {
             translatedValue
             textId
@@ -75,6 +82,7 @@ query MyUserSearches {
         }
     }
     runInfos {
+      finishedAt
       matchCount
       topUserIds
     }
@@ -92,6 +100,9 @@ query FindUserSearch($userSearchId: String!) {
         fullName
         avatarUrl
         userHandle
+        offersHelp
+        seeksHelp
+        jobTitle
         countryOfResidence {
             translatedValue
             textId
@@ -133,6 +144,7 @@ query FindUserSearch($userSearchId: String!) {
         }
     }
     runInfos {
+      finishedAt
       matchCount
       topUserIds
     }

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -11,6 +11,135 @@ query GetAuthenticatedUser {
     }
 }
 
+mutation CreateUserSearch($input: UserSearchInput!) {
+    createUserSearch(input: $input) {
+        name
+        seeksHelp
+        offersHelp
+        searchText
+        id
+        expiresAt
+        userId
+        updatedAt
+    }
+}
+
+query MyUserSearches {
+  myUserSearches {
+    topFoundUsers {
+        id
+        email
+        firstName
+        lastName
+        fullName
+        avatarUrl
+        userHandle
+        countryOfResidence {
+            translatedValue
+            textId
+        }
+        groupMemberships {
+            groupIdent
+            ... on MentorsGroupMembership {
+                expertisesTextIds
+                industriesTextIds
+                expertises {
+                    translatedValue
+                }
+                industries {
+                    translatedValue
+                }
+                endorsements
+            }
+            ... on MenteesGroupMembership {
+                soughtExpertisesTextIds
+                industryTextId
+                soughtExpertises {
+                    translatedValue
+                }
+                industry {
+                    translatedValue
+                }
+            }
+        }
+        companies {
+            name
+            companyStageTextId
+            companyStage {
+                translatedValue
+            }
+            companyTypeTextId
+            companyType {
+                translatedValue
+            }
+        }
+    }
+    runInfos {
+      matchCount
+      topUserIds
+    }
+    updatedAt
+  }
+}
+
+query FindUserSearch($userSearchId: String!) {
+  findUserSearchById(userSearchId: $userSearchId) {
+    topFoundUsers {
+        id
+        email
+        firstName
+        lastName
+        fullName
+        avatarUrl
+        userHandle
+        countryOfResidence {
+            translatedValue
+            textId
+        }
+        groupMemberships {
+            groupIdent
+            ... on MentorsGroupMembership {
+                expertisesTextIds
+                industriesTextIds
+                expertises {
+                    translatedValue
+                }
+                industries {
+                    translatedValue
+                }
+                endorsements
+            }
+            ... on MenteesGroupMembership {
+                soughtExpertisesTextIds
+                industryTextId
+                soughtExpertises {
+                    translatedValue
+                }
+                industry {
+                    translatedValue
+                }
+            }
+        }
+        companies {
+            name
+            companyStageTextId
+            companyStage {
+                translatedValue
+            }
+            companyTypeTextId
+            companyType {
+                translatedValue
+            }
+        }
+    }
+    runInfos {
+      matchCount
+      topUserIds
+    }
+    updatedAt
+  }
+}
+
 query FindMenteeUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
     findUsers(options: $options, filter: $filter, match: $match) {
         id

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -108,6 +108,7 @@ enum OptionType {
   educationLevel
   expertise
   gender
+  pronoun
   country
   industry
   language
@@ -207,10 +208,19 @@ type MenteesGroupMembership implements IGroupMembership {
 
   """Must match industry ids or textIds."""
   industryTextId: String
+
+  """From MM2, not used in MM3 (yet)"""
   actionsTaken: String
+
+  """From MM2, not used in MM3 (yet)"""
   currentChallenges: String
+
+  """From MM2, not used in MM3 (yet)"""
   futureGoals: String
+
+  """From MM2, not used in MM3 (yet)"""
   motivationsForMentorship: String
+  reasonsForStartingBusiness: String
 }
 
 type MentorsGroupMembership implements IGroupMembership {
@@ -260,6 +270,7 @@ type Query {
   findGenders(fallbackUiLanguage: UiLanguage): [Gender!]!
   myInbox(refresh: Boolean): UserInbox!
   findChannelInvitationById(id: String!): ChannelInvitation!
+  findChannelInvitationsBetweenUsers(options: FindObjectsOptions, onlyPending: Boolean, userIds: [String!]!): [ChannelInvitation!]!
   findChannelInvitationsForUser(options: FindObjectsOptions, onlyPending: Boolean, direction: ChannelInvitationDirection, userId: String!): [ChannelInvitation!]!
   myChannelInvitations(options: FindObjectsOptions, onlyPending: Boolean, direction: ChannelInvitationDirection): [ChannelInvitation!]!
   findPendingChannelInvitationsForUser(options: FindObjectsOptions, userId: String!): [ChannelInvitation!]!
@@ -283,7 +294,7 @@ type Query {
   findUserSearchById(userSearchId: String!): UserSearch!
   findUserSearches(options: FindObjectsOptions, match: UserSearchInput, filter: UserSearchListFilter): [UserSearch!]!
   myUserSearches: [UserSearch!]!
-  findNlpConversation(conversationId: String!): NlpConversation!
+  getMm2Integration: Mm2Integration!
   findMyActiveMultiStepAction: [SidMultiStepAction!]!
   getMultiStepActionProgress(
     """
@@ -353,10 +364,11 @@ type User {
   genderSelfDescribed: String
   ethnicity: String
   educationLevelTextId: String
-  professionalBackground: String
+  personalBio: String
   yearsManagementExperience: Int
   yearsOwnershipExperience: Int
   ssoIdp: String
+  pronounsTextIds: [String!]
 
   """This attribute is only used by the MM2 synchronizer."""
   mm2Id: String
@@ -366,11 +378,13 @@ type User {
 
   """This is the MM2 password hash."""
   mm2PasswordHash: String
-
-  """
-  Users can enter a short description to be prominently displayed along with their name and other info.
-  """
-  oneLiner: String
+  businessExperienceIds: [ID!]
+  academicExperienceIds: [ID!]
+  businessExperiences: [BusinessExperience!]
+  academicExperiences: [AcademicExperience!]
+  cityOfOrigin: String
+  regionOfOrigin: String
+  countryOfOriginTextId: String
   countryOfResidence: Country
   gender: Gender
   latestUserDevice: UserDevice!
@@ -384,12 +398,15 @@ type User {
   channelInvitations: [ChannelInvitation!]!
   channelParticipants: [ChannelParticipant!]!
   companies: [Company!]!
+  countryOfOrigin: Country
   educationLevel: EducationLevel
   endorsements: [EndorsementWithTypes!]
   groupMembers: [GroupMembership!]!
   groups: [Group!]!
   inbox: UserInbox!
   profileCompletionPercentage: Int!
+  pronouns: [Pronoun!]!
+  pronounsDisplay: String!
   userSearches: [UserSearch!]!
 }
 
@@ -479,6 +496,58 @@ type UserDevice {
   oAuthRefreshToken: String
   pushNotificationToken: String
   trustedAt: DateTimeISO
+}
+
+type BusinessExperience {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  businessName: String!
+  jobTitle: String!
+  city: String
+  state: String
+  country: String
+  startDate: DateTimeISO!
+
+  """If the experience is ongoing, endDate is null."""
+  endDate: DateTimeISO
+  userId: ID!
+}
+
+type AcademicExperience {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  institutionName: String!
+
+  """
+  E.g. "Bachelor of Science"
+  """
+  degreeType: String
+
+  """
+  E.g. "Computer Science"
+  """
+  fieldOfStudy: String
+  startDate: DateTimeISO!
+
+  """If the experience is ongoing, endDate is null."""
+  endDate: DateTimeISO
+  userId: ID!
 }
 
 type Country {
@@ -818,6 +887,7 @@ type Company {
   deletedBy: ID
   name: String!
   description: String
+  userIds: [String!]
   companyTypeTextId: String
   companyStageTextId: String
   websites: [LabeledStringValue!]
@@ -953,6 +1023,8 @@ type EndorsementWithTypes {
 }
 
 enum ModelType {
+  AcademicExperience
+  BusinessExperience
   Company
   MentorBoard
   MentoringSession
@@ -1110,7 +1182,6 @@ type ChannelInbox {
   userId: ID!
   unseenMessages: [ChannelInboxItemMessage!]
   unseenArchivedMessages: [ChannelInboxItemMessage!]
-  unseenArchivedMessages: [ChannelInboxItemMessage!]
   pendingInvitations: [ChannelInboxItemInvitation!]
   invitations: [ChannelInboxItemInvitation!]
   updatedAt: DateTimeISO
@@ -1139,6 +1210,35 @@ type ChannelInboxItemInvitation {
   status: ChannelInvitationStatus!
   createdAt: DateTimeISO!
   createdBy: ID
+}
+
+type Pronoun {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  textId: String!
+  parentTextId: String
+  isParent: Boolean
+  optionType: OptionType!
+  value: String!
+  translatedValue: String
+  language: UiLanguage
+
+  """This attribute is only used by the MM2 synchronizer."""
+  mm2Id: String
+  mm2Value: String
+
+  """This attribute is only used by the MM2 synchronizer."""
+  syncedWithMm2At: DateTimeISO
+  childOptions: [Option!]
+  parentOption: [Option!]
 }
 
 type UserSearch {
@@ -1232,8 +1332,6 @@ input FindObjectsOptions {
   showRecordId: Boolean
   includeDeleted: IncludeFilterOption
   includeArchived: IncludeFilterOption
-  includeDeleted: IncludeFilterOption
-  includeArchived: IncludeFilterOption
 }
 
 input SortItem {
@@ -1244,12 +1342,6 @@ input SortItem {
 enum SortDirection {
   asc
   desc
-}
-
-enum IncludeFilterOption {
-  include
-  exclude
-  only
 }
 
 enum IncludeFilterOption {
@@ -1318,22 +1410,35 @@ input UserInput {
   genderSelfDescribed: String
   ethnicity: String
   educationLevelTextId: String
-  professionalBackground: String
+  personalBio: String
   yearsManagementExperience: Int
   yearsOwnershipExperience: Int
   ssoIdp: String
-
-  """
-  Users can enter a short description to be prominently displayed along with their name and other info.
-  """
-  oneLiner: String
+  pronounsTextIds: [String!]
 
   """Specify a company you want to create and add the user to."""
   company: CompanyInput
+
+  """
+  Specify a list of business experiences you want to create for the user.
+  """
+  businessExperiences: [BusinessExperienceInput!]
+
+  """
+  Specify a list of academic experiences you want to create for the user.
+  """
+  academicExperiences: [AcademicExperienceInput!]
+  businessExperienceIds: [ID!]
+  academicExperienceIds: [ID!]
+  cityOfOrigin: String
+  regionOfOrigin: String
+
+  """Users Country of origin. Use a Country Options textId."""
+  countryOfOriginTextId: String
 }
 
 input ModelEventInput {
-  time: DateTimeISO! = "2023-08-31T14:35:36.176Z"
+  time: DateTimeISO! = "2023-09-14T22:08:19.691Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -1404,6 +1509,58 @@ input CompanyInput {
   employeeCount: Int
   foundedAt: DateTimeISO
   addUserIds: [String!]
+}
+
+input BusinessExperienceInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  businessName: String
+  jobTitle: String
+  city: String
+  state: String
+  country: String
+  startDate: DateTimeISO
+
+  """If the experience is ongoing, endDate is null."""
+  endDate: DateTimeISO
+  userId: ID
+}
+
+input AcademicExperienceInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  institutionName: String
+
+  """
+  E.g. "Bachelor of Science"
+  """
+  degreeType: String
+
+  """
+  E.g. "Computer Science"
+  """
+  fieldOfStudy: String
+  startDate: DateTimeISO
+
+  """If the experience is ongoing, endDate is null."""
+  endDate: DateTimeISO
+  userId: ID
 }
 
 input UserListFilter {
@@ -1702,30 +1859,18 @@ input UserSearchListFilter {
   updatedAtUntil: DateTimeISO
 }
 
-type NlpConversation {
+type Mm2Integration {
   id: ID!
-  userIds: [ID!]!
-  assumedMentorUserId: ID!
-  messages: [NlpMessage!]!
-  labelName: String!
-  labelProcessor: String!
-  labelProbability: Int!
-  labeledAt: DateTimeISO
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
   updatedAt: DateTimeISO
-  createdAt: DateTimeISO
-}
-
-type NlpMessage {
-  id: ID!
-  conversationId: ID!
-  messageText: String!
-  senderRole: String!
-  labelName: String
-  labelProcessor: String
-  labelProbability: Int
-  labeledAt: DateTimeISO
-  createdBy: ID!
-  createdAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  fullSyncAt: DateTimeISO
 }
 
 type SidMultiStepAction {
@@ -1891,6 +2036,12 @@ type Mutation {
   updateUser(input: UserInput!): String!
   createUserDevice(input: UserDeviceInput!): UserDevice!
   updateUserDevice(input: UserDeviceInput!): String!
+  createAcademicExperience(input: AcademicExperienceInput!): AcademicExperience!
+  deleteAcademicExperience(deletePhysically: Boolean!, academicExperienceId: String!): ServiceRequest!
+  updateAcademicExperience(input: AcademicExperienceInput!): ServiceRequest!
+  createBusinessExperience(input: BusinessExperienceInput!): BusinessExperience!
+  deleteBusinessExperience(deletePhysically: Boolean!, businessExperienceId: String!): ServiceRequest!
+  updateBusinessExperience(input: BusinessExperienceInput!): ServiceRequest!
   createCompany(input: CompanyInput!): Company!
   deleteCompany(deletePhysically: Boolean!, companyId: String!): ServiceRequest!
   updateCompany(input: CompanyInput!): ServiceRequest!
@@ -1916,7 +2067,6 @@ type Mutation {
   createContentTag(input: ContentTagInput!): ContentTag!
   deleteContentTag(deletePhysically: Boolean!, contentTagId: String!): ServiceRequest!
   updateContentTag(input: ContentTagInput!): ServiceRequest!
-  runDataGenerator(input: GenRequest!): Boolean!
   createGroupMembership(input: GroupMembershipInput!): ServiceRequest!
   createMenteesGroupMembership(input: MenteesGroupMembershipInput!): ServiceRequest!
   createMentorsGroupMembership(input: MentorsGroupMembershipInput!): ServiceRequest!
@@ -1940,9 +2090,16 @@ type Mutation {
   createNotificationTemplate(notificationTemplateInput: NotificationTemplateInput!): NotificationTemplate!
   deleteNotificationTemplate(deletePhysically: Boolean!, notificationTemplateId: String!): String!
   updateNotificationTemplate(notificationTemplateInput: NotificationTemplateInput!): String!
+  clearAllSyncInfo(includeMm3: Boolean!, includeMm2: Boolean!): String!
 
-  """Label a platform message for the NLP learning process."""
-  nlpLabelMessage(input: NlpMessageInput!): String!
+  """
+  Deletes all data that was imported from MM2. This field is only available in non-production environments.
+  """
+  deleteAllMm2DataInMm3: String!
+  createMm2Synchronization(input: Mm2SynchronizationInput!): Mm2Synchronization!
+  deleteMm2Synchronization(mm2SynchronizationId: String!): Mm2Synchronization!
+  findMm2SynchronizationById(mm2SynchronizationId: String!): Mm2Synchronization!
+  runMm2Synchronization(runAgain: Boolean, id: String!): Mm2Synchronization!
   createMultiStepAction(input: SidMultiStepActionInput!): SidMultiStepActionProgress!
   startResetPassword(deviceUuid: String!, input: UserIdentInput!): SidMultiStepActionProgress!
   startVerifyEmail(email: String!): SidMultiStepActionProgress!
@@ -2021,6 +2178,12 @@ type ServiceRequest {
 enum ServiceRequestType {
   graphQlQueryUserInbox
   graphQlQueryUserUserSearches
+  graphQlMutationCreateAcademicExperience
+  graphQlMutationDeleteAcademicExperience
+  graphQlMutationUpdateAcademicExperience
+  graphQlMutationCreateBusinessExperience
+  graphQlMutationDeleteBusinessExperience
+  graphQlMutationUpdateBusinessExperience
   graphQlMutationCreateCompany
   graphQlMutationDeleteCompany
   graphQlMutationUpdateCompany
@@ -2044,6 +2207,7 @@ enum ServiceRequestType {
   graphQlQueryChannelInvitations
   graphQlQueryChannelParticipants
   graphQlQueryFindChannelInvitationById
+  graphQlQueryFindChannelInvitationsBetweenUsers
   graphQlQueryFindChannelInvitationsForUser
   graphQlQueryFindChannelMessageById
   graphQlQueryFindChannelMessages
@@ -2141,6 +2305,10 @@ enum ServiceRequestMessageId {
 }
 
 enum ErrorCode {
+  academicExperienceNameMissing
+  academicExperienceUserIdMissing
+  businessExperienceNameMissing
+  businessExperienceUserIdMissing
   companyNameMissing
   companyNameTaken
   contentTagAlreadyExist
@@ -2289,108 +2457,6 @@ input ContentTagInput {
   approvedByRecipientAt: DateTimeISO
 }
 
-input GenRequest {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  clearDb: Boolean! = false
-  conversationCount: Int! = 0
-  messageCount: Int! = 0
-  users: GenUserInput! = {count: 0, emailDomain: "micromentor.org"}
-  groups: GenGroupsInput! = {count: 0, specificGroups: []}
-  publishAppEvents: Boolean! = false
-}
-
-input GenUserInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  count: Int! = 0
-  dualRoleCount: Int
-  emailDomain: String! = "micromentor.org"
-  emailPrefix: String
-  mentorCount: Int
-  menteeCount: Int
-  mentorRatio: Float
-}
-
-input GenGroupsInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  count: Int! = 0
-  specificGroups: [GenSpecificGroupInput!]! = []
-}
-
-input GenSpecificGroupInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  name: String! = ""
-  mentorCount: Int
-  menteeCount: Int
-  groupRules: [GenGroupRuleInput!]
-  matchingEngine: GenMatchingEngineInput
-}
-
-input GenGroupRuleInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  someGroupRule: Boolean! = false
-  someOtherGroupRule: Boolean! = false
-}
-
-input GenMatchingEngineInput {
-  id: ID
-  adminNotes: String
-  events: [ModelEventInput!]
-  metadata: BaseModelMetadataInput
-  createdAt: DateTimeISO
-  createdBy: ID
-  updatedAt: DateTimeISO
-  updatedBy: ID
-  deletedAt: DateTimeISO
-  deletedBy: ID
-  someMatchingRule: Boolean! = false
-  someOtherMatchingRule: Boolean! = false
-}
-
 input MenteesGroupMembershipInput {
   id: ID
   adminNotes: String
@@ -2413,9 +2479,16 @@ input MenteesGroupMembershipInput {
   """Must match industry id or textId."""
   industryTextId: String
   actionsTaken: String
+
+  """From MM2, not used in MM3 (yet)"""
   currentChallenges: String
+
+  """From MM2, not used in MM3 (yet)"""
   futureGoals: String
+
+  """From MM2, not used in MM3 (yet)"""
   motivationsForMentorship: String
+  reasonsForStartingBusiness: String
 }
 
 input MentorsGroupMembershipInput {
@@ -2568,11 +2641,153 @@ input NotificationTemplateInput {
   isCore: Boolean
 }
 
-input NlpMessageInput {
-  id: ID! = ""
-  labelName: String! = ""
-  labelProcessor: String! = ""
-  labelProbability: Int! = 0
+type Mm2Synchronization {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  direction: Mm2SyncDirection!
+
+  """If synchronizing a single object, set this to its ID."""
+  objectId: String
+
+  """If synchronizing a single object, set this to its model type."""
+  mm2ModelType: Mm2ModelType
+  syncMode: Mm2SynchronizationMode!
+
+  """Set to true to run the synchronization right after creation."""
+  autorun: Boolean!
+
+  """
+  Will be updated with number of synchronized objects throughout the run.
+  """
+  progress: Int!
+  totalItemCount: Int!
+
+  """Number of objects to synchronize."""
+  limit: Int
+  result: Mm2SynchronizationResult!
+
+  """
+  Set to `info` or `error` to save Mm2SynchronizationResultItem objects to Mm2Synchronization.result. Using info on a large amount of items may expand the size of the MongoDB document beyond its limit, so only use it for local debugging. `none` disables saving any items to the synchronization object. Default: `error`
+  """
+  logLevel: Mm2SynchronizerLogLevel
+
+  """Will only include objects with a newer then specified updatedAt date."""
+  usersSinceUpdatedAt: String
+  previousSyncAt: DateTimeISO
+  startedAt: DateTimeISO
+  finishedAt: DateTimeISO
+
+  """
+  Time this object will be deleted from the DB. Default = 10 days after creation.
+  """
+  expiresAt: DateTimeISO
+}
+
+enum Mm2SyncDirection {
+  mm2ToMm3
+  mm3ToMm2
+}
+
+enum Mm2ModelType {
+  Community
+  Organization
+  Conversation
+  Message
+  User
+  MenteeExpertise
+  MenteeWebsite
+  MentorExpertise
+  Profile
+  SpokenLanguage
+}
+
+enum Mm2SynchronizationMode {
+  full
+  incremental
+  updated
+}
+
+type Mm2SynchronizationResult {
+  items: [Mm2SynchronizationResultItem!]!
+  createdCount: Int!
+  deletedCount: Int!
+  updatedCount: Int!
+  skippedCount: Int!
+  errorCount: Int!
+  error: String
+}
+
+type Mm2SynchronizationResultItem {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  synchronizationId: ID!
+  modelType: ModelType
+  mm2ModelType: Mm2ModelType
+  objectId: String!
+  mm2ObjectId: String!
+  name: String
+  operation: SyncActionTaken!
+  error: String
+}
+
+enum SyncActionTaken {
+  created
+  updated
+  deleted
+  skipped
+  unset
+}
+
+enum Mm2SynchronizerLogLevel {
+  none
+  info
+  error
+}
+
+input Mm2SynchronizationInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  direction: Mm2SyncDirection! = mm2ToMm3
+  objectId: String
+  mm2ModelType: Mm2ModelType
+  syncMode: Mm2SynchronizationMode! = full
+  limit: Int
+  autorun: Boolean! = true
+  usersSinceUpdatedAt: String
+
+  """
+  Set to `info` or `error` to save Mm2SynchronizationResultItem objects to Mm2Synchronization.result. Using info on a large amount of items may expand the size of the MongoDB document beyond its limit, so only use it for local debugging. `none` disables saving any items to the synchronization object. Default: `error`
+  """
+  logLevel: Mm2SynchronizerLogLevel
+
+  """
+  Time this object will be deleted from the DB. Default = 10 days after creation.
+  """
+  expiresAt: DateTimeISO
 }
 
 input SidMultiStepActionInput {

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -1110,6 +1110,7 @@ type ChannelInbox {
   userId: ID!
   unseenMessages: [ChannelInboxItemMessage!]
   unseenArchivedMessages: [ChannelInboxItemMessage!]
+  unseenArchivedMessages: [ChannelInboxItemMessage!]
   pendingInvitations: [ChannelInboxItemInvitation!]
   invitations: [ChannelInboxItemInvitation!]
   updatedAt: DateTimeISO
@@ -1159,6 +1160,11 @@ type UserSearch {
   searchText: String
   seeksHelp: UserSearchFieldPreference
   offersHelp: UserSearchFieldPreference
+  languagesTextIds: [String!]
+  expertisesTextIds: [String!]
+  industriesTextIds: [String!]
+  countryTextIds: [String!]
+  companyStagesTextIds: [String!]
   maxResultCount: Int!
   subscription: UserSearchSubscriptionType
   expiresAt: DateTimeISO
@@ -1175,9 +1181,10 @@ enum ProfileType {
 }
 
 enum UserSearchFieldPreference {
-  mustMatch
+  isTrue
+  isFalse
+  any
   match
-  mustNotMatch
 }
 
 enum UserSearchSubscriptionType {
@@ -1225,6 +1232,8 @@ input FindObjectsOptions {
   showRecordId: Boolean
   includeDeleted: IncludeFilterOption
   includeArchived: IncludeFilterOption
+  includeDeleted: IncludeFilterOption
+  includeArchived: IncludeFilterOption
 }
 
 input SortItem {
@@ -1235,6 +1244,12 @@ input SortItem {
 enum SortDirection {
   asc
   desc
+}
+
+enum IncludeFilterOption {
+  include
+  exclude
+  only
 }
 
 enum IncludeFilterOption {
@@ -1318,7 +1333,7 @@ input UserInput {
 }
 
 input ModelEventInput {
-  time: DateTimeISO! = "2023-09-01T18:02:56.892Z"
+  time: DateTimeISO! = "2023-08-31T14:35:36.176Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -1664,6 +1679,11 @@ input UserSearchInput {
   searchText: String
   seeksHelp: UserSearchFieldPreference
   offersHelp: UserSearchFieldPreference
+  languagesTextIds: [String!]! = []
+  expertisesTextIds: [String!]! = []
+  industriesTextIds: [String!]! = []
+  countryTextIds: [String!]! = []
+  companyStagesTextIds: [String!]! = []
   maxResultCount: Int! = 10
   subscription: UserSearchSubscriptionType
   expiresAt: DateTimeISO
@@ -1896,6 +1916,7 @@ type Mutation {
   createContentTag(input: ContentTagInput!): ContentTag!
   deleteContentTag(deletePhysically: Boolean!, contentTagId: String!): ServiceRequest!
   updateContentTag(input: ContentTagInput!): ServiceRequest!
+  runDataGenerator(input: GenRequest!): Boolean!
   createGroupMembership(input: GroupMembershipInput!): ServiceRequest!
   createMenteesGroupMembership(input: MenteesGroupMembershipInput!): ServiceRequest!
   createMentorsGroupMembership(input: MentorsGroupMembershipInput!): ServiceRequest!
@@ -2266,6 +2287,108 @@ input ContentTagInput {
   childContentTagTypeTextId: String
   messageText: String
   approvedByRecipientAt: DateTimeISO
+}
+
+input GenRequest {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  clearDb: Boolean! = false
+  conversationCount: Int! = 0
+  messageCount: Int! = 0
+  users: GenUserInput! = {count: 0, emailDomain: "micromentor.org"}
+  groups: GenGroupsInput! = {count: 0, specificGroups: []}
+  publishAppEvents: Boolean! = false
+}
+
+input GenUserInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  count: Int! = 0
+  dualRoleCount: Int
+  emailDomain: String! = "micromentor.org"
+  emailPrefix: String
+  mentorCount: Int
+  menteeCount: Int
+  mentorRatio: Float
+}
+
+input GenGroupsInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  count: Int! = 0
+  specificGroups: [GenSpecificGroupInput!]! = []
+}
+
+input GenSpecificGroupInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  name: String! = ""
+  mentorCount: Int
+  menteeCount: Int
+  groupRules: [GenGroupRuleInput!]
+  matchingEngine: GenMatchingEngineInput
+}
+
+input GenGroupRuleInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  someGroupRule: Boolean! = false
+  someOtherGroupRule: Boolean! = false
+}
+
+input GenMatchingEngineInput {
+  id: ID
+  adminNotes: String
+  events: [ModelEventInput!]
+  metadata: BaseModelMetadataInput
+  createdAt: DateTimeISO
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  someMatchingRule: Boolean! = false
+  someOtherMatchingRule: Boolean! = false
 }
 
 input MenteesGroupMembershipInput {

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -188,5 +188,26 @@ export function mockMutations(serverState: MockServerState) {
             });
             return channelMessage.id;
         },
+        createUserSearch: (_: any, args: {
+            seeksHelp: string | null,
+            offersHelp: string | null,
+            expertisesTextIds: string[] | null,
+            businessDevelopment: string[] | null,
+            industriesTextIds: string[] | null,
+            countryTextIds: string[] | null,
+            companyStagesTextIds: string[] | null,
+            languagesTextIds: string[] | null,
+        }) => {
+            const search = generators.generateUserSearch(args, serverState.otherUsers);
+            serverState.userSearches.push(search);
+            // clone search
+            const response = JSON.parse(JSON.stringify(search));
+            response.runInfos = null;
+            response.updatedAt = null;
+            return response;
+        },
+        findUserSearchById: (_: any, userSearchId: string) => {
+            return serverState.userSearches.find((element) => element.id == userSearchId);
+        }
     }
 }

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -87,6 +87,26 @@ export function generateWebsite() {
     }
 }
 
+export function generateUserSearch(args, users) {
+    return {
+        __typename: "UserSearch",
+        id: faker.string.alphanumeric({ length: 24 }),
+        "name": null,
+        "seeksHelp": args.seeksHelp,
+        "offersHelp": args.offersHelp,
+        "searchText": args.searchText,
+        "expiresAt": null,
+        "userId": faker.string.alphanumeric({length: 24}),
+        "updatedAt": faker.date.recent(),
+        "runInfos": {
+            "resultsCount": faker.number.int(20),
+            "runAt": faker.date.recent(),
+            "topFoundUsers": users,
+            // TODO verify that this mirrors final backend implementation
+        }
+    }
+}
+
 // groups and group memberships
 
 export function generateGroup(mentorGroup?: boolean, menteeGroup?: boolean) {

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -12,6 +12,7 @@ export class MockServerState {
     channelInvitations: any[];
     channelMessages: any[];
     groups: any[];
+    userSearches: any[];
 
     constructor() {
         this.pubsub = new PubSub();
@@ -52,6 +53,7 @@ export class MockServerState {
             // declined invitation
             generators.generateChannelInvitation(this.loggedInUser, this.otherUsers[7], undefined, true),
         ];
+        this.userSearches = [];
         // Messages for first channel
         const message0 = generators.generateChannelMessage('Hello!', this.channels[0], this.otherUsers[0], new Date('2023-07-26T12:34:01-00:00'), true);
         const message1 = generators.generateChannelMessage('👋', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-00:00'), true, false, false);


### PR DESCRIPTION
Started these changes a couple of weeks ago while working on the backend's matching engine.

Goal:
- schema updates to match latest backend (done)
- updates to mock server for UserSearch api calls (partly done)
- updates to providers to allow for searches with filters (done)

TODO:
~~- add additional fields to the User provider (e.g. pronouns, cityOfOrigin, etc) that will be used on the detailed profile page~~
~~- remove changes to explore.dart screen, the scope of this PR is already too big~~