### PR TITLE
Mock server fixes

### DIFF
--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -205,9 +205,6 @@ export function mockMutations(serverState: MockServerState) {
             response.runInfos = null;
             response.updatedAt = null;
             return response;
-        },
-        findUserSearchById: (_: any, userSearchId: string) => {
-            return serverState.userSearches.find((element) => element.id == userSearchId);
         }
     }
 }

--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -85,5 +85,9 @@ export function mockQueries(serverState: MockServerState) {
         findGroups: () => {
             return serverState.groups;
         },
+        // user searches
+        findUserSearchById: (_: any, userSearchId: string) => {
+            return serverState.userSearches.find((element) => element.id == userSearchId);
+        },
     }
 }

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -87,7 +87,7 @@ export function generateWebsite() {
     }
 }
 
-export function generateUserSearch(args, users) {
+export function generateUserSearch(args: any, users: any) {
     return {
         __typename: "UserSearch",
         id: faker.string.alphanumeric({ length: 24 }),


### PR DESCRIPTION
Fix blocking bugs introduced in #135 to mock server, was not building due to TS error and due to a grapqhl error.
- Moved query to the queries file from the mutations.ts file
- added `:any` to the inputs to the `createUserSearch` mutation