### PR TITLE
Entrepreneur signup flow with content provider

### DIFF
--- a/lib/__generated/schema/operations_content.graphql.dart
+++ b/lib/__generated/schema/operations_content.graphql.dart
@@ -3,7 +3,6 @@
 // ignore_for_file: type=lint
 
 import 'package:gql/ast.dart';
-
 import 'schema.graphql.dart';
 
 class Query$FindAllOptionsByType {
@@ -4982,6 +4981,462 @@ class _CopyWithImpl$Query$FindGenders$findGenders<TRes>
 class _CopyWithStubImpl$Query$FindGenders$findGenders<TRes>
     implements CopyWith$Query$FindGenders$findGenders<TRes> {
   _CopyWithStubImpl$Query$FindGenders$findGenders(this._res);
+
+  TRes _res;
+
+  call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Variables$Query$FindPronouns {
+  factory Variables$Query$FindPronouns({required Enum$OptionType optionType}) =>
+      Variables$Query$FindPronouns._({
+        r'optionType': optionType,
+      });
+
+  Variables$Query$FindPronouns._(this._$data);
+
+  factory Variables$Query$FindPronouns.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$optionType = data['optionType'];
+    result$data['optionType'] =
+        fromJson$Enum$OptionType((l$optionType as String));
+    return Variables$Query$FindPronouns._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Enum$OptionType get optionType => (_$data['optionType'] as Enum$OptionType);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$optionType = optionType;
+    result$data['optionType'] = toJson$Enum$OptionType(l$optionType);
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindPronouns<Variables$Query$FindPronouns>
+      get copyWith => CopyWith$Variables$Query$FindPronouns(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindPronouns) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$optionType = optionType;
+    final lOther$optionType = other.optionType;
+    if (l$optionType != lOther$optionType) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$optionType = optionType;
+    return Object.hashAll([l$optionType]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindPronouns<TRes> {
+  factory CopyWith$Variables$Query$FindPronouns(
+    Variables$Query$FindPronouns instance,
+    TRes Function(Variables$Query$FindPronouns) then,
+  ) = _CopyWithImpl$Variables$Query$FindPronouns;
+
+  factory CopyWith$Variables$Query$FindPronouns.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindPronouns;
+
+  TRes call({Enum$OptionType? optionType});
+}
+
+class _CopyWithImpl$Variables$Query$FindPronouns<TRes>
+    implements CopyWith$Variables$Query$FindPronouns<TRes> {
+  _CopyWithImpl$Variables$Query$FindPronouns(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindPronouns _instance;
+
+  final TRes Function(Variables$Query$FindPronouns) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? optionType = _undefined}) =>
+      _then(Variables$Query$FindPronouns._({
+        ..._instance._$data,
+        if (optionType != _undefined && optionType != null)
+          'optionType': (optionType as Enum$OptionType),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindPronouns<TRes>
+    implements CopyWith$Variables$Query$FindPronouns<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindPronouns(this._res);
+
+  TRes _res;
+
+  call({Enum$OptionType? optionType}) => _res;
+}
+
+class Query$FindPronouns {
+  Query$FindPronouns({
+    required this.findOptions,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindPronouns.fromJson(Map<String, dynamic> json) {
+    final l$findOptions = json['findOptions'];
+    final l$$__typename = json['__typename'];
+    return Query$FindPronouns(
+      findOptions: (l$findOptions as List<dynamic>)
+          .map((e) => Query$FindPronouns$findOptions.fromJson(
+              (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindPronouns$findOptions> findOptions;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findOptions = findOptions;
+    _resultData['findOptions'] = l$findOptions.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findOptions = findOptions;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findOptions.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindPronouns) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findOptions = findOptions;
+    final lOther$findOptions = other.findOptions;
+    if (l$findOptions.length != lOther$findOptions.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findOptions.length; i++) {
+      final l$findOptions$entry = l$findOptions[i];
+      final lOther$findOptions$entry = lOther$findOptions[i];
+      if (l$findOptions$entry != lOther$findOptions$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindPronouns on Query$FindPronouns {
+  CopyWith$Query$FindPronouns<Query$FindPronouns> get copyWith =>
+      CopyWith$Query$FindPronouns(
+        this,
+        (i) => i,
+      );
+}
+
+abstract class CopyWith$Query$FindPronouns<TRes> {
+  factory CopyWith$Query$FindPronouns(
+    Query$FindPronouns instance,
+    TRes Function(Query$FindPronouns) then,
+  ) = _CopyWithImpl$Query$FindPronouns;
+
+  factory CopyWith$Query$FindPronouns.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindPronouns;
+
+  TRes call({
+    List<Query$FindPronouns$findOptions>? findOptions,
+    String? $__typename,
+  });
+  TRes findOptions(
+      Iterable<Query$FindPronouns$findOptions> Function(
+              Iterable<
+                  CopyWith$Query$FindPronouns$findOptions<
+                      Query$FindPronouns$findOptions>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindPronouns<TRes>
+    implements CopyWith$Query$FindPronouns<TRes> {
+  _CopyWithImpl$Query$FindPronouns(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindPronouns _instance;
+
+  final TRes Function(Query$FindPronouns) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findOptions = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindPronouns(
+        findOptions: findOptions == _undefined || findOptions == null
+            ? _instance.findOptions
+            : (findOptions as List<Query$FindPronouns$findOptions>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findOptions(
+          Iterable<Query$FindPronouns$findOptions> Function(
+                  Iterable<
+                      CopyWith$Query$FindPronouns$findOptions<
+                          Query$FindPronouns$findOptions>>)
+              _fn) =>
+      call(
+          findOptions: _fn(_instance.findOptions
+              .map((e) => CopyWith$Query$FindPronouns$findOptions(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindPronouns<TRes>
+    implements CopyWith$Query$FindPronouns<TRes> {
+  _CopyWithStubImpl$Query$FindPronouns(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindPronouns$findOptions>? findOptions,
+    String? $__typename,
+  }) =>
+      _res;
+  findOptions(_fn) => _res;
+}
+
+const documentNodeQueryFindPronouns = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindPronouns'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'optionType')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'OptionType'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findOptions'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'optionType'),
+            value: VariableNode(name: NameNode(value: 'optionType')),
+          )
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'textId'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'translatedValue'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindPronouns$findOptions {
+  Query$FindPronouns$findOptions({
+    required this.textId,
+    this.translatedValue,
+    this.$__typename = 'Option',
+  });
+
+  factory Query$FindPronouns$findOptions.fromJson(Map<String, dynamic> json) {
+    final l$textId = json['textId'];
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindPronouns$findOptions(
+      textId: (l$textId as String),
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String textId;
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$textId = textId;
+    _resultData['textId'] = l$textId;
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$textId = textId;
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$textId,
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindPronouns$findOptions) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$textId = textId;
+    final lOther$textId = other.textId;
+    if (l$textId != lOther$textId) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindPronouns$findOptions
+    on Query$FindPronouns$findOptions {
+  CopyWith$Query$FindPronouns$findOptions<Query$FindPronouns$findOptions>
+      get copyWith => CopyWith$Query$FindPronouns$findOptions(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindPronouns$findOptions<TRes> {
+  factory CopyWith$Query$FindPronouns$findOptions(
+    Query$FindPronouns$findOptions instance,
+    TRes Function(Query$FindPronouns$findOptions) then,
+  ) = _CopyWithImpl$Query$FindPronouns$findOptions;
+
+  factory CopyWith$Query$FindPronouns$findOptions.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindPronouns$findOptions;
+
+  TRes call({
+    String? textId,
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindPronouns$findOptions<TRes>
+    implements CopyWith$Query$FindPronouns$findOptions<TRes> {
+  _CopyWithImpl$Query$FindPronouns$findOptions(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindPronouns$findOptions _instance;
+
+  final TRes Function(Query$FindPronouns$findOptions) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? textId = _undefined,
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindPronouns$findOptions(
+        textId: textId == _undefined || textId == null
+            ? _instance.textId
+            : (textId as String),
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindPronouns$findOptions<TRes>
+    implements CopyWith$Query$FindPronouns$findOptions<TRes> {
+  _CopyWithStubImpl$Query$FindPronouns$findOptions(this._res);
 
   TRes _res;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ class StartScreen extends StatefulWidget {
 
 class _StartScreenState extends State<StartScreen> {
   late Future<OperationResult<AuthenticatedUser?>> _authenticatedUser;
-  late Future<OperationResult<AllOptionsByType>> _optionsByType;
+  late Future<OperationResult> _content;
   late final InboxModel _inboxModel;
   late final ContentProvider _contentProvider;
 
@@ -73,7 +73,9 @@ class _StartScreenState extends State<StartScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _optionsByType = _contentProvider.findAllOptionsByType();
+    _content = _contentProvider.findAllOptionsByType().then(
+          (value) => _contentProvider.findPresetPronouns(),
+        );
     _authenticatedUser =
         Provider.of<UserProvider>(context).getAuthenticatedUser(
       logFailures: false, // Error is expected when user is not logged in.
@@ -87,7 +89,7 @@ class _StartScreenState extends State<StartScreen> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: _optionsByType,
+      future: _content,
       builder: (_, optionsSnapshot) => AppUtility.widgetForAsyncSnapshot(
         snapshot: optionsSnapshot,
         onReady: () => FutureBuilder(

--- a/lib/providers/content_provider.dart
+++ b/lib/providers/content_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
 
 import '../__generated/schema/operations_content.graphql.dart';
 import 'base/base_provider.dart';
@@ -11,6 +12,7 @@ typedef Country = Query$FindCountries$findCountries;
 typedef EducationLevel = Query$FindEducationLevels$findEducationLevels;
 typedef Expertise = Query$FindExpertises$findExpertises;
 typedef PresetGender = Query$FindGenders$findGenders;
+typedef PresetPronoun = Query$FindPronouns$findOptions;
 typedef Industry = Query$FindIndustries$findIndustries;
 typedef Language = Query$FindLanguages$findLanguages;
 typedef OptionByType = Query$FindAllOptions$findOptions;
@@ -23,6 +25,7 @@ class ContentProvider extends BaseProvider {
   List<EducationLevel>? _educationLevels;
   List<Expertise>? _expertises;
   List<PresetGender>? _presetGenders;
+  List<PresetPronoun>? _presetPronouns;
   List<Industry>? _industries;
   List<Language>? _languages;
 
@@ -101,6 +104,11 @@ class ContentProvider extends BaseProvider {
     debugPrint('Updated content provider preset gender values: ${toString()}');
   }
 
+  void _setPresetPronounOptions(List<PresetPronoun> presetPronoun) {
+    _presetPronouns = presetPronoun;
+    debugPrint('Updated content provider preset pronoun values: ${toString()}');
+  }
+
   void _setIndustryOptions(List<Industry> industries) {
     _industries = industries;
     debugPrint('Updated content provider industry values: ${toString()}');
@@ -135,6 +143,10 @@ class ContentProvider extends BaseProvider {
 
   List<PresetGender>? get presetGenderOptions {
     return _presetGenders;
+  }
+
+  List<PresetPronoun>? get presetPronounOptions {
+    return _presetPronouns;
   }
 
   List<Industry>? get industryOptions {
@@ -296,6 +308,28 @@ class ContentProvider extends BaseProvider {
           : null,
     );
     if (result.response != null) _setPresetGenderOptions(result.response!);
+    return result;
+  }
+
+  Future<OperationResult<List<PresetPronoun>>> findPresetPronouns() async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindPronouns,
+        fetchPolicy: FetchPolicy.cacheFirst,
+        variables: Variables$Query$FindPronouns(
+          optionType: Enum$OptionType.pronoun,
+        ).toJson(),
+      ),
+    );
+    final result = OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindPronouns.fromJson(
+              queryResult.data!,
+            ).findOptions
+          : null,
+    );
+    if (result.response != null) _setPresetPronounOptions(result.response!);
     return result;
   }
 

--- a/lib/schema/operations_content.graphql
+++ b/lib/schema/operations_content.graphql
@@ -94,6 +94,13 @@ query FindGenders {
   }
 }
 
+query FindPronouns($optionType: OptionType!) {
+  findOptions(optionType: $optionType) {
+    textId
+    translatedValue
+  }
+}
+
 query FindLanguages {
   findLanguages {
     textId

--- a/lib/widgets/molecules/checkbox_list_and_form.dart
+++ b/lib/widgets/molecules/checkbox_list_and_form.dart
@@ -2,18 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 
 class LabeledCheckbox extends StatelessWidget {
+  final String label;
+  final String id;
+  final bool value;
+  final int selectionOrder;
+  final ValueChanged<bool> onChanged;
+
   const LabeledCheckbox({
     super.key,
     required this.label,
+    required this.id,
     required this.value,
     required this.selectionOrder,
     required this.onChanged,
   });
-
-  final String label;
-  final bool value;
-  final int selectionOrder;
-  final ValueChanged<bool> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -64,81 +66,6 @@ class LabeledCheckbox extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class PronounExample extends StatefulWidget {
-  const PronounExample({Key? key}) : super(key: key);
-
-  @override
-  State<PronounExample> createState() => _PronounExampleState();
-}
-
-class _PronounExampleState extends State<PronounExample> {
-  bool _isSelected1 = false;
-  bool _isSelected2 = false;
-  bool _isSelected3 = false;
-  int _numPronounsSelect = 0;
-  int _selectionorder1 = 0;
-  int _selectionorder2 = 0;
-  int _selectionorder3 = 0;
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        LabeledCheckbox(
-          label: 'she/her',
-          value: _isSelected1,
-          selectionOrder: _selectionorder1,
-          onChanged: (bool value) {
-            setState(() {
-              _isSelected1 = value;
-              if (value == true) {
-                _selectionorder1 = _numPronounsSelect + 1;
-                _numPronounsSelect = _numPronounsSelect + 1;
-              } else {
-                _selectionorder1 = _numPronounsSelect - 1;
-                _numPronounsSelect = _numPronounsSelect - 1;
-              }
-            });
-          },
-        ),
-        LabeledCheckbox(
-          label: 'he/him',
-          value: _isSelected2,
-          selectionOrder: _selectionorder2,
-          onChanged: (bool value) {
-            setState(() {
-              _isSelected2 = value;
-              if (value == true) {
-                _selectionorder2 = _numPronounsSelect + 1;
-                _numPronounsSelect = _numPronounsSelect + 1;
-              } else {
-                _selectionorder2 = _numPronounsSelect - 1;
-                _numPronounsSelect = _numPronounsSelect - 1;
-              }
-            });
-          },
-        ),
-        LabeledCheckbox(
-          label: 'they/them',
-          value: _isSelected3,
-          selectionOrder: _selectionorder3,
-          onChanged: (bool value) {
-            setState(() {
-              _isSelected3 = value;
-              if (value == true) {
-                _selectionorder3 = _numPronounsSelect + 1;
-                _numPronounsSelect = _numPronounsSelect + 1;
-              } else {
-                _selectionorder3 = _numPronounsSelect - 1;
-                _numPronounsSelect = _numPronounsSelect - 1;
-              }
-            });
-          },
-        ),
-      ],
     );
   }
 }

--- a/lib/widgets/molecules/multi_select_chips.dart
+++ b/lib/widgets/molecules/multi_select_chips.dart
@@ -15,7 +15,7 @@ class SelectChip {
   });
 }
 
-//example 1
+//examples
 CreateMultiSelectChips createMultiSelectChipsExample() {
   return CreateMultiSelectChips(
     chips: [
@@ -26,6 +26,114 @@ CreateMultiSelectChips createMultiSelectChipsExample() {
       SelectChip(chipName: 'Formal meetings', textId: 'formatMeetings'),
       SelectChip(chipName: 'Long term', textId: 'longTerm'),
     ],
+  );
+}
+
+CreateMultiSelectChips createMultiSelectChipsExampleWithIcon() {
+  return CreateMultiSelectChips(
+    chips: [
+      SelectChip(
+          chipName: 'Administrative Services',
+          textId: 'administrativeServices',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Agriculture & Forestry',
+          textId: 'agricultureAndForestry',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Architecture & Engineering',
+          textId: 'architectureAndEngineering',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Arts, Entertainment, & Recreation',
+          textId: 'artsEntertainmentAndRecreation',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Beauty, Hair, & Cosmetics',
+          textId: 'beautyHairAndCosmetics',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Building & Grounds Maintenance',
+          textId: 'buildingAndGroundsMaintenance',
+          icon: Icons.work_outline),
+    ],
+    maxSelection: 3,
+  );
+}
+
+CreateMultiSelectChips createHelpExampleWithIcon() {
+  return CreateMultiSelectChips(
+    chips: [
+      SelectChip(
+          chipName: 'Accounting & Finance',
+          textId: 'accountingAndFinance',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Advertising & Promotion',
+          textId: 'advertisingAndPromotion',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Branding & Identity',
+          textId: 'brandingAndIdentity',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Business Development',
+          textId: 'businessDevelopment',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Business Planning',
+          textId: 'businessPlanning',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'E-Commerce',
+          textId: 'eCommerce',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Financial Planning',
+          textId: 'financialPlanning',
+          icon: Icons.work_outline),
+    ],
+    maxSelection: 3,
+  );
+}
+
+CreateMultiSelectChips createMultiSelectChipsIndustry() {
+  return CreateMultiSelectChips(
+    chips: [
+      SelectChip(
+          chipName: 'Administrative Services',
+          textId: 'administrativeServices',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Agriculture & Forestry',
+          textId: 'agricultureAndForestry',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Architecture & Engineering',
+          textId: 'architectureAndEngineering',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Arts, Entertainment, & Recreation',
+          textId: 'artsEntertainmentAndRecreation',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Beauty, Hair, & Cosmetics',
+          textId: 'beautyHairAndCosmetics',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Building & Grounds Maintenance',
+          textId: 'buildingAndGroundsMaintenance',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Construction',
+          textId: 'construction',
+          icon: Icons.work_outline),
+      SelectChip(
+          chipName: 'Digital Marketing & eCommerce',
+          textId: 'digitalMarketingAndeCommerce',
+          icon: Icons.work_outline),
+    ],
+    maxSelection: 1,
   );
 }
 

--- a/lib/widgets/molecules/multi_select_chips.dart
+++ b/lib/widgets/molecules/multi_select_chips.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
 
 //class chip
-class Chip {
+class SelectChip {
   final String chipName;
   final String textId;
   final IconData? icon;
 
-  Chip({
+  SelectChip({
     required this.chipName,
     required this.textId,
     this.icon,
@@ -19,130 +19,19 @@ class Chip {
 CreateMultiSelectChips createMultiSelectChipsExample() {
   return CreateMultiSelectChips(
     chips: [
-      Chip(chipName: 'Weekly check-ins', textId: 'weeklyCheckIn'),
-      Chip(chipName: 'Monthly check-ins', textId: 'monthlyCheckIn'),
-      Chip(chipName: 'One-off sessions', textId: 'oneOffSessions'),
-      Chip(chipName: 'Informal chats', textId: 'informalChats'),
-      Chip(chipName: 'Formal meetings', textId: 'formatMeetings'),
-      Chip(chipName: 'Long term mentoring', textId: 'longTermMentoring'),
+      SelectChip(chipName: 'Weekly check-ins', textId: 'weeklyCheckIn'),
+      SelectChip(chipName: 'Monthly check-ins', textId: 'monthlyCheckIn'),
+      SelectChip(chipName: 'One-off sessions', textId: 'oneOffSessions'),
+      SelectChip(chipName: 'Informal chats', textId: 'informalChats'),
+      SelectChip(chipName: 'Formal meetings', textId: 'formatMeetings'),
+      SelectChip(chipName: 'Long term', textId: 'longTerm'),
     ],
-  );
-}
-
-//example 2
-CreateMultiSelectChips createMultiSelectChipsExampleWithIcon() {
-  return CreateMultiSelectChips(
-    chips: [
-      Chip(
-          chipName: 'Administrative Services',
-          textId: 'administrativeServices',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Agriculture & Forestry',
-          textId: 'agricultureAndForestry',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Architecture & Engineering',
-          textId: 'architectureAndEngineering',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Arts, Entertainment, & Recreation',
-          textId: 'artsEntertainmentAndRecreation',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Beauty, Hair, & Cosmetics',
-          textId: 'beautyHairAndCosmetics',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Building & Grounds Maintenance',
-          textId: 'buildingAndGroundsMaintenance',
-          icon: Icons.work_outline),
-    ],
-    maxSelection: 3,
-  );
-}
-
-//example 3:
-CreateMultiSelectChips createHelpExampleWithIcon() {
-  return CreateMultiSelectChips(
-    chips: [
-      Chip(
-          chipName: 'Accounting & Finance',
-          textId: 'accountingAndFinance',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Advertising & Promotion',
-          textId: 'advertisingAndPromotion',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Branding & Identity',
-          textId: 'brandingAndIdentity',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Business Development',
-          textId: 'businessDevelopment',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Business Planning',
-          textId: 'businessPlanning',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'E-Commerce',
-          textId: 'eCommerce',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Financial Planning',
-          textId: 'financialPlanning',
-          icon: Icons.work_outline),
-    ],
-    maxSelection: 3,
-  );
-}
-
-//example 4:
-CreateMultiSelectChips createMultiSelectChipsIndustry() {
-  return CreateMultiSelectChips(
-    chips: [
-      Chip(
-          chipName: 'Administrative Services',
-          textId: 'administrativeServices',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Agriculture & Forestry',
-          textId: 'agricultureAndForestry',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Architecture & Engineering',
-          textId: 'architectureAndEngineering',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Arts, Entertainment, & Recreation',
-          textId: 'artsEntertainmentAndRecreation',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Beauty, Hair, & Cosmetics',
-          textId: 'beautyHairAndCosmetics',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Building & Grounds Maintenance',
-          textId: 'buildingAndGroundsMaintenance',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Construction',
-          textId: 'construction',
-          icon: Icons.work_outline),
-      Chip(
-          chipName: 'Digital Marketing & eCommerce',
-          textId: 'digitalMarketingAndeCommerce',
-          icon: Icons.work_outline),
-    ],
-    maxSelection: 1,
   );
 }
 
 //build
 class CreateMultiSelectChips extends StatefulWidget {
-  final List<Chip> chips;
+  final List<SelectChip> chips;
   final int? maxSelection;
 
   const CreateMultiSelectChips({

--- a/lib/widgets/screens/sign_up/sign_up_business_add_pronouns.dart
+++ b/lib/widgets/screens/sign_up/sign_up_business_add_pronouns.dart
@@ -3,7 +3,10 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
+import 'package:provider/provider.dart';
+
 import '../../../constants/app_constants.dart';
+import '../../../providers/content_provider.dart';
 import '../../molecules/checkbox_list_and_form.dart';
 import 'sign_up_bottom_buttons.dart';
 
@@ -17,6 +20,41 @@ class SignupBusinessAddPronounsScreen extends StatefulWidget {
 
 class _SignupBusinessAddPronounsScreenState
     extends State<SignupBusinessAddPronounsScreen> {
+  late final ContentProvider _contentProvider;
+  final List<String> _selections = List.empty(growable: true);
+
+  @override
+  void initState() {
+    super.initState();
+    _contentProvider = Provider.of<ContentProvider>(context, listen: false);
+  }
+
+  List<LabeledCheckbox> _createCheckboxes() {
+    return _contentProvider.presetPronounOptions!
+        .map(
+          (e) => _createLabeledCheckbox(e.translatedValue!, e.textId),
+        )
+        .toList();
+  }
+
+  LabeledCheckbox _createLabeledCheckbox(String label, String textId) {
+    return LabeledCheckbox(
+      label: label,
+      id: textId,
+      value: _selections.contains(textId),
+      selectionOrder: _selections.indexOf(textId) + 1,
+      onChanged: (bool isSelected) {
+        setState(() {
+          if (isSelected) {
+            _selections.add(textId);
+          } else {
+            _selections.remove(textId);
+          }
+        });
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
@@ -46,7 +84,7 @@ class _SignupBusinessAddPronounsScreenState
                   .copyWith(color: theme.colorScheme.outline),
               textAlign: TextAlign.center,
             ),
-            const PronounExample(),
+            ..._createCheckboxes(),
           ],
         ),
       ),

--- a/lib/widgets/screens/sign_up/sign_up_business_help_selection.dart
+++ b/lib/widgets/screens/sign_up/sign_up_business_help_selection.dart
@@ -5,6 +5,9 @@ import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/widgets/molecules/multi_select_chips.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
+import 'package:provider/provider.dart';
+
+import '../../../providers/content_provider.dart';
 import 'sign_up_bottom_buttons.dart';
 
 class SignupBusinessHelpSelectionScreen extends StatefulWidget {
@@ -17,27 +20,51 @@ class SignupBusinessHelpSelectionScreen extends StatefulWidget {
 
 class _SignupBusinessHelpSelectionScreenState
     extends State<SignupBusinessHelpSelectionScreen> {
+  late final ContentProvider _contentProvider;
+  late final List<SelectChip> _expertiseChips;
+
+  @override
+  void initState() {
+    super.initState();
+    _contentProvider = Provider.of<ContentProvider>(context, listen: false);
+    _expertiseChips = _contentProvider.expertiseOptions!
+        .map(
+          (e) => SelectChip(
+            chipName: e.translatedValue!,
+            textId: e.textId,
+            icon: Icons.work_outline,
+          ),
+        )
+        .toList();
+    _expertiseChips.sort((a, b) => a.chipName.compareTo(b.chipName));
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
-
     return SignUpTemplate(
       progress: SignUpProgress.one,
       title: l10n.lookingForHelp,
       bottomButtons: SignUpBottomButtons(
-          leftButtonText: l10n.previous,
-          rightButtonText: l10n.next,
-          leftOnPress: () {
-            context.pop();
-          },
-          rightOnPress: () {
-            context.push(Routes.signupMoreInfo.path);
-          }),
+        leftButtonText: l10n.previous,
+        rightButtonText: l10n.next,
+        leftOnPress: () {
+          context.pop();
+        },
+        rightOnPress: () {
+          context.push(Routes.signupMoreInfo.path);
+        },
+      ),
       footer: SignUpIconFooter(
-          icon: Icons.visibility_outlined, text: l10n.signUpShownOnProfileInfo),
+        icon: Icons.visibility_outlined,
+        text: l10n.signUpShownOnProfileInfo,
+      ),
       body: Column(
         children: [
-          createMultiSelectChipsExampleWithIcon(),
+          CreateMultiSelectChips(
+            chips: _expertiseChips,
+            maxSelection: 3,
+          ),
         ],
       ),
     );

--- a/lib/widgets/screens/sign_up/sign_up_business_industry.dart
+++ b/lib/widgets/screens/sign_up/sign_up_business_industry.dart
@@ -3,7 +3,10 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
+import 'package:provider/provider.dart';
+
 import '../../../constants/app_constants.dart';
+import '../../../providers/content_provider.dart';
 import '../../molecules/multi_select_chips.dart';
 import 'sign_up_bottom_buttons.dart';
 
@@ -17,6 +20,25 @@ class SignupBusinessIndustryScreen extends StatefulWidget {
 
 class _SignupBusinessIndustryScreenState
     extends State<SignupBusinessIndustryScreen> {
+  late final ContentProvider _contentProvider;
+  late final List<SelectChip> _industryChips;
+
+  @override
+  void initState() {
+    super.initState();
+    _contentProvider = Provider.of<ContentProvider>(context, listen: false);
+    _industryChips = _contentProvider.industryOptions!
+        .map(
+          (e) => SelectChip(
+            chipName: e.translatedValue!,
+            textId: e.textId,
+            icon: Icons.work_outline,
+          ),
+        )
+        .toList();
+    _industryChips.sort((a, b) => a.chipName.compareTo(b.chipName));
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l10n = AppLocalizations.of(context)!;
@@ -39,7 +61,10 @@ class _SignupBusinessIndustryScreenState
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          createMultiSelectChipsIndustry(),
+          CreateMultiSelectChips(
+            chips: _industryChips,
+            maxSelection: 1,
+          ),
         ],
       ),
     );

--- a/lib/widgets/screens/sign_up/sign_up_mentor_pronouns.dart
+++ b/lib/widgets/screens/sign_up/sign_up_mentor_pronouns.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_icon_footer.dart';
 import 'package:mm_flutter_app/widgets/screens/sign_up/sign_up_template.dart';
+
 import '../../molecules/checkbox_list_and_form.dart';
 import 'sign_up_bottom_buttons.dart';
 
@@ -47,6 +48,84 @@ class _SignupMentorPronounsScreenState
           const PronounExample(),
         ],
       ),
+    );
+  }
+}
+
+class PronounExample extends StatefulWidget {
+  const PronounExample({Key? key}) : super(key: key);
+
+  @override
+  State<PronounExample> createState() => _PronounExampleState();
+}
+
+class _PronounExampleState extends State<PronounExample> {
+  bool _isSelected1 = false;
+  bool _isSelected2 = false;
+  bool _isSelected3 = false;
+  int _numPronounsSelect = 0;
+  int _selectionorder1 = 0;
+  int _selectionorder2 = 0;
+  int _selectionorder3 = 0;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        LabeledCheckbox(
+          label: 'she/her',
+          id: 'f',
+          value: _isSelected1,
+          selectionOrder: _selectionorder1,
+          onChanged: (bool value) {
+            setState(() {
+              _isSelected1 = value;
+              if (value == true) {
+                _selectionorder1 = _numPronounsSelect + 1;
+                _numPronounsSelect = _numPronounsSelect + 1;
+              } else {
+                _selectionorder1 = _numPronounsSelect - 1;
+                _numPronounsSelect = _numPronounsSelect - 1;
+              }
+            });
+          },
+        ),
+        LabeledCheckbox(
+          label: 'he/him',
+          id: 'm',
+          value: _isSelected2,
+          selectionOrder: _selectionorder2,
+          onChanged: (bool value) {
+            setState(() {
+              _isSelected2 = value;
+              if (value == true) {
+                _selectionorder2 = _numPronounsSelect + 1;
+                _numPronounsSelect = _numPronounsSelect + 1;
+              } else {
+                _selectionorder2 = _numPronounsSelect - 1;
+                _numPronounsSelect = _numPronounsSelect - 1;
+              }
+            });
+          },
+        ),
+        LabeledCheckbox(
+          label: 'they/them',
+          id: 'x',
+          value: _isSelected3,
+          selectionOrder: _selectionorder3,
+          onChanged: (bool value) {
+            setState(() {
+              _isSelected3 = value;
+              if (value == true) {
+                _selectionorder3 = _numPronounsSelect + 1;
+                _numPronounsSelect = _numPronounsSelect + 1;
+              } else {
+                _selectionorder3 = _numPronounsSelect - 1;
+                _numPronounsSelect = _numPronounsSelect - 1;
+              }
+            });
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/screens/sign_up/sign_up_template.dart
+++ b/lib/widgets/screens/sign_up/sign_up_template.dart
@@ -23,13 +23,14 @@ class SignUpTemplate extends StatefulWidget {
   final Widget? footer;
   final Widget? bottomButtons;
 
-  const SignUpTemplate(
-      {super.key,
-      required this.progress,
-      required this.title,
-      required this.body,
-      this.footer,
-      this.bottomButtons});
+  const SignUpTemplate({
+    super.key,
+    required this.progress,
+    required this.title,
+    required this.body,
+    this.footer,
+    this.bottomButtons,
+  });
 
   @override
   State<SignUpTemplate> createState() => _SignUpTemplateState();
@@ -68,8 +69,11 @@ class _SignUpTemplateState extends State<SignUpTemplate> {
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: Insets.paddingMedium),
-                widget.body,
-                const Spacer(),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: widget.body,
+                  ),
+                ),
                 if (widget.footer != null)
                   SizedBox(width: 240, child: widget.footer),
                 if (widget.bottomButtons != null) widget.bottomButtons!,


### PR DESCRIPTION
Fetches options from the backend using the content provider. This PR integrates the expertise picker, the pronoun picker, and the industry picker. This should cover the entire entrepreneur flow.

Note that some functions with hardcoded data were left in some classes because these are being used in the pages that Rupal is working on, so I chose not to delete them to avoid conflicts. These should be cleaned up as soon as we integrate the mentor's flow with the content provider.