### PR TITLE
Channel messages infinite scrolling with lazy loading

### DIFF
--- a/lib/constants/numerical.dart
+++ b/lib/constants/numerical.dart
@@ -3,6 +3,7 @@ part of 'app_constants.dart';
 class Limits {
   Limits._private();
   static const maxNotificationsDisplayed = 99;
+  static const chatMessagesPageSize = 25;
   static const searchResultsBatchSize = 100;
   static const searchResultsPageSize = 5;
 }

--- a/lib/providers/messages_provider.dart
+++ b/lib/providers/messages_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:mm_flutter_app/__generated/schema/operations_message.graphql.dart';
 import 'package:mm_flutter_app/__generated/schema/schema.graphql.dart';
+import 'package:mm_flutter_app/constants/app_constants.dart';
 
 import 'base/base_provider.dart';
 import 'base/operation_result.dart';
@@ -43,6 +44,7 @@ class MessagesProvider extends BaseProvider {
 
   Future<OperationResult<List<ChannelMessage>>> findChannelMessages({
     required Input$ChannelMessageListFilter input,
+    required int fetchSkip,
     bool fetchFromNetworkOnly = false,
   }) async {
     final QueryResult queryResult = await asyncQuery(
@@ -55,6 +57,14 @@ class MessagesProvider extends BaseProvider {
           filter: input,
           options: Input$FindObjectsOptions(
             includeDeleted: Enum$IncludeFilterOption.include,
+            limit: Limits.chatMessagesPageSize,
+            sort: [
+              Input$SortItem(
+                field: "createdAt",
+                direction: Enum$SortDirection.desc,
+              ),
+            ],
+            skip: fetchSkip,
           ),
         ).toJson(),
       ),


### PR DESCRIPTION
Fetches the most recent messages of a chat whenever it is opened, and only fetch older messages as the user scrolls up. This allows opening the chat very quickly and reduce data utilization since it is not expected users need the entire history of chat messages every time they open a conversation.

This video demonstrates the feature with a conversation that has a very large number of messages:

[lazy_loading.webm](https://github.com/micromentor-team/mm-flutter-app/assets/25093428/6d30d4bc-1241-4379-b8b7-ffa56477f5a4)
