### PR TITLE
Add paginated user search results to user provider

### DIFF
--- a/lib/__generated/schema/operations_content.graphql.dart
+++ b/lib/__generated/schema/operations_content.graphql.dart
@@ -3,7 +3,6 @@
 // ignore_for_file: type=lint
 
 import 'package:gql/ast.dart';
-
 import 'schema.graphql.dart';
 
 class Query$FindAllOptionsByType {

--- a/lib/__generated/schema/operations_user.graphql.dart
+++ b/lib/__generated/schema/operations_user.graphql.dart
@@ -7799,6 +7799,2479 @@ class _CopyWithStubImpl$Query$FindUserSearch$findUserSearchById$runInfos<TRes>
       _res;
 }
 
+class Variables$Query$FindUserSearchResults {
+  factory Variables$Query$FindUserSearchResults({
+    required String userSearchId,
+    Input$FindObjectsOptions? options,
+  }) =>
+      Variables$Query$FindUserSearchResults._({
+        r'userSearchId': userSearchId,
+        if (options != null) r'options': options,
+      });
+
+  Variables$Query$FindUserSearchResults._(this._$data);
+
+  factory Variables$Query$FindUserSearchResults.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$userSearchId = data['userSearchId'];
+    result$data['userSearchId'] = (l$userSearchId as String);
+    if (data.containsKey('options')) {
+      final l$options = data['options'];
+      result$data['options'] = l$options == null
+          ? null
+          : Input$FindObjectsOptions.fromJson(
+              (l$options as Map<String, dynamic>));
+    }
+    return Variables$Query$FindUserSearchResults._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String get userSearchId => (_$data['userSearchId'] as String);
+  Input$FindObjectsOptions? get options =>
+      (_$data['options'] as Input$FindObjectsOptions?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$userSearchId = userSearchId;
+    result$data['userSearchId'] = l$userSearchId;
+    if (_$data.containsKey('options')) {
+      final l$options = options;
+      result$data['options'] = l$options?.toJson();
+    }
+    return result$data;
+  }
+
+  CopyWith$Variables$Query$FindUserSearchResults<
+          Variables$Query$FindUserSearchResults>
+      get copyWith => CopyWith$Variables$Query$FindUserSearchResults(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Query$FindUserSearchResults) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$userSearchId = userSearchId;
+    final lOther$userSearchId = other.userSearchId;
+    if (l$userSearchId != lOther$userSearchId) {
+      return false;
+    }
+    final l$options = options;
+    final lOther$options = other.options;
+    if (_$data.containsKey('options') != other._$data.containsKey('options')) {
+      return false;
+    }
+    if (l$options != lOther$options) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$userSearchId = userSearchId;
+    final l$options = options;
+    return Object.hashAll([
+      l$userSearchId,
+      _$data.containsKey('options') ? l$options : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Variables$Query$FindUserSearchResults<TRes> {
+  factory CopyWith$Variables$Query$FindUserSearchResults(
+    Variables$Query$FindUserSearchResults instance,
+    TRes Function(Variables$Query$FindUserSearchResults) then,
+  ) = _CopyWithImpl$Variables$Query$FindUserSearchResults;
+
+  factory CopyWith$Variables$Query$FindUserSearchResults.stub(TRes res) =
+      _CopyWithStubImpl$Variables$Query$FindUserSearchResults;
+
+  TRes call({
+    String? userSearchId,
+    Input$FindObjectsOptions? options,
+  });
+}
+
+class _CopyWithImpl$Variables$Query$FindUserSearchResults<TRes>
+    implements CopyWith$Variables$Query$FindUserSearchResults<TRes> {
+  _CopyWithImpl$Variables$Query$FindUserSearchResults(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Query$FindUserSearchResults _instance;
+
+  final TRes Function(Variables$Query$FindUserSearchResults) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? userSearchId = _undefined,
+    Object? options = _undefined,
+  }) =>
+      _then(Variables$Query$FindUserSearchResults._({
+        ..._instance._$data,
+        if (userSearchId != _undefined && userSearchId != null)
+          'userSearchId': (userSearchId as String),
+        if (options != _undefined)
+          'options': (options as Input$FindObjectsOptions?),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Query$FindUserSearchResults<TRes>
+    implements CopyWith$Variables$Query$FindUserSearchResults<TRes> {
+  _CopyWithStubImpl$Variables$Query$FindUserSearchResults(this._res);
+
+  TRes _res;
+
+  call({
+    String? userSearchId,
+    Input$FindObjectsOptions? options,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults {
+  Query$FindUserSearchResults({
+    required this.findUserSearchResults,
+    this.$__typename = 'Query',
+  });
+
+  factory Query$FindUserSearchResults.fromJson(Map<String, dynamic> json) {
+    final l$findUserSearchResults = json['findUserSearchResults'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults(
+      findUserSearchResults: (l$findUserSearchResults as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearchResults$findUserSearchResults.fromJson(
+                  (e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final List<Query$FindUserSearchResults$findUserSearchResults>
+      findUserSearchResults;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$findUserSearchResults = findUserSearchResults;
+    _resultData['findUserSearchResults'] =
+        l$findUserSearchResults.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$findUserSearchResults = findUserSearchResults;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      Object.hashAll(l$findUserSearchResults.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearchResults) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$findUserSearchResults = findUserSearchResults;
+    final lOther$findUserSearchResults = other.findUserSearchResults;
+    if (l$findUserSearchResults.length != lOther$findUserSearchResults.length) {
+      return false;
+    }
+    for (int i = 0; i < l$findUserSearchResults.length; i++) {
+      final l$findUserSearchResults$entry = l$findUserSearchResults[i];
+      final lOther$findUserSearchResults$entry =
+          lOther$findUserSearchResults[i];
+      if (l$findUserSearchResults$entry != lOther$findUserSearchResults$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults
+    on Query$FindUserSearchResults {
+  CopyWith$Query$FindUserSearchResults<Query$FindUserSearchResults>
+      get copyWith => CopyWith$Query$FindUserSearchResults(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults<TRes> {
+  factory CopyWith$Query$FindUserSearchResults(
+    Query$FindUserSearchResults instance,
+    TRes Function(Query$FindUserSearchResults) then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults;
+
+  factory CopyWith$Query$FindUserSearchResults.stub(TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults;
+
+  TRes call({
+    List<Query$FindUserSearchResults$findUserSearchResults>?
+        findUserSearchResults,
+    String? $__typename,
+  });
+  TRes findUserSearchResults(
+      Iterable<Query$FindUserSearchResults$findUserSearchResults> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearchResults$findUserSearchResults<
+                      Query$FindUserSearchResults$findUserSearchResults>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults<TRes>
+    implements CopyWith$Query$FindUserSearchResults<TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults _instance;
+
+  final TRes Function(Query$FindUserSearchResults) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? findUserSearchResults = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearchResults(
+        findUserSearchResults:
+            findUserSearchResults == _undefined || findUserSearchResults == null
+                ? _instance.findUserSearchResults
+                : (findUserSearchResults
+                    as List<Query$FindUserSearchResults$findUserSearchResults>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  TRes findUserSearchResults(
+          Iterable<Query$FindUserSearchResults$findUserSearchResults> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearchResults$findUserSearchResults<
+                          Query$FindUserSearchResults$findUserSearchResults>>)
+              _fn) =>
+      call(
+          findUserSearchResults: _fn(_instance.findUserSearchResults.map(
+              (e) => CopyWith$Query$FindUserSearchResults$findUserSearchResults(
+                    e,
+                    (i) => i,
+                  ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults<TRes>
+    implements CopyWith$Query$FindUserSearchResults<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults(this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindUserSearchResults$findUserSearchResults>?
+        findUserSearchResults,
+    String? $__typename,
+  }) =>
+      _res;
+  findUserSearchResults(_fn) => _res;
+}
+
+const documentNodeQueryFindUserSearchResults = DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.query,
+    name: NameNode(value: 'FindUserSearchResults'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'userSearchId')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'options')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'FindObjectsOptions'),
+          isNonNull: false,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      ),
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'findUserSearchResults'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'userSearchId'),
+            value: VariableNode(name: NameNode(value: 'userSearchId')),
+          ),
+          ArgumentNode(
+            name: NameNode(value: 'options'),
+            value: VariableNode(name: NameNode(value: 'options')),
+          ),
+        ],
+        directives: [],
+        selectionSet: SelectionSetNode(selections: [
+          FieldNode(
+            name: NameNode(value: 'id'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'email'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'firstName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'lastName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'fullName'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'avatarUrl'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'userHandle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'offersHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'seeksHelp'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'jobTitle'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'cityOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'regionOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
+            name: NameNode(value: 'countryOfResidence'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'translatedValue'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'groupMemberships'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'groupIdent'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MentorsGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'expertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: 'endorsements'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              InlineFragmentNode(
+                typeCondition: TypeConditionNode(
+                    on: NamedTypeNode(
+                  name: NameNode(value: 'MenteesGroupMembership'),
+                  isNonNull: false,
+                )),
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                    name: NameNode(value: 'soughtExpertises'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: SelectionSetNode(selections: [
+                      FieldNode(
+                        name: NameNode(value: 'translatedValue'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                      FieldNode(
+                        name: NameNode(value: '__typename'),
+                        alias: null,
+                        arguments: [],
+                        directives: [],
+                        selectionSet: null,
+                      ),
+                    ]),
+                  ),
+                  FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null,
+                  ),
+                ]),
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: 'companies'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: SelectionSetNode(selections: [
+              FieldNode(
+                name: NameNode(value: 'name'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+              FieldNode(
+                name: NameNode(value: '__typename'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null,
+              ),
+            ]),
+          ),
+          FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+        ]),
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Query$FindUserSearchResults$findUserSearchResults {
+  Query$FindUserSearchResults$findUserSearchResults({
+    required this.id,
+    this.email,
+    this.firstName,
+    this.lastName,
+    this.fullName,
+    this.avatarUrl,
+    this.userHandle,
+    required this.offersHelp,
+    required this.seeksHelp,
+    this.jobTitle,
+    this.cityOfResidence,
+    this.regionOfResidence,
+    this.countryOfResidence,
+    required this.groupMemberships,
+    required this.companies,
+    this.$__typename = 'User',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults.fromJson(
+      Map<String, dynamic> json) {
+    final l$id = json['id'];
+    final l$email = json['email'];
+    final l$firstName = json['firstName'];
+    final l$lastName = json['lastName'];
+    final l$fullName = json['fullName'];
+    final l$avatarUrl = json['avatarUrl'];
+    final l$userHandle = json['userHandle'];
+    final l$offersHelp = json['offersHelp'];
+    final l$seeksHelp = json['seeksHelp'];
+    final l$jobTitle = json['jobTitle'];
+    final l$cityOfResidence = json['cityOfResidence'];
+    final l$regionOfResidence = json['regionOfResidence'];
+    final l$countryOfResidence = json['countryOfResidence'];
+    final l$groupMemberships = json['groupMemberships'];
+    final l$companies = json['companies'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults(
+      id: (l$id as String),
+      email: (l$email as String?),
+      firstName: (l$firstName as String?),
+      lastName: (l$lastName as String?),
+      fullName: (l$fullName as String?),
+      avatarUrl: (l$avatarUrl as String?),
+      userHandle: (l$userHandle as String?),
+      offersHelp: (l$offersHelp as bool),
+      seeksHelp: (l$seeksHelp as bool),
+      jobTitle: (l$jobTitle as String?),
+      cityOfResidence: (l$cityOfResidence as String?),
+      regionOfResidence: (l$regionOfResidence as String?),
+      countryOfResidence: l$countryOfResidence == null
+          ? null
+          : Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+              .fromJson((l$countryOfResidence as Map<String, dynamic>)),
+      groupMemberships: (l$groupMemberships as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearchResults$findUserSearchResults$groupMemberships
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      companies: (l$companies as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearchResults$findUserSearchResults$companies
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String id;
+
+  final String? email;
+
+  final String? firstName;
+
+  final String? lastName;
+
+  final String? fullName;
+
+  final String? avatarUrl;
+
+  final String? userHandle;
+
+  final bool offersHelp;
+
+  final bool seeksHelp;
+
+  final String? jobTitle;
+
+  final String? cityOfResidence;
+
+  final String? regionOfResidence;
+
+  final Query$FindUserSearchResults$findUserSearchResults$countryOfResidence?
+      countryOfResidence;
+
+  final List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships>
+      groupMemberships;
+
+  final List<Query$FindUserSearchResults$findUserSearchResults$companies>
+      companies;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$id = id;
+    _resultData['id'] = l$id;
+    final l$email = email;
+    _resultData['email'] = l$email;
+    final l$firstName = firstName;
+    _resultData['firstName'] = l$firstName;
+    final l$lastName = lastName;
+    _resultData['lastName'] = l$lastName;
+    final l$fullName = fullName;
+    _resultData['fullName'] = l$fullName;
+    final l$avatarUrl = avatarUrl;
+    _resultData['avatarUrl'] = l$avatarUrl;
+    final l$userHandle = userHandle;
+    _resultData['userHandle'] = l$userHandle;
+    final l$offersHelp = offersHelp;
+    _resultData['offersHelp'] = l$offersHelp;
+    final l$seeksHelp = seeksHelp;
+    _resultData['seeksHelp'] = l$seeksHelp;
+    final l$jobTitle = jobTitle;
+    _resultData['jobTitle'] = l$jobTitle;
+    final l$cityOfResidence = cityOfResidence;
+    _resultData['cityOfResidence'] = l$cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    _resultData['regionOfResidence'] = l$regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    _resultData['countryOfResidence'] = l$countryOfResidence?.toJson();
+    final l$groupMemberships = groupMemberships;
+    _resultData['groupMemberships'] =
+        l$groupMemberships.map((e) => e.toJson()).toList();
+    final l$companies = companies;
+    _resultData['companies'] = l$companies.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$email = email;
+    final l$firstName = firstName;
+    final l$lastName = lastName;
+    final l$fullName = fullName;
+    final l$avatarUrl = avatarUrl;
+    final l$userHandle = userHandle;
+    final l$offersHelp = offersHelp;
+    final l$seeksHelp = seeksHelp;
+    final l$jobTitle = jobTitle;
+    final l$cityOfResidence = cityOfResidence;
+    final l$regionOfResidence = regionOfResidence;
+    final l$countryOfResidence = countryOfResidence;
+    final l$groupMemberships = groupMemberships;
+    final l$companies = companies;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$id,
+      l$email,
+      l$firstName,
+      l$lastName,
+      l$fullName,
+      l$avatarUrl,
+      l$userHandle,
+      l$offersHelp,
+      l$seeksHelp,
+      l$jobTitle,
+      l$cityOfResidence,
+      l$regionOfResidence,
+      l$countryOfResidence,
+      Object.hashAll(l$groupMemberships.map((v) => v)),
+      Object.hashAll(l$companies.map((v) => v)),
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Query$FindUserSearchResults$findUserSearchResults) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$email = email;
+    final lOther$email = other.email;
+    if (l$email != lOther$email) {
+      return false;
+    }
+    final l$firstName = firstName;
+    final lOther$firstName = other.firstName;
+    if (l$firstName != lOther$firstName) {
+      return false;
+    }
+    final l$lastName = lastName;
+    final lOther$lastName = other.lastName;
+    if (l$lastName != lOther$lastName) {
+      return false;
+    }
+    final l$fullName = fullName;
+    final lOther$fullName = other.fullName;
+    if (l$fullName != lOther$fullName) {
+      return false;
+    }
+    final l$avatarUrl = avatarUrl;
+    final lOther$avatarUrl = other.avatarUrl;
+    if (l$avatarUrl != lOther$avatarUrl) {
+      return false;
+    }
+    final l$userHandle = userHandle;
+    final lOther$userHandle = other.userHandle;
+    if (l$userHandle != lOther$userHandle) {
+      return false;
+    }
+    final l$offersHelp = offersHelp;
+    final lOther$offersHelp = other.offersHelp;
+    if (l$offersHelp != lOther$offersHelp) {
+      return false;
+    }
+    final l$seeksHelp = seeksHelp;
+    final lOther$seeksHelp = other.seeksHelp;
+    if (l$seeksHelp != lOther$seeksHelp) {
+      return false;
+    }
+    final l$jobTitle = jobTitle;
+    final lOther$jobTitle = other.jobTitle;
+    if (l$jobTitle != lOther$jobTitle) {
+      return false;
+    }
+    final l$cityOfResidence = cityOfResidence;
+    final lOther$cityOfResidence = other.cityOfResidence;
+    if (l$cityOfResidence != lOther$cityOfResidence) {
+      return false;
+    }
+    final l$regionOfResidence = regionOfResidence;
+    final lOther$regionOfResidence = other.regionOfResidence;
+    if (l$regionOfResidence != lOther$regionOfResidence) {
+      return false;
+    }
+    final l$countryOfResidence = countryOfResidence;
+    final lOther$countryOfResidence = other.countryOfResidence;
+    if (l$countryOfResidence != lOther$countryOfResidence) {
+      return false;
+    }
+    final l$groupMemberships = groupMemberships;
+    final lOther$groupMemberships = other.groupMemberships;
+    if (l$groupMemberships.length != lOther$groupMemberships.length) {
+      return false;
+    }
+    for (int i = 0; i < l$groupMemberships.length; i++) {
+      final l$groupMemberships$entry = l$groupMemberships[i];
+      final lOther$groupMemberships$entry = lOther$groupMemberships[i];
+      if (l$groupMemberships$entry != lOther$groupMemberships$entry) {
+        return false;
+      }
+    }
+    final l$companies = companies;
+    final lOther$companies = other.companies;
+    if (l$companies.length != lOther$companies.length) {
+      return false;
+    }
+    for (int i = 0; i < l$companies.length; i++) {
+      final l$companies$entry = l$companies[i];
+      final lOther$companies$entry = lOther$companies[i];
+      if (l$companies$entry != lOther$companies$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults
+    on Query$FindUserSearchResults$findUserSearchResults {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults<
+          Query$FindUserSearchResults$findUserSearchResults>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults(
+    Query$FindUserSearchResults$findUserSearchResults instance,
+    TRes Function(Query$FindUserSearchResults$findUserSearchResults) then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults;
+
+  TRes call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindUserSearchResults$findUserSearchResults$countryOfResidence?
+        countryOfResidence,
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships>?
+        groupMemberships,
+    List<Query$FindUserSearchResults$findUserSearchResults$companies>?
+        companies,
+    String? $__typename,
+  });
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+      TRes> get countryOfResidence;
+  TRes groupMemberships(
+      Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+                      Query$FindUserSearchResults$findUserSearchResults$groupMemberships>>)
+          _fn);
+  TRes companies(
+      Iterable<Query$FindUserSearchResults$findUserSearchResults$companies> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+                      Query$FindUserSearchResults$findUserSearchResults$companies>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults<TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults<TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults _instance;
+
+  final TRes Function(Query$FindUserSearchResults$findUserSearchResults) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? email = _undefined,
+    Object? firstName = _undefined,
+    Object? lastName = _undefined,
+    Object? fullName = _undefined,
+    Object? avatarUrl = _undefined,
+    Object? userHandle = _undefined,
+    Object? offersHelp = _undefined,
+    Object? seeksHelp = _undefined,
+    Object? jobTitle = _undefined,
+    Object? cityOfResidence = _undefined,
+    Object? regionOfResidence = _undefined,
+    Object? countryOfResidence = _undefined,
+    Object? groupMemberships = _undefined,
+    Object? companies = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearchResults$findUserSearchResults(
+        id: id == _undefined || id == null ? _instance.id : (id as String),
+        email: email == _undefined ? _instance.email : (email as String?),
+        firstName: firstName == _undefined
+            ? _instance.firstName
+            : (firstName as String?),
+        lastName:
+            lastName == _undefined ? _instance.lastName : (lastName as String?),
+        fullName:
+            fullName == _undefined ? _instance.fullName : (fullName as String?),
+        avatarUrl: avatarUrl == _undefined
+            ? _instance.avatarUrl
+            : (avatarUrl as String?),
+        userHandle: userHandle == _undefined
+            ? _instance.userHandle
+            : (userHandle as String?),
+        offersHelp: offersHelp == _undefined || offersHelp == null
+            ? _instance.offersHelp
+            : (offersHelp as bool),
+        seeksHelp: seeksHelp == _undefined || seeksHelp == null
+            ? _instance.seeksHelp
+            : (seeksHelp as bool),
+        jobTitle:
+            jobTitle == _undefined ? _instance.jobTitle : (jobTitle as String?),
+        cityOfResidence: cityOfResidence == _undefined
+            ? _instance.cityOfResidence
+            : (cityOfResidence as String?),
+        regionOfResidence: regionOfResidence == _undefined
+            ? _instance.regionOfResidence
+            : (regionOfResidence as String?),
+        countryOfResidence: countryOfResidence == _undefined
+            ? _instance.countryOfResidence
+            : (countryOfResidence
+                as Query$FindUserSearchResults$findUserSearchResults$countryOfResidence?),
+        groupMemberships: groupMemberships == _undefined ||
+                groupMemberships == null
+            ? _instance.groupMemberships
+            : (groupMemberships as List<
+                Query$FindUserSearchResults$findUserSearchResults$groupMemberships>),
+        companies: companies == _undefined || companies == null
+            ? _instance.companies
+            : (companies as List<
+                Query$FindUserSearchResults$findUserSearchResults$companies>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+      TRes> get countryOfResidence {
+    final local$countryOfResidence = _instance.countryOfResidence;
+    return local$countryOfResidence == null
+        ? CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+            .stub(_then(_instance))
+        : CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+            local$countryOfResidence, (e) => call(countryOfResidence: e));
+  }
+
+  TRes groupMemberships(
+          Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+                          Query$FindUserSearchResults$findUserSearchResults$groupMemberships>>)
+              _fn) =>
+      call(
+          groupMemberships: _fn(_instance.groupMemberships.map((e) =>
+              CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+                e,
+                (i) => i,
+              ))).toList());
+  TRes companies(
+          Iterable<Query$FindUserSearchResults$findUserSearchResults$companies> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+                          Query$FindUserSearchResults$findUserSearchResults$companies>>)
+              _fn) =>
+      call(
+          companies: _fn(_instance.companies.map((e) =>
+              CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults<TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults<TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? email,
+    String? firstName,
+    String? lastName,
+    String? fullName,
+    String? avatarUrl,
+    String? userHandle,
+    bool? offersHelp,
+    bool? seeksHelp,
+    String? jobTitle,
+    String? cityOfResidence,
+    String? regionOfResidence,
+    Query$FindUserSearchResults$findUserSearchResults$countryOfResidence?
+        countryOfResidence,
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships>?
+        groupMemberships,
+    List<Query$FindUserSearchResults$findUserSearchResults$companies>?
+        companies,
+    String? $__typename,
+  }) =>
+      _res;
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+          TRes>
+      get countryOfResidence =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+              .stub(_res);
+  groupMemberships(_fn) => _res;
+  companies(_fn) => _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$countryOfResidence {
+  Query$FindUserSearchResults$findUserSearchResults$countryOfResidence({
+    this.translatedValue,
+    this.$__typename = 'Country',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$countryOfResidence.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$countryOfResidence) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+    on Query$FindUserSearchResults$findUserSearchResults$countryOfResidence {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+          Query$FindUserSearchResults$findUserSearchResults$countryOfResidence>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+    Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$countryOfResidence)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$countryOfResidence
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$countryOfResidence)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$countryOfResidence(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships({
+    required this.groupIdent,
+    required this.$__typename,
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships.fromJson(
+      Map<String, dynamic> json) {
+    switch (json["__typename"] as String) {
+      case "MentorsGroupMembership":
+        return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership
+            .fromJson(json);
+
+      case "MenteesGroupMembership":
+        return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership
+            .fromJson(json);
+
+      case "GroupMembership":
+        return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership
+            .fromJson(json);
+
+      default:
+        final l$groupIdent = json['groupIdent'];
+        final l$$__typename = json['__typename'];
+        return Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+          groupIdent: (l$groupIdent as String),
+          $__typename: (l$$__typename as String),
+        );
+    }
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+            this,
+            (i) => i,
+          );
+  _T when<_T>({
+    required _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership)
+        mentorsGroupMembership,
+    required _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership)
+        menteesGroupMembership,
+    required _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership)
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        return mentorsGroupMembership(this
+            as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership);
+
+      case "MenteesGroupMembership":
+        return menteesGroupMembership(this
+            as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership);
+
+      case "GroupMembership":
+        return groupMembership(this
+            as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership);
+
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership)?
+        mentorsGroupMembership,
+    _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership)?
+        menteesGroupMembership,
+    _T Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership)?
+        groupMembership,
+    required _T Function() orElse,
+  }) {
+    switch ($__typename) {
+      case "MentorsGroupMembership":
+        if (mentorsGroupMembership != null) {
+          return mentorsGroupMembership(this
+              as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "MenteesGroupMembership":
+        if (menteesGroupMembership != null) {
+          return menteesGroupMembership(this
+              as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership);
+        } else {
+          return orElse();
+        }
+
+      case "GroupMembership":
+        if (groupMembership != null) {
+          return groupMembership(this
+              as Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership);
+        } else {
+          return orElse();
+        }
+
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships
+      _instance;
+
+  final TRes Function(
+      Query$FindUserSearchResults$findUserSearchResults$groupMemberships) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership
+    implements
+        Query$FindUserSearchResults$findUserSearchResults$groupMemberships {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership({
+    required this.expertises,
+    this.endorsements,
+    this.$__typename = 'MentorsGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$expertises = json['expertises'];
+    final l$endorsements = json['endorsements'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+      expertises: (l$expertises as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      endorsements: (l$endorsements as int?),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>
+      expertises;
+
+  final int? endorsements;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$expertises = expertises;
+    _resultData['expertises'] = l$expertises.map((e) => e.toJson()).toList();
+    final l$endorsements = endorsements;
+    _resultData['endorsements'] = l$endorsements;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$expertises = expertises;
+    final l$endorsements = endorsements;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      Object.hashAll(l$expertises.map((v) => v)),
+      l$endorsements,
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$expertises = expertises;
+    final lOther$expertises = other.expertises;
+    if (l$expertises.length != lOther$expertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$expertises.length; i++) {
+      final l$expertises$entry = l$expertises[i];
+      final lOther$expertises$entry = lOther$expertises[i];
+      if (l$expertises$entry != lOther$expertises$entry) {
+        return false;
+      }
+    }
+    final l$endorsements = endorsements;
+    final lOther$endorsements = other.endorsements;
+    if (l$endorsements != lOther$endorsements) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership;
+
+  TRes call({
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes expertises(
+      Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+                      Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? expertises = _undefined,
+    Object? endorsements = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+        expertises: expertises == _undefined || expertises == null
+            ? _instance.expertises
+            : (expertises as List<
+                Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>),
+        endorsements: endorsements == _undefined
+            ? _instance.endorsements
+            : (endorsements as int?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes expertises(
+          Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+                          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>>)
+              _fn) =>
+      call(
+          expertises: _fn(_instance.expertises.map((e) =>
+              CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>?
+        expertises,
+    int? endorsements,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  expertises(_fn) => _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MentorsGroupMembership$expertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership
+    implements
+        Query$FindUserSearchResults$findUserSearchResults$groupMemberships {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership({
+    required this.soughtExpertises,
+    this.$__typename = 'MenteesGroupMembership',
+    required this.groupIdent,
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$soughtExpertises = json['soughtExpertises'];
+    final l$$__typename = json['__typename'];
+    final l$groupIdent = json['groupIdent'];
+    return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+      soughtExpertises: (l$soughtExpertises as List<dynamic>)
+          .map((e) =>
+              Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises
+                  .fromJson((e as Map<String, dynamic>)))
+          .toList(),
+      $__typename: (l$$__typename as String),
+      groupIdent: (l$groupIdent as String),
+    );
+  }
+
+  final List<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      soughtExpertises;
+
+  final String $__typename;
+
+  final String groupIdent;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$soughtExpertises = soughtExpertises;
+    _resultData['soughtExpertises'] =
+        l$soughtExpertises.map((e) => e.toJson()).toList();
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$soughtExpertises = soughtExpertises;
+    final l$$__typename = $__typename;
+    final l$groupIdent = groupIdent;
+    return Object.hashAll([
+      Object.hashAll(l$soughtExpertises.map((v) => v)),
+      l$$__typename,
+      l$groupIdent,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$soughtExpertises = soughtExpertises;
+    final lOther$soughtExpertises = other.soughtExpertises;
+    if (l$soughtExpertises.length != lOther$soughtExpertises.length) {
+      return false;
+    }
+    for (int i = 0; i < l$soughtExpertises.length; i++) {
+      final l$soughtExpertises$entry = l$soughtExpertises[i];
+      final lOther$soughtExpertises$entry = lOther$soughtExpertises[i];
+      if (l$soughtExpertises$entry != lOther$soughtExpertises$entry) {
+        return false;
+      }
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership;
+
+  TRes call({
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    String? $__typename,
+    String? groupIdent,
+  });
+  TRes soughtExpertises(
+      Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+              Iterable<
+                  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                      Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+          _fn);
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? soughtExpertises = _undefined,
+    Object? $__typename = _undefined,
+    Object? groupIdent = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+        soughtExpertises: soughtExpertises == _undefined ||
+                soughtExpertises == null
+            ? _instance.soughtExpertises
+            : (soughtExpertises as List<
+                Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+      ));
+  TRes soughtExpertises(
+          Iterable<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises> Function(
+                  Iterable<
+                      CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+                          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>>)
+              _fn) =>
+      call(
+          soughtExpertises: _fn(_instance.soughtExpertises.map((e) =>
+              CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+                e,
+                (i) => i,
+              ))).toList());
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    List<Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>?
+        soughtExpertises,
+    String? $__typename,
+    String? groupIdent,
+  }) =>
+      _res;
+  soughtExpertises(_fn) => _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises({
+    this.translatedValue,
+    this.$__typename = 'Expertise',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises.fromJson(
+      Map<String, dynamic> json) {
+    final l$translatedValue = json['translatedValue'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      translatedValue: (l$translatedValue as String?),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String? translatedValue;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$translatedValue = translatedValue;
+    _resultData['translatedValue'] = l$translatedValue;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$translatedValue = translatedValue;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$translatedValue,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$translatedValue = translatedValue;
+    final lOther$translatedValue = other.translatedValue;
+    if (l$translatedValue != lOther$translatedValue) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises;
+
+  TRes call({
+    String? translatedValue,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? translatedValue = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+        translatedValue: translatedValue == _undefined
+            ? _instance.translatedValue
+            : (translatedValue as String?),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$MenteesGroupMembership$soughtExpertises(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? translatedValue,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership
+    implements
+        Query$FindUserSearchResults$findUserSearchResults$groupMemberships {
+  Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership({
+    required this.groupIdent,
+    this.$__typename = 'GroupMembership',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership.fromJson(
+      Map<String, dynamic> json) {
+    final l$groupIdent = json['groupIdent'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+      groupIdent: (l$groupIdent as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String groupIdent;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$groupIdent = groupIdent;
+    _resultData['groupIdent'] = l$groupIdent;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$groupIdent = groupIdent;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$groupIdent,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$groupIdent = groupIdent;
+    final lOther$groupIdent = other.groupIdent;
+    if (l$groupIdent != lOther$groupIdent) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership
+    on Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+    Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership
+        instance,
+    TRes Function(
+            Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership;
+
+  TRes call({
+    String? groupIdent,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership
+      _instance;
+
+  final TRes Function(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership)
+      _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? groupIdent = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(
+          Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+        groupIdent: groupIdent == _undefined || groupIdent == null
+            ? _instance.groupIdent
+            : (groupIdent as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$groupMemberships$$GroupMembership(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? groupIdent,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+class Query$FindUserSearchResults$findUserSearchResults$companies {
+  Query$FindUserSearchResults$findUserSearchResults$companies({
+    required this.name,
+    this.$__typename = 'Company',
+  });
+
+  factory Query$FindUserSearchResults$findUserSearchResults$companies.fromJson(
+      Map<String, dynamic> json) {
+    final l$name = json['name'];
+    final l$$__typename = json['__typename'];
+    return Query$FindUserSearchResults$findUserSearchResults$companies(
+      name: (l$name as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String name;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$name = name;
+    _resultData['name'] = l$name;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$name,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other
+            is Query$FindUserSearchResults$findUserSearchResults$companies) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$FindUserSearchResults$findUserSearchResults$companies
+    on Query$FindUserSearchResults$findUserSearchResults$companies {
+  CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+          Query$FindUserSearchResults$findUserSearchResults$companies>
+      get copyWith =>
+          CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+    TRes> {
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies(
+    Query$FindUserSearchResults$findUserSearchResults$companies instance,
+    TRes Function(Query$FindUserSearchResults$findUserSearchResults$companies)
+        then,
+  ) = _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$companies;
+
+  factory CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies.stub(
+          TRes res) =
+      _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$companies;
+
+  TRes call({
+    String? name,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+            TRes> {
+  _CopyWithImpl$Query$FindUserSearchResults$findUserSearchResults$companies(
+    this._instance,
+    this._then,
+  );
+
+  final Query$FindUserSearchResults$findUserSearchResults$companies _instance;
+
+  final TRes Function(
+      Query$FindUserSearchResults$findUserSearchResults$companies) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Query$FindUserSearchResults$findUserSearchResults$companies(
+        name: name == _undefined || name == null
+            ? _instance.name
+            : (name as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$companies<
+        TRes>
+    implements
+        CopyWith$Query$FindUserSearchResults$findUserSearchResults$companies<
+            TRes> {
+  _CopyWithStubImpl$Query$FindUserSearchResults$findUserSearchResults$companies(
+      this._res);
+
+  TRes _res;
+
+  call({
+    String? name,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
 class Variables$Query$FindMenteeUsers {
   factory Variables$Query$FindMenteeUsers({
     Input$FindObjectsOptions? options,

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -6824,6 +6824,7 @@ class _CopyWithStubImpl$Input$AcademicExperienceInput<TRes>
 class Input$UserListFilter {
   factory Input$UserListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -6834,9 +6835,11 @@ class Input$UserListFilter {
     List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
+    bool? isMm2User,
   }) =>
       Input$UserListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -6847,6 +6850,7 @@ class Input$UserListFilter {
         if (rolesIn != null) r'rolesIn': rolesIn,
         if (companyId != null) r'companyId': companyId,
         if (syncedWithMm2 != null) r'syncedWithMm2': syncedWithMm2,
+        if (isMm2User != null) r'isMm2User': isMm2User,
       });
 
   Input$UserListFilter._(this._$data);
@@ -6857,6 +6861,11 @@ class Input$UserListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -6910,12 +6919,17 @@ class Input$UserListFilter {
       final l$syncedWithMm2 = data['syncedWithMm2'];
       result$data['syncedWithMm2'] = (l$syncedWithMm2 as bool?);
     }
+    if (data.containsKey('isMm2User')) {
+      final l$isMm2User = data['isMm2User'];
+      result$data['isMm2User'] = (l$isMm2User as bool?);
+    }
     return Input$UserListFilter._(result$data);
   }
 
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -6928,11 +6942,16 @@ class Input$UserListFilter {
       (_$data['rolesIn'] as List<Enum$UserRole>?);
   String? get companyId => (_$data['companyId'] as String?);
   bool? get syncedWithMm2 => (_$data['syncedWithMm2'] as bool?);
+  bool? get isMm2User => (_$data['isMm2User'] as bool?);
   Map<String, dynamic> toJson() {
     final result$data = <String, dynamic>{};
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -6976,6 +6995,10 @@ class Input$UserListFilter {
       final l$syncedWithMm2 = syncedWithMm2;
       result$data['syncedWithMm2'] = l$syncedWithMm2;
     }
+    if (_$data.containsKey('isMm2User')) {
+      final l$isMm2User = isMm2User;
+      result$data['isMm2User'] = l$isMm2User;
+    }
     return result$data;
   }
 
@@ -7009,6 +7032,26 @@ class Input$UserListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -7122,12 +7165,22 @@ class Input$UserListFilter {
     if (l$syncedWithMm2 != lOther$syncedWithMm2) {
       return false;
     }
+    final l$isMm2User = isMm2User;
+    final lOther$isMm2User = other.isMm2User;
+    if (_$data.containsKey('isMm2User') !=
+        other._$data.containsKey('isMm2User')) {
+      return false;
+    }
+    if (l$isMm2User != lOther$isMm2User) {
+      return false;
+    }
     return true;
   }
 
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -7138,11 +7191,17 @@ class Input$UserListFilter {
     final l$rolesIn = rolesIn;
     final l$companyId = companyId;
     final l$syncedWithMm2 = syncedWithMm2;
+    final l$isMm2User = isMm2User;
     return Object.hashAll([
       _$data.containsKey('ids')
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -7162,6 +7221,7 @@ class Input$UserListFilter {
           : const {},
       _$data.containsKey('companyId') ? l$companyId : const {},
       _$data.containsKey('syncedWithMm2') ? l$syncedWithMm2 : const {},
+      _$data.containsKey('isMm2User') ? l$isMm2User : const {},
     ]);
   }
 }
@@ -7177,6 +7237,7 @@ abstract class CopyWith$Input$UserListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -7187,6 +7248,7 @@ abstract class CopyWith$Input$UserListFilter<TRes> {
     List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
+    bool? isMm2User,
   });
 }
 
@@ -7205,6 +7267,7 @@ class _CopyWithImpl$Input$UserListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -7215,10 +7278,13 @@ class _CopyWithImpl$Input$UserListFilter<TRes>
     Object? rolesIn = _undefined,
     Object? companyId = _undefined,
     Object? syncedWithMm2 = _undefined,
+    Object? isMm2User = _undefined,
   }) =>
       _then(Input$UserListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -7236,6 +7302,7 @@ class _CopyWithImpl$Input$UserListFilter<TRes>
         if (companyId != _undefined) 'companyId': (companyId as String?),
         if (syncedWithMm2 != _undefined)
           'syncedWithMm2': (syncedWithMm2 as bool?),
+        if (isMm2User != _undefined) 'isMm2User': (isMm2User as bool?),
       }));
 }
 
@@ -7247,6 +7314,7 @@ class _CopyWithStubImpl$Input$UserListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -7257,6 +7325,7 @@ class _CopyWithStubImpl$Input$UserListFilter<TRes>
     List<Enum$UserRole>? rolesIn,
     String? companyId,
     bool? syncedWithMm2,
+    bool? isMm2User,
   }) =>
       _res;
 }
@@ -8545,6 +8614,7 @@ class _CopyWithStubImpl$Input$UserDeviceInput<TRes>
 class Input$SidUserDeviceListFilter {
   factory Input$SidUserDeviceListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -8555,6 +8625,7 @@ class Input$SidUserDeviceListFilter {
   }) =>
       Input$SidUserDeviceListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -8572,6 +8643,11 @@ class Input$SidUserDeviceListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -8617,6 +8693,7 @@ class Input$SidUserDeviceListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -8630,6 +8707,10 @@ class Input$SidUserDeviceListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -8694,6 +8775,26 @@ class Input$SidUserDeviceListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -8776,6 +8877,7 @@ class Input$SidUserDeviceListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -8788,6 +8890,11 @@ class Input$SidUserDeviceListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -8815,6 +8922,7 @@ abstract class CopyWith$Input$SidUserDeviceListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -8840,6 +8948,7 @@ class _CopyWithImpl$Input$SidUserDeviceListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -8851,6 +8960,8 @@ class _CopyWithImpl$Input$SidUserDeviceListFilter<TRes>
       _then(Input$SidUserDeviceListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -8875,6 +8986,7 @@ class _CopyWithStubImpl$Input$SidUserDeviceListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -9916,6 +10028,7 @@ class _CopyWithStubImpl$Input$BgChannelStatusInput<TRes>
 class Input$ChannelListFilter {
   factory Input$ChannelListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -9926,6 +10039,7 @@ class Input$ChannelListFilter {
   }) =>
       Input$ChannelListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -9943,6 +10057,11 @@ class Input$ChannelListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -9988,6 +10107,7 @@ class Input$ChannelListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -10001,6 +10121,10 @@ class Input$ChannelListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -10065,6 +10189,26 @@ class Input$ChannelListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -10147,6 +10291,7 @@ class Input$ChannelListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -10159,6 +10304,11 @@ class Input$ChannelListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -10186,6 +10336,7 @@ abstract class CopyWith$Input$ChannelListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -10211,6 +10362,7 @@ class _CopyWithImpl$Input$ChannelListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -10222,6 +10374,8 @@ class _CopyWithImpl$Input$ChannelListFilter<TRes>
       _then(Input$ChannelListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -10246,6 +10400,7 @@ class _CopyWithStubImpl$Input$ChannelListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -11089,6 +11244,7 @@ class _CopyWithStubImpl$Input$ChannelMessageStatusInput<TRes>
 class Input$ChannelMessageListFilter {
   factory Input$ChannelMessageListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -11105,6 +11261,7 @@ class Input$ChannelMessageListFilter {
   }) =>
       Input$ChannelMessageListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -11129,6 +11286,11 @@ class Input$ChannelMessageListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -11201,6 +11363,7 @@ class Input$ChannelMessageListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -11221,6 +11384,10 @@ class Input$ChannelMessageListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -11311,6 +11478,26 @@ class Input$ChannelMessageListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -11463,6 +11650,7 @@ class Input$ChannelMessageListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -11481,6 +11669,11 @@ class Input$ChannelMessageListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -11518,6 +11711,7 @@ abstract class CopyWith$Input$ChannelMessageListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -11549,6 +11743,7 @@ class _CopyWithImpl$Input$ChannelMessageListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -11566,6 +11761,8 @@ class _CopyWithImpl$Input$ChannelMessageListFilter<TRes>
       _then(Input$ChannelMessageListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -11600,6 +11797,7 @@ class _CopyWithStubImpl$Input$ChannelMessageListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -11620,6 +11818,7 @@ class _CopyWithStubImpl$Input$ChannelMessageListFilter<TRes>
 class Input$GroupMembershipListFilter {
   factory Input$GroupMembershipListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -11633,6 +11832,7 @@ class Input$GroupMembershipListFilter {
   }) =>
       Input$GroupMembershipListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -11653,6 +11853,11 @@ class Input$GroupMembershipListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -11712,6 +11917,7 @@ class Input$GroupMembershipListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -11729,6 +11935,10 @@ class Input$GroupMembershipListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -11806,6 +12016,26 @@ class Input$GroupMembershipListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -11924,6 +12154,7 @@ class Input$GroupMembershipListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -11939,6 +12170,11 @@ class Input$GroupMembershipListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -11973,6 +12209,7 @@ abstract class CopyWith$Input$GroupMembershipListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -12001,6 +12238,7 @@ class _CopyWithImpl$Input$GroupMembershipListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -12015,6 +12253,8 @@ class _CopyWithImpl$Input$GroupMembershipListFilter<TRes>
       _then(Input$GroupMembershipListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -12043,6 +12283,7 @@ class _CopyWithStubImpl$Input$GroupMembershipListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -13408,6 +13649,7 @@ class _CopyWithStubImpl$Input$GroupRuleBaseConfigInput<TRes>
 class Input$GroupListFilter {
   factory Input$GroupListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -13420,6 +13662,7 @@ class Input$GroupListFilter {
   }) =>
       Input$GroupListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -13439,6 +13682,11 @@ class Input$GroupListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -13492,6 +13740,7 @@ class Input$GroupListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -13507,6 +13756,10 @@ class Input$GroupListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -13578,6 +13831,26 @@ class Input$GroupListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -13678,6 +13951,7 @@ class Input$GroupListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -13692,6 +13966,11 @@ class Input$GroupListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -13721,6 +14000,7 @@ abstract class CopyWith$Input$GroupListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -13748,6 +14028,7 @@ class _CopyWithImpl$Input$GroupListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -13761,6 +14042,8 @@ class _CopyWithImpl$Input$GroupListFilter<TRes>
       _then(Input$GroupListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -13788,6 +14071,7 @@ class _CopyWithStubImpl$Input$GroupListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -14809,6 +15093,7 @@ class _CopyWithStubImpl$Input$UserSearchInput<TRes>
 class Input$UserSearchListFilter {
   factory Input$UserSearchListFilter({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -14819,6 +15104,7 @@ class Input$UserSearchListFilter {
   }) =>
       Input$UserSearchListFilter._({
         if (ids != null) r'ids': ids,
+        if (excludeIds != null) r'excludeIds': excludeIds,
         if (searchText != null) r'searchText': searchText,
         if (caseSensitive != null) r'caseSensitive': caseSensitive,
         if (textSearchFields != null) r'textSearchFields': textSearchFields,
@@ -14836,6 +15122,11 @@ class Input$UserSearchListFilter {
       final l$ids = data['ids'];
       result$data['ids'] =
           (l$ids as List<dynamic>?)?.map((e) => (e as String)).toList();
+    }
+    if (data.containsKey('excludeIds')) {
+      final l$excludeIds = data['excludeIds'];
+      result$data['excludeIds'] =
+          (l$excludeIds as List<dynamic>?)?.map((e) => (e as String)).toList();
     }
     if (data.containsKey('searchText')) {
       final l$searchText = data['searchText'];
@@ -14881,6 +15172,7 @@ class Input$UserSearchListFilter {
   Map<String, dynamic> _$data;
 
   List<String>? get ids => (_$data['ids'] as List<String>?);
+  List<String>? get excludeIds => (_$data['excludeIds'] as List<String>?);
   String? get searchText => (_$data['searchText'] as String?);
   bool? get caseSensitive => (_$data['caseSensitive'] as bool?);
   List<String>? get textSearchFields =>
@@ -14894,6 +15186,10 @@ class Input$UserSearchListFilter {
     if (_$data.containsKey('ids')) {
       final l$ids = ids;
       result$data['ids'] = l$ids?.map((e) => e).toList();
+    }
+    if (_$data.containsKey('excludeIds')) {
+      final l$excludeIds = excludeIds;
+      result$data['excludeIds'] = l$excludeIds?.map((e) => e).toList();
     }
     if (_$data.containsKey('searchText')) {
       final l$searchText = searchText;
@@ -14958,6 +15254,26 @@ class Input$UserSearchListFilter {
         }
       }
     } else if (l$ids != lOther$ids) {
+      return false;
+    }
+    final l$excludeIds = excludeIds;
+    final lOther$excludeIds = other.excludeIds;
+    if (_$data.containsKey('excludeIds') !=
+        other._$data.containsKey('excludeIds')) {
+      return false;
+    }
+    if (l$excludeIds != null && lOther$excludeIds != null) {
+      if (l$excludeIds.length != lOther$excludeIds.length) {
+        return false;
+      }
+      for (int i = 0; i < l$excludeIds.length; i++) {
+        final l$excludeIds$entry = l$excludeIds[i];
+        final lOther$excludeIds$entry = lOther$excludeIds[i];
+        if (l$excludeIds$entry != lOther$excludeIds$entry) {
+          return false;
+        }
+      }
+    } else if (l$excludeIds != lOther$excludeIds) {
       return false;
     }
     final l$searchText = searchText;
@@ -15040,6 +15356,7 @@ class Input$UserSearchListFilter {
   @override
   int get hashCode {
     final l$ids = ids;
+    final l$excludeIds = excludeIds;
     final l$searchText = searchText;
     final l$caseSensitive = caseSensitive;
     final l$textSearchFields = textSearchFields;
@@ -15052,6 +15369,11 @@ class Input$UserSearchListFilter {
           ? l$ids == null
               ? null
               : Object.hashAll(l$ids.map((v) => v))
+          : const {},
+      _$data.containsKey('excludeIds')
+          ? l$excludeIds == null
+              ? null
+              : Object.hashAll(l$excludeIds.map((v) => v))
           : const {},
       _$data.containsKey('searchText') ? l$searchText : const {},
       _$data.containsKey('caseSensitive') ? l$caseSensitive : const {},
@@ -15079,6 +15401,7 @@ abstract class CopyWith$Input$UserSearchListFilter<TRes> {
 
   TRes call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -15104,6 +15427,7 @@ class _CopyWithImpl$Input$UserSearchListFilter<TRes>
 
   TRes call({
     Object? ids = _undefined,
+    Object? excludeIds = _undefined,
     Object? searchText = _undefined,
     Object? caseSensitive = _undefined,
     Object? textSearchFields = _undefined,
@@ -15115,6 +15439,8 @@ class _CopyWithImpl$Input$UserSearchListFilter<TRes>
       _then(Input$UserSearchListFilter._({
         ..._instance._$data,
         if (ids != _undefined) 'ids': (ids as List<String>?),
+        if (excludeIds != _undefined)
+          'excludeIds': (excludeIds as List<String>?),
         if (searchText != _undefined) 'searchText': (searchText as String?),
         if (caseSensitive != _undefined)
           'caseSensitive': (caseSensitive as bool?),
@@ -15139,6 +15465,7 @@ class _CopyWithStubImpl$Input$UserSearchListFilter<TRes>
 
   call({
     List<String>? ids,
+    List<String>? excludeIds,
     String? searchText,
     bool? caseSensitive,
     List<String>? textSearchFields,
@@ -16112,6 +16439,225 @@ class _CopyWithStubImpl$Input$UserSignUpInput<TRes>
   events(_fn) => _res;
   CopyWith$Input$BaseModelMetadataInput<TRes> get metadata =>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
+}
+
+class Input$UserBlockInput {
+  factory Input$UserBlockInput({
+    String? blockedByUserId,
+    String? userId,
+    String? reasonTextId,
+    String? notes,
+    String? adminNotes,
+  }) =>
+      Input$UserBlockInput._({
+        if (blockedByUserId != null) r'blockedByUserId': blockedByUserId,
+        if (userId != null) r'userId': userId,
+        if (reasonTextId != null) r'reasonTextId': reasonTextId,
+        if (notes != null) r'notes': notes,
+        if (adminNotes != null) r'adminNotes': adminNotes,
+      });
+
+  Input$UserBlockInput._(this._$data);
+
+  factory Input$UserBlockInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('blockedByUserId')) {
+      final l$blockedByUserId = data['blockedByUserId'];
+      result$data['blockedByUserId'] = (l$blockedByUserId as String);
+    }
+    if (data.containsKey('userId')) {
+      final l$userId = data['userId'];
+      result$data['userId'] = (l$userId as String);
+    }
+    if (data.containsKey('reasonTextId')) {
+      final l$reasonTextId = data['reasonTextId'];
+      result$data['reasonTextId'] = (l$reasonTextId as String);
+    }
+    if (data.containsKey('notes')) {
+      final l$notes = data['notes'];
+      result$data['notes'] = (l$notes as String);
+    }
+    if (data.containsKey('adminNotes')) {
+      final l$adminNotes = data['adminNotes'];
+      result$data['adminNotes'] = (l$adminNotes as String);
+    }
+    return Input$UserBlockInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get blockedByUserId => (_$data['blockedByUserId'] as String?);
+  String? get userId => (_$data['userId'] as String?);
+  String? get reasonTextId => (_$data['reasonTextId'] as String?);
+  String? get notes => (_$data['notes'] as String?);
+  String? get adminNotes => (_$data['adminNotes'] as String?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('blockedByUserId')) {
+      final l$blockedByUserId = blockedByUserId;
+      result$data['blockedByUserId'] = (l$blockedByUserId as String);
+    }
+    if (_$data.containsKey('userId')) {
+      final l$userId = userId;
+      result$data['userId'] = (l$userId as String);
+    }
+    if (_$data.containsKey('reasonTextId')) {
+      final l$reasonTextId = reasonTextId;
+      result$data['reasonTextId'] = (l$reasonTextId as String);
+    }
+    if (_$data.containsKey('notes')) {
+      final l$notes = notes;
+      result$data['notes'] = (l$notes as String);
+    }
+    if (_$data.containsKey('adminNotes')) {
+      final l$adminNotes = adminNotes;
+      result$data['adminNotes'] = (l$adminNotes as String);
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$UserBlockInput<Input$UserBlockInput> get copyWith =>
+      CopyWith$Input$UserBlockInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$UserBlockInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$blockedByUserId = blockedByUserId;
+    final lOther$blockedByUserId = other.blockedByUserId;
+    if (_$data.containsKey('blockedByUserId') !=
+        other._$data.containsKey('blockedByUserId')) {
+      return false;
+    }
+    if (l$blockedByUserId != lOther$blockedByUserId) {
+      return false;
+    }
+    final l$userId = userId;
+    final lOther$userId = other.userId;
+    if (_$data.containsKey('userId') != other._$data.containsKey('userId')) {
+      return false;
+    }
+    if (l$userId != lOther$userId) {
+      return false;
+    }
+    final l$reasonTextId = reasonTextId;
+    final lOther$reasonTextId = other.reasonTextId;
+    if (_$data.containsKey('reasonTextId') !=
+        other._$data.containsKey('reasonTextId')) {
+      return false;
+    }
+    if (l$reasonTextId != lOther$reasonTextId) {
+      return false;
+    }
+    final l$notes = notes;
+    final lOther$notes = other.notes;
+    if (_$data.containsKey('notes') != other._$data.containsKey('notes')) {
+      return false;
+    }
+    if (l$notes != lOther$notes) {
+      return false;
+    }
+    final l$adminNotes = adminNotes;
+    final lOther$adminNotes = other.adminNotes;
+    if (_$data.containsKey('adminNotes') !=
+        other._$data.containsKey('adminNotes')) {
+      return false;
+    }
+    if (l$adminNotes != lOther$adminNotes) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$blockedByUserId = blockedByUserId;
+    final l$userId = userId;
+    final l$reasonTextId = reasonTextId;
+    final l$notes = notes;
+    final l$adminNotes = adminNotes;
+    return Object.hashAll([
+      _$data.containsKey('blockedByUserId') ? l$blockedByUserId : const {},
+      _$data.containsKey('userId') ? l$userId : const {},
+      _$data.containsKey('reasonTextId') ? l$reasonTextId : const {},
+      _$data.containsKey('notes') ? l$notes : const {},
+      _$data.containsKey('adminNotes') ? l$adminNotes : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$UserBlockInput<TRes> {
+  factory CopyWith$Input$UserBlockInput(
+    Input$UserBlockInput instance,
+    TRes Function(Input$UserBlockInput) then,
+  ) = _CopyWithImpl$Input$UserBlockInput;
+
+  factory CopyWith$Input$UserBlockInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$UserBlockInput;
+
+  TRes call({
+    String? blockedByUserId,
+    String? userId,
+    String? reasonTextId,
+    String? notes,
+    String? adminNotes,
+  });
+}
+
+class _CopyWithImpl$Input$UserBlockInput<TRes>
+    implements CopyWith$Input$UserBlockInput<TRes> {
+  _CopyWithImpl$Input$UserBlockInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$UserBlockInput _instance;
+
+  final TRes Function(Input$UserBlockInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? blockedByUserId = _undefined,
+    Object? userId = _undefined,
+    Object? reasonTextId = _undefined,
+    Object? notes = _undefined,
+    Object? adminNotes = _undefined,
+  }) =>
+      _then(Input$UserBlockInput._({
+        ..._instance._$data,
+        if (blockedByUserId != _undefined && blockedByUserId != null)
+          'blockedByUserId': (blockedByUserId as String),
+        if (userId != _undefined && userId != null)
+          'userId': (userId as String),
+        if (reasonTextId != _undefined && reasonTextId != null)
+          'reasonTextId': (reasonTextId as String),
+        if (notes != _undefined && notes != null) 'notes': (notes as String),
+        if (adminNotes != _undefined && adminNotes != null)
+          'adminNotes': (adminNotes as String),
+      }));
+}
+
+class _CopyWithStubImpl$Input$UserBlockInput<TRes>
+    implements CopyWith$Input$UserBlockInput<TRes> {
+  _CopyWithStubImpl$Input$UserBlockInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? blockedByUserId,
+    String? userId,
+    String? reasonTextId,
+    String? notes,
+    String? adminNotes,
+  }) =>
+      _res;
 }
 
 class Input$ChannelInvitationInput {
@@ -25038,11 +25584,13 @@ enum Enum$OptionType {
   expertise,
   gender,
   pronoun,
+  userRelationshipType,
   country,
   industry,
   language,
   unset,
   contentTagType,
+  blockUserReason,
   $unknown
 }
 
@@ -25060,6 +25608,8 @@ String toJson$Enum$OptionType(Enum$OptionType e) {
       return r'gender';
     case Enum$OptionType.pronoun:
       return r'pronoun';
+    case Enum$OptionType.userRelationshipType:
+      return r'userRelationshipType';
     case Enum$OptionType.country:
       return r'country';
     case Enum$OptionType.industry:
@@ -25070,6 +25620,8 @@ String toJson$Enum$OptionType(Enum$OptionType e) {
       return r'unset';
     case Enum$OptionType.contentTagType:
       return r'contentTagType';
+    case Enum$OptionType.blockUserReason:
+      return r'blockUserReason';
     case Enum$OptionType.$unknown:
       return r'$unknown';
   }
@@ -25089,6 +25641,8 @@ Enum$OptionType fromJson$Enum$OptionType(String value) {
       return Enum$OptionType.gender;
     case r'pronoun':
       return Enum$OptionType.pronoun;
+    case r'userRelationshipType':
+      return Enum$OptionType.userRelationshipType;
     case r'country':
       return Enum$OptionType.country;
     case r'industry':
@@ -25099,6 +25653,8 @@ Enum$OptionType fromJson$Enum$OptionType(String value) {
       return Enum$OptionType.unset;
     case r'contentTagType':
       return Enum$OptionType.contentTagType;
+    case r'blockUserReason':
+      return Enum$OptionType.blockUserReason;
     default:
       return Enum$OptionType.$unknown;
   }
@@ -25419,6 +25975,7 @@ enum Enum$ModelType {
   Mm2Synchronization,
   Mm2SynchronizationResultItem,
   MultiStepAction,
+  UserRelationship,
   ServiceRequest,
   User,
   UserDevice,
@@ -25490,6 +26047,8 @@ String toJson$Enum$ModelType(Enum$ModelType e) {
       return r'Mm2SynchronizationResultItem';
     case Enum$ModelType.MultiStepAction:
       return r'MultiStepAction';
+    case Enum$ModelType.UserRelationship:
+      return r'UserRelationship';
     case Enum$ModelType.ServiceRequest:
       return r'ServiceRequest';
     case Enum$ModelType.User:
@@ -25567,6 +26126,8 @@ Enum$ModelType fromJson$Enum$ModelType(String value) {
       return Enum$ModelType.Mm2SynchronizationResultItem;
     case r'MultiStepAction':
       return Enum$ModelType.MultiStepAction;
+    case r'UserRelationship':
+      return Enum$ModelType.UserRelationship;
     case r'ServiceRequest':
       return Enum$ModelType.ServiceRequest;
     case r'User':
@@ -26151,8 +26712,6 @@ Enum$MultiStepActionResult fromJson$Enum$MultiStepActionResult(String value) {
 }
 
 enum Enum$ServiceRequestType {
-  graphQlQueryUserInbox,
-  graphQlQueryUserUserSearches,
   graphQlMutationCreateAcademicExperience,
   graphQlMutationDeleteAcademicExperience,
   graphQlMutationUpdateAcademicExperience,
@@ -26162,6 +26721,9 @@ enum Enum$ServiceRequestType {
   graphQlMutationCreateCompany,
   graphQlMutationDeleteCompany,
   graphQlMutationUpdateCompany,
+  graphQlQueryFindAndUpdateAllMm2Users,
+  graphQlQueryUserInbox,
+  graphQlQueryUserUserSearches,
   graphQlMutationAddChannelMessageEvent,
   graphQlMutationArchiveChannelForUserByMe,
   graphQlMutationCreateChannel,
@@ -26182,7 +26744,6 @@ enum Enum$ServiceRequestType {
   graphQlQueryChannelInvitations,
   graphQlQueryChannelParticipants,
   graphQlQueryFindChannelInvitationById,
-  graphQlQueryFindChannelInvitationsBetweenUsers,
   graphQlQueryFindChannelInvitationsForUser,
   graphQlQueryFindChannelMessageById,
   graphQlQueryFindChannelMessages,
@@ -26247,32 +26808,34 @@ enum Enum$ServiceRequestType {
   graphQlMutationRunMm2Synchronization,
   graphQlQueryFindMm2SynchronizationById,
   graphQlQueryGetMm2Integration,
+  graphQlMutationBlockUser,
   graphQlMutationCreateMultiStepAction,
   graphQlMutationCreateUserDevice,
+  graphQlMutationCreateUserRelationship,
   graphQlMutationDeleteUser,
   graphQlMutationSignInUser,
   graphQlMutationSignMeOut,
   graphQlMutationSignUpUser,
+  graphQlMutationUnblockUser,
   graphQlMutationUpdateUser,
   graphQlMutationUpdateUserDevice,
+  graphQlMutationUpdateUserRelationship,
   graphQlMutationVerifyMultiStepActionToken,
   graphQlQueryFindUserById,
   graphQlQueryFindUserByIdent,
   graphQlQueryFindUserDeviceById,
+  graphQlQueryFindUserRelationshipById,
   graphQlQueryFindUsers,
   graphQlQueryGetAuthenticatedUser,
   graphQlQueryGetMultiStepActionProgress,
   graphQlQueryLatestUserDevice,
   graphQlQueryUserUserDevices,
+  graphQlQueryUserUserRelationships,
   $unknown
 }
 
 String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
   switch (e) {
-    case Enum$ServiceRequestType.graphQlQueryUserInbox:
-      return r'graphQlQueryUserInbox';
-    case Enum$ServiceRequestType.graphQlQueryUserUserSearches:
-      return r'graphQlQueryUserUserSearches';
     case Enum$ServiceRequestType.graphQlMutationCreateAcademicExperience:
       return r'graphQlMutationCreateAcademicExperience';
     case Enum$ServiceRequestType.graphQlMutationDeleteAcademicExperience:
@@ -26291,6 +26854,12 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlMutationDeleteCompany';
     case Enum$ServiceRequestType.graphQlMutationUpdateCompany:
       return r'graphQlMutationUpdateCompany';
+    case Enum$ServiceRequestType.graphQlQueryFindAndUpdateAllMm2Users:
+      return r'graphQlQueryFindAndUpdateAllMm2Users';
+    case Enum$ServiceRequestType.graphQlQueryUserInbox:
+      return r'graphQlQueryUserInbox';
+    case Enum$ServiceRequestType.graphQlQueryUserUserSearches:
+      return r'graphQlQueryUserUserSearches';
     case Enum$ServiceRequestType.graphQlMutationAddChannelMessageEvent:
       return r'graphQlMutationAddChannelMessageEvent';
     case Enum$ServiceRequestType.graphQlMutationArchiveChannelForUserByMe:
@@ -26331,8 +26900,6 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryChannelParticipants';
     case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationById:
       return r'graphQlQueryFindChannelInvitationById';
-    case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsBetweenUsers:
-      return r'graphQlQueryFindChannelInvitationsBetweenUsers';
     case Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsForUser:
       return r'graphQlQueryFindChannelInvitationsForUser';
     case Enum$ServiceRequestType.graphQlQueryFindChannelMessageById:
@@ -26462,10 +27029,14 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryFindMm2SynchronizationById';
     case Enum$ServiceRequestType.graphQlQueryGetMm2Integration:
       return r'graphQlQueryGetMm2Integration';
+    case Enum$ServiceRequestType.graphQlMutationBlockUser:
+      return r'graphQlMutationBlockUser';
     case Enum$ServiceRequestType.graphQlMutationCreateMultiStepAction:
       return r'graphQlMutationCreateMultiStepAction';
     case Enum$ServiceRequestType.graphQlMutationCreateUserDevice:
       return r'graphQlMutationCreateUserDevice';
+    case Enum$ServiceRequestType.graphQlMutationCreateUserRelationship:
+      return r'graphQlMutationCreateUserRelationship';
     case Enum$ServiceRequestType.graphQlMutationDeleteUser:
       return r'graphQlMutationDeleteUser';
     case Enum$ServiceRequestType.graphQlMutationSignInUser:
@@ -26474,10 +27045,14 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlMutationSignMeOut';
     case Enum$ServiceRequestType.graphQlMutationSignUpUser:
       return r'graphQlMutationSignUpUser';
+    case Enum$ServiceRequestType.graphQlMutationUnblockUser:
+      return r'graphQlMutationUnblockUser';
     case Enum$ServiceRequestType.graphQlMutationUpdateUser:
       return r'graphQlMutationUpdateUser';
     case Enum$ServiceRequestType.graphQlMutationUpdateUserDevice:
       return r'graphQlMutationUpdateUserDevice';
+    case Enum$ServiceRequestType.graphQlMutationUpdateUserRelationship:
+      return r'graphQlMutationUpdateUserRelationship';
     case Enum$ServiceRequestType.graphQlMutationVerifyMultiStepActionToken:
       return r'graphQlMutationVerifyMultiStepActionToken';
     case Enum$ServiceRequestType.graphQlQueryFindUserById:
@@ -26486,6 +27061,8 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryFindUserByIdent';
     case Enum$ServiceRequestType.graphQlQueryFindUserDeviceById:
       return r'graphQlQueryFindUserDeviceById';
+    case Enum$ServiceRequestType.graphQlQueryFindUserRelationshipById:
+      return r'graphQlQueryFindUserRelationshipById';
     case Enum$ServiceRequestType.graphQlQueryFindUsers:
       return r'graphQlQueryFindUsers';
     case Enum$ServiceRequestType.graphQlQueryGetAuthenticatedUser:
@@ -26496,6 +27073,8 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
       return r'graphQlQueryLatestUserDevice';
     case Enum$ServiceRequestType.graphQlQueryUserUserDevices:
       return r'graphQlQueryUserUserDevices';
+    case Enum$ServiceRequestType.graphQlQueryUserUserRelationships:
+      return r'graphQlQueryUserUserRelationships';
     case Enum$ServiceRequestType.$unknown:
       return r'$unknown';
   }
@@ -26503,10 +27082,6 @@ String toJson$Enum$ServiceRequestType(Enum$ServiceRequestType e) {
 
 Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
   switch (value) {
-    case r'graphQlQueryUserInbox':
-      return Enum$ServiceRequestType.graphQlQueryUserInbox;
-    case r'graphQlQueryUserUserSearches':
-      return Enum$ServiceRequestType.graphQlQueryUserUserSearches;
     case r'graphQlMutationCreateAcademicExperience':
       return Enum$ServiceRequestType.graphQlMutationCreateAcademicExperience;
     case r'graphQlMutationDeleteAcademicExperience':
@@ -26525,6 +27100,12 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlMutationDeleteCompany;
     case r'graphQlMutationUpdateCompany':
       return Enum$ServiceRequestType.graphQlMutationUpdateCompany;
+    case r'graphQlQueryFindAndUpdateAllMm2Users':
+      return Enum$ServiceRequestType.graphQlQueryFindAndUpdateAllMm2Users;
+    case r'graphQlQueryUserInbox':
+      return Enum$ServiceRequestType.graphQlQueryUserInbox;
+    case r'graphQlQueryUserUserSearches':
+      return Enum$ServiceRequestType.graphQlQueryUserUserSearches;
     case r'graphQlMutationAddChannelMessageEvent':
       return Enum$ServiceRequestType.graphQlMutationAddChannelMessageEvent;
     case r'graphQlMutationArchiveChannelForUserByMe':
@@ -26566,9 +27147,6 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryChannelParticipants;
     case r'graphQlQueryFindChannelInvitationById':
       return Enum$ServiceRequestType.graphQlQueryFindChannelInvitationById;
-    case r'graphQlQueryFindChannelInvitationsBetweenUsers':
-      return Enum$ServiceRequestType
-          .graphQlQueryFindChannelInvitationsBetweenUsers;
     case r'graphQlQueryFindChannelInvitationsForUser':
       return Enum$ServiceRequestType.graphQlQueryFindChannelInvitationsForUser;
     case r'graphQlQueryFindChannelMessageById':
@@ -26699,10 +27277,14 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryFindMm2SynchronizationById;
     case r'graphQlQueryGetMm2Integration':
       return Enum$ServiceRequestType.graphQlQueryGetMm2Integration;
+    case r'graphQlMutationBlockUser':
+      return Enum$ServiceRequestType.graphQlMutationBlockUser;
     case r'graphQlMutationCreateMultiStepAction':
       return Enum$ServiceRequestType.graphQlMutationCreateMultiStepAction;
     case r'graphQlMutationCreateUserDevice':
       return Enum$ServiceRequestType.graphQlMutationCreateUserDevice;
+    case r'graphQlMutationCreateUserRelationship':
+      return Enum$ServiceRequestType.graphQlMutationCreateUserRelationship;
     case r'graphQlMutationDeleteUser':
       return Enum$ServiceRequestType.graphQlMutationDeleteUser;
     case r'graphQlMutationSignInUser':
@@ -26711,10 +27293,14 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlMutationSignMeOut;
     case r'graphQlMutationSignUpUser':
       return Enum$ServiceRequestType.graphQlMutationSignUpUser;
+    case r'graphQlMutationUnblockUser':
+      return Enum$ServiceRequestType.graphQlMutationUnblockUser;
     case r'graphQlMutationUpdateUser':
       return Enum$ServiceRequestType.graphQlMutationUpdateUser;
     case r'graphQlMutationUpdateUserDevice':
       return Enum$ServiceRequestType.graphQlMutationUpdateUserDevice;
+    case r'graphQlMutationUpdateUserRelationship':
+      return Enum$ServiceRequestType.graphQlMutationUpdateUserRelationship;
     case r'graphQlMutationVerifyMultiStepActionToken':
       return Enum$ServiceRequestType.graphQlMutationVerifyMultiStepActionToken;
     case r'graphQlQueryFindUserById':
@@ -26723,6 +27309,8 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryFindUserByIdent;
     case r'graphQlQueryFindUserDeviceById':
       return Enum$ServiceRequestType.graphQlQueryFindUserDeviceById;
+    case r'graphQlQueryFindUserRelationshipById':
+      return Enum$ServiceRequestType.graphQlQueryFindUserRelationshipById;
     case r'graphQlQueryFindUsers':
       return Enum$ServiceRequestType.graphQlQueryFindUsers;
     case r'graphQlQueryGetAuthenticatedUser':
@@ -26733,6 +27321,8 @@ Enum$ServiceRequestType fromJson$Enum$ServiceRequestType(String value) {
       return Enum$ServiceRequestType.graphQlQueryLatestUserDevice;
     case r'graphQlQueryUserUserDevices':
       return Enum$ServiceRequestType.graphQlQueryUserUserDevices;
+    case r'graphQlQueryUserUserRelationships':
+      return Enum$ServiceRequestType.graphQlQueryUserUserRelationships;
     default:
       return Enum$ServiceRequestType.$unknown;
   }

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -24,7 +24,7 @@ typedef MentorUser = Query$FindMentorUsers$findUsers;
 // UserSearch queries and mutation
 typedef CreateUserSearchResponse = Mutation$CreateUserSearch$createUserSearch;
 typedef UserSearch = Query$FindUserSearch$findUserSearchById;
-typedef TopFoundUser = Query$FindUserSearch$findUserSearchById$topFoundUsers;
+typedef UserSearchResult = Query$FindUserSearchResults$findUserSearchResults;
 
 class UserProvider extends BaseProvider with ChangeNotifier {
   AuthenticatedUser? _user;
@@ -108,6 +108,32 @@ class UserProvider extends BaseProvider with ChangeNotifier {
           ? Query$FindUserSearch.fromJson(
               queryResult.data!,
             ).findUserSearchById
+          : null,
+    );
+  }
+
+  Future<OperationResult<List<UserSearchResult>>> findUserSearchResults({
+    required String userSearchId,
+    required Input$FindObjectsOptions optionsInput,
+    bool fetchFromNetworkOnly = false,
+  }) async {
+    final QueryResult queryResult = await asyncQuery(
+      queryOptions: QueryOptions(
+        document: documentNodeQueryFindUserSearchResults,
+        fetchPolicy: fetchFromNetworkOnly
+            ? FetchPolicy.networkOnly
+            : FetchPolicy.cacheFirst,
+        variables: Variables$Query$FindUserSearchResults(
+                userSearchId: userSearchId, options: optionsInput)
+            .toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Query$FindUserSearchResults.fromJson(
+              queryResult.data!,
+            ).findUserSearchResults
           : null,
     );
   }

--- a/lib/schema/operations_user.graphql
+++ b/lib/schema/operations_user.graphql
@@ -128,6 +128,43 @@ query FindUserSearch($userSearchId: String!) {
   }
 }
 
+query FindUserSearchResults($userSearchId: String!, $options: FindObjectsOptions) {
+  findUserSearchResults(userSearchId: $userSearchId, options: $options) {
+    id
+    email
+    firstName
+    lastName
+    fullName
+    avatarUrl
+    userHandle
+    offersHelp
+    seeksHelp
+    jobTitle
+    cityOfResidence
+    regionOfResidence
+    countryOfResidence {
+        translatedValue
+    }
+    groupMemberships {
+        groupIdent
+        ... on MentorsGroupMembership {
+            expertises {
+                translatedValue
+            }
+            endorsements
+        }
+        ... on MenteesGroupMembership {
+            soughtExpertises {
+                translatedValue
+            }
+        }
+    }
+    companies {
+        name
+    }
+  }
+}
+
 query FindMenteeUsers($options: FindObjectsOptions, $filter: UserListFilter, $match: UserInput) {
     findUsers(options: $options, filter: $filter, match: $match) {
         id

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -109,11 +109,13 @@ enum OptionType {
   expertise
   gender
   pronoun
+  userRelationshipType
   country
   industry
   language
   unset
   contentTagType
+  blockUserReason
 }
 
 enum UiLanguage {
@@ -270,7 +272,6 @@ type Query {
   findGenders(fallbackUiLanguage: UiLanguage): [Gender!]!
   myInbox(refresh: Boolean): UserInbox!
   findChannelInvitationById(id: String!): ChannelInvitation!
-  findChannelInvitationsBetweenUsers(options: FindObjectsOptions, onlyPending: Boolean, userIds: [String!]!): [ChannelInvitation!]!
   findChannelInvitationsForUser(options: FindObjectsOptions, onlyPending: Boolean, direction: ChannelInvitationDirection, userId: String!): [ChannelInvitation!]!
   myChannelInvitations(options: FindObjectsOptions, onlyPending: Boolean, direction: ChannelInvitationDirection): [ChannelInvitation!]!
   findPendingChannelInvitationsForUser(options: FindObjectsOptions, userId: String!): [ChannelInvitation!]!
@@ -293,6 +294,7 @@ type Query {
   findGroups(options: FindObjectsOptions, match: GroupInput, filter: GroupListFilter): [Group!]!
   findUserSearchById(userSearchId: String!): UserSearch!
   findUserSearches(options: FindObjectsOptions, match: UserSearchInput, filter: UserSearchListFilter): [UserSearch!]!
+  findUserSearchResults(options: FindObjectsOptions, userSearchId: String!): [User!]!
   myUserSearches: [UserSearch!]!
   getMm2Integration: Mm2Integration!
   findMyActiveMultiStepAction: [SidMultiStepAction!]!
@@ -351,6 +353,8 @@ type User {
   signedOutAt: DateTimeISO
   latestActivityAt: DateTimeISO
   userDevices: [UserDevice!]!
+  userBlocks: [UserBlock!]
+  relationships: [UserRelationship!]
   inactivatedAt: DateTimeISO
   inactivatedBy: ID
   companyIds: [ID!]
@@ -496,6 +500,32 @@ type UserDevice {
   oAuthRefreshToken: String
   pushNotificationToken: String
   trustedAt: DateTimeISO
+}
+
+type UserBlock {
+  userId: ID!
+  reasonTextId: String!
+  notes: String
+  adminNotes: String
+  createdAt: DateTimeISO!
+}
+
+type UserRelationship {
+  id: ID!
+  adminNotes: String
+  events: [ModelEvent!]
+  metadata: BaseModelMetadata
+  createdAt: DateTimeISO!
+  createdBy: ID
+  updatedAt: DateTimeISO
+  updatedBy: ID
+  deletedAt: DateTimeISO
+  deletedBy: ID
+  userId: ID!
+  typeTextIds: [String!]!
+  blockedAt: DateTimeISO
+  blockReason: String
+  notes: String
 }
 
 type BusinessExperience {
@@ -1054,6 +1084,7 @@ enum ModelType {
   Mm2Synchronization
   Mm2SynchronizationResultItem
   MultiStepAction
+  UserRelationship
   ServiceRequest
   User
   UserDevice
@@ -1252,7 +1283,14 @@ type UserSearch {
   updatedBy: ID
   deletedAt: DateTimeISO
   deletedBy: ID
+
+  """The ID of the user that is searching and owns this object"""
   userId: ID!
+
+  """
+  A list of user IDs of users that should not be included into the search results, i.e. blocked users.
+  """
+  excludeUserIds: [ID!]
   matchingEngineId: ID
   name: String
   profileType: ProfileType
@@ -1438,7 +1476,7 @@ input UserInput {
 }
 
 input ModelEventInput {
-  time: DateTimeISO! = "2023-09-14T22:08:19.691Z"
+  time: DateTimeISO! = "2023-09-28T05:07:06.736Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -1565,6 +1603,7 @@ input AcademicExperienceInput {
 
 input UserListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1575,6 +1614,7 @@ input UserListFilter {
   rolesIn: [UserRole!]
   companyId: ID
   syncedWithMm2: Boolean
+  isMm2User: Boolean
 }
 
 input UserDeviceInput {
@@ -1624,6 +1664,7 @@ input UserDeviceInput {
 
 input SidUserDeviceListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1677,6 +1718,7 @@ input BgChannelStatusInput {
 
 input ChannelListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1719,6 +1761,7 @@ input ChannelMessageStatusInput {
 
 input ChannelMessageListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1748,6 +1791,7 @@ type SystemHealthReport {
 
 input GroupMembershipListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1806,6 +1850,7 @@ input GroupRuleBaseConfigInput {
 
 input GroupListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -1850,6 +1895,7 @@ input UserSearchInput {
 
 input UserSearchListFilter {
   ids: [String!]
+  excludeIds: [ID!]
   searchText: String
   caseSensitive: Boolean
   textSearchFields: [String!]
@@ -2032,7 +2078,11 @@ type Mutation {
   signInUser(input: UserSignInInput!): UserAuthResponse!
   signMeOut: String!
   signUpUser(input: UserSignUpInput!): UserAuthResponse!
+  blockUser(input: UserBlockInput!): String!
+  blockUserForMe(notes: String, reasonTextId: String, userId: String!): String!
   deleteUser(deletePhysically: Boolean!, userId: String!): String!
+  unblockUser(userId: String!, blockedByUserId: String!): String!
+  unblockUserForMe(userId: String!): String!
   updateUser(input: UserInput!): String!
   createUserDevice(input: UserDeviceInput!): UserDevice!
   updateUserDevice(input: UserDeviceInput!): String!
@@ -2045,6 +2095,7 @@ type Mutation {
   createCompany(input: CompanyInput!): Company!
   deleteCompany(deletePhysically: Boolean!, companyId: String!): ServiceRequest!
   updateCompany(input: CompanyInput!): ServiceRequest!
+  findAndUpdateAllMm2Users: Boolean!
   acceptChannelInvitation(channelInvitationId: String!): String!
   createChannelInvitation(input: ChannelInvitationInput!): ChannelInvitation!
   declineChannelInvitation(channelInvitationId: String!): String!
@@ -2152,6 +2203,14 @@ input UserSignUpInput {
   seeksHelp: Boolean
 }
 
+input UserBlockInput {
+  blockedByUserId: ID! = ""
+  userId: ID! = ""
+  reasonTextId: String! = ""
+  notes: String! = ""
+  adminNotes: String! = ""
+}
+
 type ServiceRequest {
   id: ID!
   serviceRequestType: ServiceRequestType!
@@ -2176,8 +2235,6 @@ type ServiceRequest {
 }
 
 enum ServiceRequestType {
-  graphQlQueryUserInbox
-  graphQlQueryUserUserSearches
   graphQlMutationCreateAcademicExperience
   graphQlMutationDeleteAcademicExperience
   graphQlMutationUpdateAcademicExperience
@@ -2187,6 +2244,9 @@ enum ServiceRequestType {
   graphQlMutationCreateCompany
   graphQlMutationDeleteCompany
   graphQlMutationUpdateCompany
+  graphQlQueryFindAndUpdateAllMm2Users
+  graphQlQueryUserInbox
+  graphQlQueryUserUserSearches
   graphQlMutationAddChannelMessageEvent
   graphQlMutationArchiveChannelForUserByMe
   graphQlMutationCreateChannel
@@ -2207,7 +2267,6 @@ enum ServiceRequestType {
   graphQlQueryChannelInvitations
   graphQlQueryChannelParticipants
   graphQlQueryFindChannelInvitationById
-  graphQlQueryFindChannelInvitationsBetweenUsers
   graphQlQueryFindChannelInvitationsForUser
   graphQlQueryFindChannelMessageById
   graphQlQueryFindChannelMessages
@@ -2272,23 +2331,29 @@ enum ServiceRequestType {
   graphQlMutationRunMm2Synchronization
   graphQlQueryFindMm2SynchronizationById
   graphQlQueryGetMm2Integration
+  graphQlMutationBlockUser
   graphQlMutationCreateMultiStepAction
   graphQlMutationCreateUserDevice
+  graphQlMutationCreateUserRelationship
   graphQlMutationDeleteUser
   graphQlMutationSignInUser
   graphQlMutationSignMeOut
   graphQlMutationSignUpUser
+  graphQlMutationUnblockUser
   graphQlMutationUpdateUser
   graphQlMutationUpdateUserDevice
+  graphQlMutationUpdateUserRelationship
   graphQlMutationVerifyMultiStepActionToken
   graphQlQueryFindUserById
   graphQlQueryFindUserByIdent
   graphQlQueryFindUserDeviceById
+  graphQlQueryFindUserRelationshipById
   graphQlQueryFindUsers
   graphQlQueryGetAuthenticatedUser
   graphQlQueryGetMultiStepActionProgress
   graphQlQueryLatestUserDevice
   graphQlQueryUserUserDevices
+  graphQlQueryUserUserRelationships
 }
 
 enum ServiceRequestResult {


### PR DESCRIPTION
Fixes an issue which may be blocking #139, the lack of paginated user search results.

`topUserIds` from the searches only included the top 10 users from a search. The search results exposed here will allow us to get more results. Right now, it allows us to fetch the entire list, so I recommend using some variables like this to limit the response to a reasonable number at first:

```json
{
    "userSearchId":"6514ab0174d1baabebddca7c",
    "options": {
        "limit": 10,
        "skip": 0
    }
}
```