### PR TITLE
Inbox polling & improved Selectors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,6 +71,12 @@ class _StartScreenState extends State<StartScreen> {
   }
 
   @override
+  void dispose() {
+    _inboxModel.cancelDataPolling();
+    super.dispose();
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _content = _contentProvider.findAllOptionsByType().then(
@@ -84,6 +90,7 @@ class _StartScreenState extends State<StartScreen> {
 
   void _initializeUser() async {
     await _inboxModel.refreshAll();
+    _inboxModel.initializeDataPolling();
   }
 
   @override

--- a/lib/providers/models/chat_model.dart
+++ b/lib/providers/models/chat_model.dart
@@ -89,7 +89,7 @@ class ChatModel extends ChangeNotifier {
       CrashHandler.logCrashReport('Could not mark messages as read: $e');
       return;
     }
-    _inboxModel.refreshInboxChatNotifications();
+    _inboxModel.refreshUnseenMessages();
   }
 
   Future<void> _refreshSingleChannelMessage({

--- a/lib/providers/models/inbox_model.dart
+++ b/lib/providers/models/inbox_model.dart
@@ -238,7 +238,6 @@ class InboxModel extends ChangeNotifier {
   }
 
   Future<void> _refreshLatestMessage(String channelId) async {
-    // TODO: Possible race condition here if the query executes before the mutation completes, consider polling result
     final latestMessageResult =
         await _messagesProvider.findChannelLatestMessage(
       channelId: channelId,

--- a/lib/providers/models/scaffold_model.dart
+++ b/lib/providers/models/scaffold_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mm_flutter_app/providers/models/inbox_model.dart';
 import 'package:mm_flutter_app/providers/user_provider.dart';
 import 'package:provider/provider.dart';
 
@@ -54,6 +55,10 @@ class ScaffoldModel extends ChangeNotifier {
                     ).signOutUser().then(
                       (void future) {
                         try {
+                          Provider.of<InboxModel>(
+                            context,
+                            listen: false,
+                          ).cancelDataPolling();
                           Navigator.of(context).pop();
                           router.goNamed(Routes.root.name);
                         } catch (_) {}

--- a/lib/widgets/molecules/invitation_section.dart
+++ b/lib/widgets/molecules/invitation_section.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
@@ -86,6 +87,10 @@ class _InvitationSectionState extends State<InvitationSection> {
   Widget build(BuildContext context) {
     return Selector<InboxModel, List<ReceivedChannelInvitation>?>(
       selector: (_, inboxModel) => inboxModel.pendingReceivedInvitations,
+      shouldRebuild: (oldValue, newValue) =>
+          !(const DeepCollectionEquality.unordered()
+              .equals(oldValue, newValue)) ||
+          _inboxModel.receivedInvitationsState != AsyncState.loading,
       builder: (context, pendingReceivedInvitations, _) {
         return AppUtility.widgetForAsyncState(
           state: _inboxModel.receivedInvitationsState,

--- a/lib/widgets/screens/inbox/inbox_chat_list.dart
+++ b/lib/widgets/screens/inbox/inbox_chat_list.dart
@@ -172,7 +172,7 @@ class _InboxChatListScreenState extends State<InboxChatListScreen>
         channelId: channelId,
         isArchivedForMe: !widget.isArchivedForUser,
       );
-      await _inboxModel.refreshInboxChatNotifications();
+      await _inboxModel.refreshUnseenMessages();
       setState(() {});
     }
   }

--- a/lib/widgets/screens/inbox/inbox_chat_list.dart
+++ b/lib/widgets/screens/inbox/inbox_chat_list.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_swipe_action_cell/core/cell.dart';
@@ -194,6 +195,10 @@ class _InboxChatListScreenState extends State<InboxChatListScreen>
         inboxModel.unseenMessages!,
         inboxModel.activeChannels,
       ),
+      shouldRebuild: (oldValue, newValue) =>
+          !(const DeepCollectionEquality.unordered()
+              .equals(oldValue, newValue)) ||
+          _inboxModel.channelsState != AsyncState.loading,
       builder: (_, __, ___) {
         return AppUtility.widgetForAsyncState(
           state: _inboxModel.channelsState,

--- a/lib/widgets/screens/inbox/inbox_invites_received.dart
+++ b/lib/widgets/screens/inbox/inbox_invites_received.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
@@ -112,6 +113,10 @@ class _InboxInvitesReceivedScreenState extends State<InboxInvitesReceivedScreen>
     _refreshTabIndex(context);
     return Selector<InboxModel, List<ReceivedChannelInvitation>?>(
       selector: (_, inboxModel) => inboxModel.pendingReceivedInvitations,
+      shouldRebuild: (oldValue, newValue) =>
+          !(const DeepCollectionEquality.unordered()
+              .equals(oldValue, newValue)) ||
+          _inboxModel.receivedInvitationsState != AsyncState.loading,
       builder: (_, pendingReceivedInvitations, __) {
         return AppUtility.widgetForAsyncState(
           state: _inboxModel.receivedInvitationsState,

--- a/lib/widgets/screens/inbox/inbox_invites_sent.dart
+++ b/lib/widgets/screens/inbox/inbox_invites_sent.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:mm_flutter_app/constants/app_constants.dart';
@@ -109,6 +110,10 @@ class _InboxInvitesSentScreenState extends State<InboxInvitesSentScreen>
     _refreshTabIndex(context);
     return Selector<InboxModel, List<SentChannelInvitation>?>(
       selector: (_, inboxModel) => inboxModel.pendingSentInvitations,
+      shouldRebuild: (oldValue, newValue) =>
+          !(const DeepCollectionEquality.unordered()
+              .equals(oldValue, newValue)) ||
+          _inboxModel.sentInvitationsState != AsyncState.loading,
       builder: (_, pendingSentInvitations, __) {
         return AppUtility.widgetForAsyncState(
           state: _inboxModel.sentInvitationsState,

--- a/lib/widgets/screens/inbox/invitation_detail.dart
+++ b/lib/widgets/screens/inbox/invitation_detail.dart
@@ -217,7 +217,6 @@ class _InvitationDetailState extends State<InvitationDetail>
               channelInvitationId: widget.channelInvitationId,
             );
             await _inboxModel.refreshPendingReceivedInvitations();
-            _inboxModel.refreshInboxInviteNotifications();
           },
           child: Text(
             _l10n.decline,
@@ -238,7 +237,6 @@ class _InvitationDetailState extends State<InvitationDetail>
               channelInvitationId: widget.channelInvitationId,
             );
             await _inboxModel.refreshPendingReceivedInvitations();
-            await _inboxModel.refreshInboxInviteNotifications();
             await _inboxModel.refreshActiveChannels();
             final ChannelForUser? newChannel = _inboxModel.activeChannels
                 .where((e) => e.participants.any((p) => p.user.id == senderId))

--- a/lib/widgets/screens/inbox/invitation_detail.dart
+++ b/lib/widgets/screens/inbox/invitation_detail.dart
@@ -217,6 +217,7 @@ class _InvitationDetailState extends State<InvitationDetail>
               channelInvitationId: widget.channelInvitationId,
             );
             await _inboxModel.refreshPendingReceivedInvitations();
+            router.push(Routes.inboxInvitesReceived.path);
           },
           child: Text(
             _l10n.decline,

--- a/lib/widgets/screens/profile/profile.dart
+++ b/lib/widgets/screens/profile/profile.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:mm_flutter_app/__generated/schema/operations_user.graphql.dart';
 import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
@@ -79,6 +80,10 @@ class _ProfileScreenState extends State<ProfileScreen>
                 inboxModel.pendingReceivedInvitations,
                 inboxModel.pendingSentInvitations,
               ),
+              shouldRebuild: (oldValue, newValue) =>
+                  !(const DeepCollectionEquality.unordered()
+                      .equals(oldValue, newValue)) ||
+                  _inboxModel.invitesState != AsyncState.loading,
               builder: (_, __, ___) {
                 return AppUtility.widgetForAsyncState(
                   state: _isMyProfile

--- a/lib/widgets/screens/profile/profile_page_header.dart
+++ b/lib/widgets/screens/profile/profile_page_header.dart
@@ -65,7 +65,6 @@ class _ProfilePageHeaderState extends State<ProfilePageHeader> {
               channelInvitationId: widget.invitationId!,
             );
             await _inboxModel.refreshPendingReceivedInvitations();
-            _inboxModel.refreshInboxInviteNotifications();
           },
           child: Text(
             l10n.decline,
@@ -86,7 +85,6 @@ class _ProfilePageHeaderState extends State<ProfilePageHeader> {
               channelInvitationId: widget.invitationId!,
             );
             await _inboxModel.refreshPendingReceivedInvitations();
-            await _inboxModel.refreshInboxInviteNotifications();
             await _inboxModel.refreshActiveChannels();
             final ChannelForUser? newChannel = _inboxModel.activeChannels
                 .where(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "4.5.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   firebase_messaging: ^14.6.5
   textfield_tags: ^2.0.2
   tuple: ^2.0.2
+  collection: 1.17.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This introduces additional improvements to the InboxModel:

- The redundant queries were consolidated to reduce data utilization.
- Polls the backend at regular intervals to retrieve new invitations received, new channels created, or determine if a sent invitation has been accepted or declined. This is necessary because subscriptions require an existing channel, and the events mentioned lack a channel to subscribe to. The scope of the poll will eventually be reduced to only include the most recent data to avoid wasteful data utilization.
- InboxModel Selectors were overriden to only rebuild widgets when certain model fields change, AND the model is not in a loading state. This is extremely important when polling because we do not want the screen to be rebuilding every time a poll occurs, only when the displayed elements change.