### PR TITLE
Website signup -> optional, support "dual-role" users

### DIFF
--- a/lib/widgets/screens/sign_up/sign_up_entrepreneur_website.dart
+++ b/lib/widgets/screens/sign_up/sign_up_entrepreneur_website.dart
@@ -45,12 +45,10 @@ class _SignupEntrepreneurWebsiteScreenState
         leftOnPress: () {
           context.pop();
         },
-        rightOnPress: _website?.isNotEmpty ?? false
-            ? () {
-                _registrationModel.updateUserInput.companyWebsite = _website;
-                context.push(Routes.signupEntrepreneurCompanyReason.path);
-              }
-            : null,
+        rightOnPress: () {
+          _registrationModel.updateUserInput.companyWebsite = _website;
+          context.push(Routes.signupEntrepreneurCompanyReason.path);
+        },
       ),
       footer: SignUpIconFooter(
           icon: Icons.visibility_outlined, text: l10n.signUpShownOnProfileInfo),


### PR DESCRIPTION
This PR contains 2 changes:
1. Allow entrepreneur/mentee users to continue through signup without entering a website
2. Show "dual-role" users (who are both mentors and mentees) in search results

For the optional input, I wasn't sure if we have a specific way to implement this.

2 isn't scoped for this app but it is a use case the MicroMentor will need to support, feel free to reject if it seems like it's outside the scope for the open source app. In that case I can revert that commit and merge this without that change.