### PR TITLE
Photo upload widget 

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -238,5 +238,7 @@
     "profileChipsSelectUpTo": "Select up to {maxSelection} (optional)",
     "createAPassword": "Create a password",
     "password": "Password",
-    "confirmPassword": "Confirm password"
+    "confirmPassword": "Confirm password",
+    "uploadPhoto": "Upload photo",
+    "takePhoto": "Take photo"
 }

--- a/lib/widgets/molecules/upload_photo_button.dart
+++ b/lib/widgets/molecules/upload_photo_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class UploadPhotoButton extends StatelessWidget {
   const UploadPhotoButton({Key? key}) : super(key: key);
@@ -7,6 +8,7 @@ class UploadPhotoButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final AppLocalizations l10n = AppLocalizations.of(context)!;
 
     return OutlinedButton(
       onPressed: () {
@@ -15,15 +17,19 @@ class UploadPhotoButton extends StatelessWidget {
           builder: (BuildContext context) {
             return AlertDialog(
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8.0)),
-              backgroundColor: theme.colorScheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(Insets.paddingSmall)),
+              //converting secondary color to one with 95% brightness below:
+              backgroundColor: HSLColor.fromColor(theme.colorScheme.secondary)
+                  .withLightness(0.95)
+                  .toColor(),
               contentPadding: EdgeInsets.zero,
               content: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Padding(
-                    padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+                    padding: const EdgeInsets.only(
+                        top: Insets.paddingMedium, bottom: Insets.paddingSmall),
                     child: OutlinedButton(
                       onPressed: () {},
                       style: ButtonStyle(
@@ -31,21 +37,24 @@ class UploadPhotoButton extends StatelessWidget {
                             theme.colorScheme.onSecondaryContainer),
                         side: const MaterialStatePropertyAll(BorderSide.none),
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Icon(
+                          const Icon(
                             Icons.insert_photo_outlined,
                           ),
-                          SizedBox(width: 8),
-                          Text("Upload photo"),
+                          const SizedBox(width: Insets.paddingSmall),
+                          Text(l10n.uploadPhoto),
                         ],
                       ),
                     ),
                   ),
-                  const Divider(),
+                  Divider(
+                    color: theme.colorScheme.outlineVariant,
+                  ),
                   Padding(
-                    padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
+                    padding: const EdgeInsets.only(
+                        bottom: Insets.paddingMedium, top: Insets.paddingSmall),
                     child: OutlinedButton(
                       onPressed: () {},
                       style: ButtonStyle(
@@ -53,14 +62,14 @@ class UploadPhotoButton extends StatelessWidget {
                             theme.colorScheme.onSecondaryContainer),
                         side: const MaterialStatePropertyAll(BorderSide.none),
                       ),
-                      child: const Row(
+                      child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Icon(
+                          const Icon(
                             Icons.camera_alt_outlined,
                           ),
-                          SizedBox(width: 8),
-                          Text("Take photo"),
+                          const SizedBox(width: Insets.paddingSmall),
+                          Text(l10n.takePhoto),
                         ],
                       ),
                     ),
@@ -72,13 +81,13 @@ class UploadPhotoButton extends StatelessWidget {
         );
       },
       style: ButtonStyle(
-        shape: MaterialStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0))),
+        shape: MaterialStatePropertyAll(RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(Insets.paddingSmall))),
         backgroundColor:
             MaterialStatePropertyAll(theme.colorScheme.secondaryContainer),
         side: const MaterialStatePropertyAll(BorderSide.none),
       ),
-      child: Container(
+      child: SizedBox(
         width: 200,
         height: 200,
         child: Center(

--- a/lib/widgets/molecules/upload_photo_button.dart
+++ b/lib/widgets/molecules/upload_photo_button.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
+
+class UploadPhotoButton extends StatelessWidget {
+  const UploadPhotoButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return OutlinedButton(
+      onPressed: null,
+      style: ButtonStyle(
+        backgroundColor:
+            MaterialStatePropertyAll(theme.colorScheme.secondaryContainer),
+      ),
+      child: Container(
+        child: Icon(Icons.add_circle_outline,
+            color: theme.colorScheme.onSecondaryContainer),
+      ),
+    );
+  }
+}

--- a/lib/widgets/molecules/upload_photo_button.dart
+++ b/lib/widgets/molecules/upload_photo_button.dart
@@ -9,14 +9,82 @@ class UploadPhotoButton extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     return OutlinedButton(
-      onPressed: null,
+      onPressed: () {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8.0)),
+              backgroundColor: theme.colorScheme.secondaryContainer,
+              contentPadding: EdgeInsets.zero,
+              content: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+                    child: OutlinedButton(
+                      onPressed: () {},
+                      style: ButtonStyle(
+                        foregroundColor: MaterialStatePropertyAll(
+                            theme.colorScheme.onSecondaryContainer),
+                        side: const MaterialStatePropertyAll(BorderSide.none),
+                      ),
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.insert_photo_outlined,
+                          ),
+                          SizedBox(width: 8),
+                          Text("Upload photo"),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const Divider(),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
+                    child: OutlinedButton(
+                      onPressed: () {},
+                      style: ButtonStyle(
+                        foregroundColor: MaterialStatePropertyAll(
+                            theme.colorScheme.onSecondaryContainer),
+                        side: const MaterialStatePropertyAll(BorderSide.none),
+                      ),
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.camera_alt_outlined,
+                          ),
+                          SizedBox(width: 8),
+                          Text("Take photo"),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
       style: ButtonStyle(
+        shape: MaterialStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0))),
         backgroundColor:
             MaterialStatePropertyAll(theme.colorScheme.secondaryContainer),
+        side: const MaterialStatePropertyAll(BorderSide.none),
       ),
       child: Container(
-        child: Icon(Icons.add_circle_outline,
-            color: theme.colorScheme.onSecondaryContainer),
+        width: 200,
+        height: 200,
+        child: Center(
+          child: Icon(Icons.add_circle_outline,
+              color: theme.colorScheme.onSecondaryContainer),
+        ),
       ),
     );
   }

--- a/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
+++ b/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
@@ -4,9 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
-
 import '../../molecules/login_radio_button_cards.dart';
-import '../../molecules/upload_photo_button.dart';
 import 'sign_up_bottom_buttons.dart';
 
 class MentorOrEntrepreneurScreen extends StatefulWidget {
@@ -38,8 +36,7 @@ class _MentorOrEntrepreneurScreenState
           icon: Icons.lock_outline, text: l10n.signUpHiddenInfoDesc),
       body: Column(
         children: [
-          // createEntrepreneurMentorCards(context),
-          UploadPhotoButton(),
+          createEntrepreneurMentorCards(context),
           const SizedBox(height: Insets.paddingMedium),
           Padding(
             padding: const EdgeInsets.all(Insets.paddingSmall),

--- a/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
+++ b/lib/widgets/screens/sign_up/mentor_or_entrepreneur.dart
@@ -6,6 +6,7 @@ import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart'
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
 
 import '../../molecules/login_radio_button_cards.dart';
+import '../../molecules/upload_photo_button.dart';
 import 'sign_up_bottom_buttons.dart';
 
 class MentorOrEntrepreneurScreen extends StatefulWidget {
@@ -37,7 +38,8 @@ class _MentorOrEntrepreneurScreenState
           icon: Icons.lock_outline, text: l10n.signUpHiddenInfoDesc),
       body: Column(
         children: [
-          createEntrepreneurMentorCards(context),
+          // createEntrepreneurMentorCards(context),
+          UploadPhotoButton(),
           const SizedBox(height: Insets.paddingMedium),
           Padding(
             padding: const EdgeInsets.all(Insets.paddingSmall),


### PR DESCRIPTION
This PR implements the photo upload widget:
1. Big button that triggers a popup with two options.
2. The popup appears on top of a scrim that blocks user interaction with the components underneath it.
<img width="602" alt="Screenshot 2023-09-15 at 2 35 50 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/63002494/de3ae340-b617-44cc-95a4-7253cc02c707">
<img width="602" alt="Screenshot 2023-09-15 at 2 35 52 PM" src="https://github.com/micromentor-team/mm-flutter-app/assets/63002494/5b8e2f61-a1c6-46a9-8bc5-2c9c745bfd68">
