### PR TITLE
Enable marking received invitations as read

### DIFF
--- a/lib/__generated/schema/operations_invitation.graphql.dart
+++ b/lib/__generated/schema/operations_invitation.graphql.dart
@@ -300,6 +300,13 @@ const documentNodeQueryFindChannelInvitationById = DocumentNode(definitions: [
             selectionSet: null,
           ),
           FieldNode(
+            name: NameNode(value: 'readByRecipientAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
             name: NameNode(value: 'sender'),
             alias: null,
             arguments: [],
@@ -930,6 +937,7 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
     required this.createdAt,
     this.messageText,
     required this.status,
+    this.readByRecipientAt,
     required this.sender,
     required this.recipient,
     this.$__typename = 'ChannelInvitation',
@@ -940,6 +948,7 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
     final l$createdAt = json['createdAt'];
     final l$messageText = json['messageText'];
     final l$status = json['status'];
+    final l$readByRecipientAt = json['readByRecipientAt'];
     final l$sender = json['sender'];
     final l$recipient = json['recipient'];
     final l$$__typename = json['__typename'];
@@ -947,6 +956,9 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
       createdAt: DateTime.parse((l$createdAt as String)),
       messageText: (l$messageText as String?),
       status: fromJson$Enum$ChannelInvitationStatus((l$status as String)),
+      readByRecipientAt: l$readByRecipientAt == null
+          ? null
+          : DateTime.parse((l$readByRecipientAt as String)),
       sender: Query$FindChannelInvitationById$findChannelInvitationById$sender
           .fromJson((l$sender as Map<String, dynamic>)),
       recipient:
@@ -961,6 +973,8 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
   final String? messageText;
 
   final Enum$ChannelInvitationStatus status;
+
+  final DateTime? readByRecipientAt;
 
   final Query$FindChannelInvitationById$findChannelInvitationById$sender sender;
 
@@ -977,6 +991,8 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
     _resultData['messageText'] = l$messageText;
     final l$status = status;
     _resultData['status'] = toJson$Enum$ChannelInvitationStatus(l$status);
+    final l$readByRecipientAt = readByRecipientAt;
+    _resultData['readByRecipientAt'] = l$readByRecipientAt?.toIso8601String();
     final l$sender = sender;
     _resultData['sender'] = l$sender.toJson();
     final l$recipient = recipient;
@@ -991,6 +1007,7 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
     final l$createdAt = createdAt;
     final l$messageText = messageText;
     final l$status = status;
+    final l$readByRecipientAt = readByRecipientAt;
     final l$sender = sender;
     final l$recipient = recipient;
     final l$$__typename = $__typename;
@@ -998,6 +1015,7 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
       l$createdAt,
       l$messageText,
       l$status,
+      l$readByRecipientAt,
       l$sender,
       l$recipient,
       l$$__typename,
@@ -1026,6 +1044,11 @@ class Query$FindChannelInvitationById$findChannelInvitationById {
     final l$status = status;
     final lOther$status = other.status;
     if (l$status != lOther$status) {
+      return false;
+    }
+    final l$readByRecipientAt = readByRecipientAt;
+    final lOther$readByRecipientAt = other.readByRecipientAt;
+    if (l$readByRecipientAt != lOther$readByRecipientAt) {
       return false;
     }
     final l$sender = sender;
@@ -1074,6 +1097,7 @@ abstract class CopyWith$Query$FindChannelInvitationById$findChannelInvitationByI
     DateTime? createdAt,
     String? messageText,
     Enum$ChannelInvitationStatus? status,
+    DateTime? readByRecipientAt,
     Query$FindChannelInvitationById$findChannelInvitationById$sender? sender,
     Query$FindChannelInvitationById$findChannelInvitationById$recipient?
         recipient,
@@ -1106,6 +1130,7 @@ class _CopyWithImpl$Query$FindChannelInvitationById$findChannelInvitationById<
     Object? createdAt = _undefined,
     Object? messageText = _undefined,
     Object? status = _undefined,
+    Object? readByRecipientAt = _undefined,
     Object? sender = _undefined,
     Object? recipient = _undefined,
     Object? $__typename = _undefined,
@@ -1120,6 +1145,9 @@ class _CopyWithImpl$Query$FindChannelInvitationById$findChannelInvitationById<
         status: status == _undefined || status == null
             ? _instance.status
             : (status as Enum$ChannelInvitationStatus),
+        readByRecipientAt: readByRecipientAt == _undefined
+            ? _instance.readByRecipientAt
+            : (readByRecipientAt as DateTime?),
         sender: sender == _undefined || sender == null
             ? _instance.sender
             : (sender
@@ -1161,6 +1189,7 @@ class _CopyWithStubImpl$Query$FindChannelInvitationById$findChannelInvitationByI
     DateTime? createdAt,
     String? messageText,
     Enum$ChannelInvitationStatus? status,
+    DateTime? readByRecipientAt,
     Query$FindChannelInvitationById$findChannelInvitationById$sender? sender,
     Query$FindChannelInvitationById$findChannelInvitationById$recipient?
         recipient,
@@ -6694,6 +6723,13 @@ const documentNodeQueryMyReceivedChannelInvitations =
             selectionSet: null,
           ),
           FieldNode(
+            name: NameNode(value: 'readByRecipientAt'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null,
+          ),
+          FieldNode(
             name: NameNode(value: 'sender'),
             alias: null,
             arguments: [],
@@ -6763,6 +6799,7 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
     required this.id,
     this.messageText,
     required this.status,
+    this.readByRecipientAt,
     required this.sender,
     this.$__typename = 'ChannelInvitation',
   });
@@ -6774,6 +6811,7 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
     final l$id = json['id'];
     final l$messageText = json['messageText'];
     final l$status = json['status'];
+    final l$readByRecipientAt = json['readByRecipientAt'];
     final l$sender = json['sender'];
     final l$$__typename = json['__typename'];
     return Query$MyReceivedChannelInvitations$myChannelInvitations(
@@ -6782,6 +6820,9 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
       id: (l$id as String),
       messageText: (l$messageText as String?),
       status: fromJson$Enum$ChannelInvitationStatus((l$status as String)),
+      readByRecipientAt: l$readByRecipientAt == null
+          ? null
+          : DateTime.parse((l$readByRecipientAt as String)),
       sender: Query$MyReceivedChannelInvitations$myChannelInvitations$sender
           .fromJson((l$sender as Map<String, dynamic>)),
       $__typename: (l$$__typename as String),
@@ -6797,6 +6838,8 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
   final String? messageText;
 
   final Enum$ChannelInvitationStatus status;
+
+  final DateTime? readByRecipientAt;
 
   final Query$MyReceivedChannelInvitations$myChannelInvitations$sender sender;
 
@@ -6814,6 +6857,8 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
     _resultData['messageText'] = l$messageText;
     final l$status = status;
     _resultData['status'] = toJson$Enum$ChannelInvitationStatus(l$status);
+    final l$readByRecipientAt = readByRecipientAt;
+    _resultData['readByRecipientAt'] = l$readByRecipientAt?.toIso8601String();
     final l$sender = sender;
     _resultData['sender'] = l$sender.toJson();
     final l$$__typename = $__typename;
@@ -6828,6 +6873,7 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
     final l$id = id;
     final l$messageText = messageText;
     final l$status = status;
+    final l$readByRecipientAt = readByRecipientAt;
     final l$sender = sender;
     final l$$__typename = $__typename;
     return Object.hashAll([
@@ -6836,6 +6882,7 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
       l$id,
       l$messageText,
       l$status,
+      l$readByRecipientAt,
       l$sender,
       l$$__typename,
     ]);
@@ -6873,6 +6920,11 @@ class Query$MyReceivedChannelInvitations$myChannelInvitations {
     final l$status = status;
     final lOther$status = other.status;
     if (l$status != lOther$status) {
+      return false;
+    }
+    final l$readByRecipientAt = readByRecipientAt;
+    final lOther$readByRecipientAt = other.readByRecipientAt;
+    if (l$readByRecipientAt != lOther$readByRecipientAt) {
       return false;
     }
     final l$sender = sender;
@@ -6917,6 +6969,7 @@ abstract class CopyWith$Query$MyReceivedChannelInvitations$myChannelInvitations<
     String? id,
     String? messageText,
     Enum$ChannelInvitationStatus? status,
+    DateTime? readByRecipientAt,
     Query$MyReceivedChannelInvitations$myChannelInvitations$sender? sender,
     String? $__typename,
   });
@@ -6946,6 +6999,7 @@ class _CopyWithImpl$Query$MyReceivedChannelInvitations$myChannelInvitations<
     Object? id = _undefined,
     Object? messageText = _undefined,
     Object? status = _undefined,
+    Object? readByRecipientAt = _undefined,
     Object? sender = _undefined,
     Object? $__typename = _undefined,
   }) =>
@@ -6963,6 +7017,9 @@ class _CopyWithImpl$Query$MyReceivedChannelInvitations$myChannelInvitations<
         status: status == _undefined || status == null
             ? _instance.status
             : (status as Enum$ChannelInvitationStatus),
+        readByRecipientAt: readByRecipientAt == _undefined
+            ? _instance.readByRecipientAt
+            : (readByRecipientAt as DateTime?),
         sender: sender == _undefined || sender == null
             ? _instance.sender
             : (sender
@@ -6994,6 +7051,7 @@ class _CopyWithStubImpl$Query$MyReceivedChannelInvitations$myChannelInvitations<
     String? id,
     String? messageText,
     Enum$ChannelInvitationStatus? status,
+    DateTime? readByRecipientAt,
     Query$MyReceivedChannelInvitations$myChannelInvitations$sender? sender,
     String? $__typename,
   }) =>
@@ -9357,6 +9415,286 @@ const documentNodeMutationDeleteChannelInvitation = DocumentNode(definitions: [
             name: NameNode(value: 'channelInvitationId'),
             value: VariableNode(name: NameNode(value: 'channelInvitationId')),
           ),
+        ],
+        directives: [],
+        selectionSet: null,
+      ),
+      FieldNode(
+        name: NameNode(value: '__typename'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]),
+  ),
+]);
+
+class Variables$Mutation$MarkChannelInvitationAsSeenByMe {
+  factory Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+          {required Input$ChannelInvitationInput channelInvitationInput}) =>
+      Variables$Mutation$MarkChannelInvitationAsSeenByMe._({
+        r'channelInvitationInput': channelInvitationInput,
+      });
+
+  Variables$Mutation$MarkChannelInvitationAsSeenByMe._(this._$data);
+
+  factory Variables$Mutation$MarkChannelInvitationAsSeenByMe.fromJson(
+      Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    final l$channelInvitationInput = data['channelInvitationInput'];
+    result$data['channelInvitationInput'] =
+        Input$ChannelInvitationInput.fromJson(
+            (l$channelInvitationInput as Map<String, dynamic>));
+    return Variables$Mutation$MarkChannelInvitationAsSeenByMe._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Input$ChannelInvitationInput get channelInvitationInput =>
+      (_$data['channelInvitationInput'] as Input$ChannelInvitationInput);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    final l$channelInvitationInput = channelInvitationInput;
+    result$data['channelInvitationInput'] = l$channelInvitationInput.toJson();
+    return result$data;
+  }
+
+  CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe<
+          Variables$Mutation$MarkChannelInvitationAsSeenByMe>
+      get copyWith =>
+          CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Variables$Mutation$MarkChannelInvitationAsSeenByMe) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$channelInvitationInput = channelInvitationInput;
+    final lOther$channelInvitationInput = other.channelInvitationInput;
+    if (l$channelInvitationInput != lOther$channelInvitationInput) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$channelInvitationInput = channelInvitationInput;
+    return Object.hashAll([l$channelInvitationInput]);
+  }
+}
+
+abstract class CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe<
+    TRes> {
+  factory CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+    Variables$Mutation$MarkChannelInvitationAsSeenByMe instance,
+    TRes Function(Variables$Mutation$MarkChannelInvitationAsSeenByMe) then,
+  ) = _CopyWithImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe;
+
+  factory CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe.stub(
+          TRes res) =
+      _CopyWithStubImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe;
+
+  TRes call({Input$ChannelInvitationInput? channelInvitationInput});
+}
+
+class _CopyWithImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe<TRes>
+    implements
+        CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe<TRes> {
+  _CopyWithImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+    this._instance,
+    this._then,
+  );
+
+  final Variables$Mutation$MarkChannelInvitationAsSeenByMe _instance;
+
+  final TRes Function(Variables$Mutation$MarkChannelInvitationAsSeenByMe) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({Object? channelInvitationInput = _undefined}) =>
+      _then(Variables$Mutation$MarkChannelInvitationAsSeenByMe._({
+        ..._instance._$data,
+        if (channelInvitationInput != _undefined &&
+            channelInvitationInput != null)
+          'channelInvitationInput':
+              (channelInvitationInput as Input$ChannelInvitationInput),
+      }));
+}
+
+class _CopyWithStubImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe<TRes>
+    implements
+        CopyWith$Variables$Mutation$MarkChannelInvitationAsSeenByMe<TRes> {
+  _CopyWithStubImpl$Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+      this._res);
+
+  TRes _res;
+
+  call({Input$ChannelInvitationInput? channelInvitationInput}) => _res;
+}
+
+class Mutation$MarkChannelInvitationAsSeenByMe {
+  Mutation$MarkChannelInvitationAsSeenByMe({
+    required this.updateChannelInvitation,
+    this.$__typename = 'Mutation',
+  });
+
+  factory Mutation$MarkChannelInvitationAsSeenByMe.fromJson(
+      Map<String, dynamic> json) {
+    final l$updateChannelInvitation = json['updateChannelInvitation'];
+    final l$$__typename = json['__typename'];
+    return Mutation$MarkChannelInvitationAsSeenByMe(
+      updateChannelInvitation: (l$updateChannelInvitation as String),
+      $__typename: (l$$__typename as String),
+    );
+  }
+
+  final String updateChannelInvitation;
+
+  final String $__typename;
+
+  Map<String, dynamic> toJson() {
+    final _resultData = <String, dynamic>{};
+    final l$updateChannelInvitation = updateChannelInvitation;
+    _resultData['updateChannelInvitation'] = l$updateChannelInvitation;
+    final l$$__typename = $__typename;
+    _resultData['__typename'] = l$$__typename;
+    return _resultData;
+  }
+
+  @override
+  int get hashCode {
+    final l$updateChannelInvitation = updateChannelInvitation;
+    final l$$__typename = $__typename;
+    return Object.hashAll([
+      l$updateChannelInvitation,
+      l$$__typename,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Mutation$MarkChannelInvitationAsSeenByMe) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$updateChannelInvitation = updateChannelInvitation;
+    final lOther$updateChannelInvitation = other.updateChannelInvitation;
+    if (l$updateChannelInvitation != lOther$updateChannelInvitation) {
+      return false;
+    }
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) {
+      return false;
+    }
+    return true;
+  }
+}
+
+extension UtilityExtension$Mutation$MarkChannelInvitationAsSeenByMe
+    on Mutation$MarkChannelInvitationAsSeenByMe {
+  CopyWith$Mutation$MarkChannelInvitationAsSeenByMe<
+          Mutation$MarkChannelInvitationAsSeenByMe>
+      get copyWith => CopyWith$Mutation$MarkChannelInvitationAsSeenByMe(
+            this,
+            (i) => i,
+          );
+}
+
+abstract class CopyWith$Mutation$MarkChannelInvitationAsSeenByMe<TRes> {
+  factory CopyWith$Mutation$MarkChannelInvitationAsSeenByMe(
+    Mutation$MarkChannelInvitationAsSeenByMe instance,
+    TRes Function(Mutation$MarkChannelInvitationAsSeenByMe) then,
+  ) = _CopyWithImpl$Mutation$MarkChannelInvitationAsSeenByMe;
+
+  factory CopyWith$Mutation$MarkChannelInvitationAsSeenByMe.stub(TRes res) =
+      _CopyWithStubImpl$Mutation$MarkChannelInvitationAsSeenByMe;
+
+  TRes call({
+    String? updateChannelInvitation,
+    String? $__typename,
+  });
+}
+
+class _CopyWithImpl$Mutation$MarkChannelInvitationAsSeenByMe<TRes>
+    implements CopyWith$Mutation$MarkChannelInvitationAsSeenByMe<TRes> {
+  _CopyWithImpl$Mutation$MarkChannelInvitationAsSeenByMe(
+    this._instance,
+    this._then,
+  );
+
+  final Mutation$MarkChannelInvitationAsSeenByMe _instance;
+
+  final TRes Function(Mutation$MarkChannelInvitationAsSeenByMe) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? updateChannelInvitation = _undefined,
+    Object? $__typename = _undefined,
+  }) =>
+      _then(Mutation$MarkChannelInvitationAsSeenByMe(
+        updateChannelInvitation: updateChannelInvitation == _undefined ||
+                updateChannelInvitation == null
+            ? _instance.updateChannelInvitation
+            : (updateChannelInvitation as String),
+        $__typename: $__typename == _undefined || $__typename == null
+            ? _instance.$__typename
+            : ($__typename as String),
+      ));
+}
+
+class _CopyWithStubImpl$Mutation$MarkChannelInvitationAsSeenByMe<TRes>
+    implements CopyWith$Mutation$MarkChannelInvitationAsSeenByMe<TRes> {
+  _CopyWithStubImpl$Mutation$MarkChannelInvitationAsSeenByMe(this._res);
+
+  TRes _res;
+
+  call({
+    String? updateChannelInvitation,
+    String? $__typename,
+  }) =>
+      _res;
+}
+
+const documentNodeMutationMarkChannelInvitationAsSeenByMe =
+    DocumentNode(definitions: [
+  OperationDefinitionNode(
+    type: OperationType.mutation,
+    name: NameNode(value: 'MarkChannelInvitationAsSeenByMe'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+        variable: VariableNode(name: NameNode(value: 'channelInvitationInput')),
+        type: NamedTypeNode(
+          name: NameNode(value: 'ChannelInvitationInput'),
+          isNonNull: true,
+        ),
+        defaultValue: DefaultValueNode(value: null),
+        directives: [],
+      )
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+        name: NameNode(value: 'updateChannelInvitation'),
+        alias: null,
+        arguments: [
+          ArgumentNode(
+            name: NameNode(value: 'input'),
+            value:
+                VariableNode(name: NameNode(value: 'channelInvitationInput')),
+          )
         ],
         directives: [],
         selectionSet: null,

--- a/lib/__generated/schema/schema.graphql.dart
+++ b/lib/__generated/schema/schema.graphql.dart
@@ -906,6 +906,7 @@ class Input$UserInput {
     DateTime? latestActivityAt,
     DateTime? inactivatedAt,
     String? inactivatedBy,
+    DateTime? termsAndConditionsAcceptedAt,
     List<String>? companyIds,
     List<String>? groupIds,
     List<String>? parentGroupIds,
@@ -987,6 +988,8 @@ class Input$UserInput {
         if (latestActivityAt != null) r'latestActivityAt': latestActivityAt,
         if (inactivatedAt != null) r'inactivatedAt': inactivatedAt,
         if (inactivatedBy != null) r'inactivatedBy': inactivatedBy,
+        if (termsAndConditionsAcceptedAt != null)
+          r'termsAndConditionsAcceptedAt': termsAndConditionsAcceptedAt,
         if (companyIds != null) r'companyIds': companyIds,
         if (groupIds != null) r'groupIds': groupIds,
         if (parentGroupIds != null) r'parentGroupIds': parentGroupIds,
@@ -1257,6 +1260,14 @@ class Input$UserInput {
       final l$inactivatedBy = data['inactivatedBy'];
       result$data['inactivatedBy'] = (l$inactivatedBy as String?);
     }
+    if (data.containsKey('termsAndConditionsAcceptedAt')) {
+      final l$termsAndConditionsAcceptedAt =
+          data['termsAndConditionsAcceptedAt'];
+      result$data['termsAndConditionsAcceptedAt'] =
+          l$termsAndConditionsAcceptedAt == null
+              ? null
+              : DateTime.parse((l$termsAndConditionsAcceptedAt as String));
+    }
     if (data.containsKey('companyIds')) {
       final l$companyIds = data['companyIds'];
       result$data['companyIds'] =
@@ -1458,6 +1469,8 @@ class Input$UserInput {
   DateTime? get latestActivityAt => (_$data['latestActivityAt'] as DateTime?);
   DateTime? get inactivatedAt => (_$data['inactivatedAt'] as DateTime?);
   String? get inactivatedBy => (_$data['inactivatedBy'] as String?);
+  DateTime? get termsAndConditionsAcceptedAt =>
+      (_$data['termsAndConditionsAcceptedAt'] as DateTime?);
   List<String>? get companyIds => (_$data['companyIds'] as List<String>?);
   List<String>? get groupIds => (_$data['groupIds'] as List<String>?);
   List<String>? get parentGroupIds =>
@@ -1693,6 +1706,11 @@ class Input$UserInput {
     if (_$data.containsKey('inactivatedBy')) {
       final l$inactivatedBy = inactivatedBy;
       result$data['inactivatedBy'] = l$inactivatedBy;
+    }
+    if (_$data.containsKey('termsAndConditionsAcceptedAt')) {
+      final l$termsAndConditionsAcceptedAt = termsAndConditionsAcceptedAt;
+      result$data['termsAndConditionsAcceptedAt'] =
+          l$termsAndConditionsAcceptedAt?.toIso8601String();
     }
     if (_$data.containsKey('companyIds')) {
       final l$companyIds = companyIds;
@@ -2290,6 +2308,16 @@ class Input$UserInput {
     if (l$inactivatedBy != lOther$inactivatedBy) {
       return false;
     }
+    final l$termsAndConditionsAcceptedAt = termsAndConditionsAcceptedAt;
+    final lOther$termsAndConditionsAcceptedAt =
+        other.termsAndConditionsAcceptedAt;
+    if (_$data.containsKey('termsAndConditionsAcceptedAt') !=
+        other._$data.containsKey('termsAndConditionsAcceptedAt')) {
+      return false;
+    }
+    if (l$termsAndConditionsAcceptedAt != lOther$termsAndConditionsAcceptedAt) {
+      return false;
+    }
     final l$companyIds = companyIds;
     final lOther$companyIds = other.companyIds;
     if (_$data.containsKey('companyIds') !=
@@ -2713,6 +2741,7 @@ class Input$UserInput {
     final l$latestActivityAt = latestActivityAt;
     final l$inactivatedAt = inactivatedAt;
     final l$inactivatedBy = inactivatedBy;
+    final l$termsAndConditionsAcceptedAt = termsAndConditionsAcceptedAt;
     final l$companyIds = companyIds;
     final l$groupIds = groupIds;
     final l$parentGroupIds = parentGroupIds;
@@ -2818,6 +2847,9 @@ class Input$UserInput {
       _$data.containsKey('latestActivityAt') ? l$latestActivityAt : const {},
       _$data.containsKey('inactivatedAt') ? l$inactivatedAt : const {},
       _$data.containsKey('inactivatedBy') ? l$inactivatedBy : const {},
+      _$data.containsKey('termsAndConditionsAcceptedAt')
+          ? l$termsAndConditionsAcceptedAt
+          : const {},
       _$data.containsKey('companyIds')
           ? l$companyIds == null
               ? null
@@ -2962,6 +2994,7 @@ abstract class CopyWith$Input$UserInput<TRes> {
     DateTime? latestActivityAt,
     DateTime? inactivatedAt,
     String? inactivatedBy,
+    DateTime? termsAndConditionsAcceptedAt,
     List<String>? companyIds,
     List<String>? groupIds,
     List<String>? parentGroupIds,
@@ -3082,6 +3115,7 @@ class _CopyWithImpl$Input$UserInput<TRes>
     Object? latestActivityAt = _undefined,
     Object? inactivatedAt = _undefined,
     Object? inactivatedBy = _undefined,
+    Object? termsAndConditionsAcceptedAt = _undefined,
     Object? companyIds = _undefined,
     Object? groupIds = _undefined,
     Object? parentGroupIds = _undefined,
@@ -3181,6 +3215,9 @@ class _CopyWithImpl$Input$UserInput<TRes>
           'inactivatedAt': (inactivatedAt as DateTime?),
         if (inactivatedBy != _undefined)
           'inactivatedBy': (inactivatedBy as String?),
+        if (termsAndConditionsAcceptedAt != _undefined)
+          'termsAndConditionsAcceptedAt':
+              (termsAndConditionsAcceptedAt as DateTime?),
         if (companyIds != _undefined)
           'companyIds': (companyIds as List<String>?),
         if (groupIds != _undefined) 'groupIds': (groupIds as List<String>?),
@@ -3366,6 +3403,7 @@ class _CopyWithStubImpl$Input$UserInput<TRes>
     DateTime? latestActivityAt,
     DateTime? inactivatedAt,
     String? inactivatedBy,
+    DateTime? termsAndConditionsAcceptedAt,
     List<String>? companyIds,
     List<String>? groupIds,
     List<String>? parentGroupIds,
@@ -16680,6 +16718,7 @@ class Input$ChannelInvitationInput {
     String? messageText,
     DateTime? dismissedFromInboxBySenderAt,
     DateTime? dismissedFromInboxByRecipientAt,
+    DateTime? readByRecipientAt,
     Enum$ChannelInvitationStatus? status,
   }) =>
       Input$ChannelInvitationInput._({
@@ -16703,6 +16742,7 @@ class Input$ChannelInvitationInput {
           r'dismissedFromInboxBySenderAt': dismissedFromInboxBySenderAt,
         if (dismissedFromInboxByRecipientAt != null)
           r'dismissedFromInboxByRecipientAt': dismissedFromInboxByRecipientAt,
+        if (readByRecipientAt != null) r'readByRecipientAt': readByRecipientAt,
         if (status != null) r'status': status,
       });
 
@@ -16799,6 +16839,12 @@ class Input$ChannelInvitationInput {
               ? null
               : DateTime.parse((l$dismissedFromInboxByRecipientAt as String));
     }
+    if (data.containsKey('readByRecipientAt')) {
+      final l$readByRecipientAt = data['readByRecipientAt'];
+      result$data['readByRecipientAt'] = l$readByRecipientAt == null
+          ? null
+          : DateTime.parse((l$readByRecipientAt as String));
+    }
     if (data.containsKey('status')) {
       final l$status = data['status'];
       result$data['status'] = l$status == null
@@ -16832,6 +16878,7 @@ class Input$ChannelInvitationInput {
       (_$data['dismissedFromInboxBySenderAt'] as DateTime?);
   DateTime? get dismissedFromInboxByRecipientAt =>
       (_$data['dismissedFromInboxByRecipientAt'] as DateTime?);
+  DateTime? get readByRecipientAt => (_$data['readByRecipientAt'] as DateTime?);
   Enum$ChannelInvitationStatus? get status =>
       (_$data['status'] as Enum$ChannelInvitationStatus?);
   Map<String, dynamic> toJson() {
@@ -16909,6 +16956,10 @@ class Input$ChannelInvitationInput {
       final l$dismissedFromInboxByRecipientAt = dismissedFromInboxByRecipientAt;
       result$data['dismissedFromInboxByRecipientAt'] =
           l$dismissedFromInboxByRecipientAt?.toIso8601String();
+    }
+    if (_$data.containsKey('readByRecipientAt')) {
+      final l$readByRecipientAt = readByRecipientAt;
+      result$data['readByRecipientAt'] = l$readByRecipientAt?.toIso8601String();
     }
     if (_$data.containsKey('status')) {
       final l$status = status;
@@ -17107,6 +17158,15 @@ class Input$ChannelInvitationInput {
         lOther$dismissedFromInboxByRecipientAt) {
       return false;
     }
+    final l$readByRecipientAt = readByRecipientAt;
+    final lOther$readByRecipientAt = other.readByRecipientAt;
+    if (_$data.containsKey('readByRecipientAt') !=
+        other._$data.containsKey('readByRecipientAt')) {
+      return false;
+    }
+    if (l$readByRecipientAt != lOther$readByRecipientAt) {
+      return false;
+    }
     final l$status = status;
     final lOther$status = other.status;
     if (_$data.containsKey('status') != other._$data.containsKey('status')) {
@@ -17138,6 +17198,7 @@ class Input$ChannelInvitationInput {
     final l$messageText = messageText;
     final l$dismissedFromInboxBySenderAt = dismissedFromInboxBySenderAt;
     final l$dismissedFromInboxByRecipientAt = dismissedFromInboxByRecipientAt;
+    final l$readByRecipientAt = readByRecipientAt;
     final l$status = status;
     return Object.hashAll([
       _$data.containsKey('id') ? l$id : const {},
@@ -17166,6 +17227,7 @@ class Input$ChannelInvitationInput {
       _$data.containsKey('dismissedFromInboxByRecipientAt')
           ? l$dismissedFromInboxByRecipientAt
           : const {},
+      _$data.containsKey('readByRecipientAt') ? l$readByRecipientAt : const {},
       _$data.containsKey('status') ? l$status : const {},
     ]);
   }
@@ -17199,6 +17261,7 @@ abstract class CopyWith$Input$ChannelInvitationInput<TRes> {
     String? messageText,
     DateTime? dismissedFromInboxBySenderAt,
     DateTime? dismissedFromInboxByRecipientAt,
+    DateTime? readByRecipientAt,
     Enum$ChannelInvitationStatus? status,
   });
   TRes events(
@@ -17240,6 +17303,7 @@ class _CopyWithImpl$Input$ChannelInvitationInput<TRes>
     Object? messageText = _undefined,
     Object? dismissedFromInboxBySenderAt = _undefined,
     Object? dismissedFromInboxByRecipientAt = _undefined,
+    Object? readByRecipientAt = _undefined,
     Object? status = _undefined,
   }) =>
       _then(Input$ChannelInvitationInput._({
@@ -17269,6 +17333,8 @@ class _CopyWithImpl$Input$ChannelInvitationInput<TRes>
         if (dismissedFromInboxByRecipientAt != _undefined)
           'dismissedFromInboxByRecipientAt':
               (dismissedFromInboxByRecipientAt as DateTime?),
+        if (readByRecipientAt != _undefined)
+          'readByRecipientAt': (readByRecipientAt as DateTime?),
         if (status != _undefined)
           'status': (status as Enum$ChannelInvitationStatus?),
       }));
@@ -17317,6 +17383,7 @@ class _CopyWithStubImpl$Input$ChannelInvitationInput<TRes>
     String? messageText,
     DateTime? dismissedFromInboxBySenderAt,
     DateTime? dismissedFromInboxByRecipientAt,
+    DateTime? readByRecipientAt,
     Enum$ChannelInvitationStatus? status,
   }) =>
       _res;
@@ -23311,6 +23378,585 @@ class _CopyWithStubImpl$Input$Mm2SynchronizationInput<TRes>
       CopyWith$Input$BaseModelMetadataInput.stub(_res);
 }
 
+class Input$NlpConversationInput {
+  factory Input$NlpConversationInput({
+    String? id,
+    required String label,
+    List<Input$NlpLabelInput>? labels,
+  }) =>
+      Input$NlpConversationInput._({
+        if (id != null) r'id': id,
+        r'label': label,
+        if (labels != null) r'labels': labels,
+      });
+
+  Input$NlpConversationInput._(this._$data);
+
+  factory Input$NlpConversationInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String);
+    }
+    final l$label = data['label'];
+    result$data['label'] = (l$label as String);
+    if (data.containsKey('labels')) {
+      final l$labels = data['labels'];
+      result$data['labels'] = (l$labels as List<dynamic>)
+          .map((e) => Input$NlpLabelInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    return Input$NlpConversationInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String get label => (_$data['label'] as String);
+  List<Input$NlpLabelInput>? get labels =>
+      (_$data['labels'] as List<Input$NlpLabelInput>?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = (l$id as String);
+    }
+    final l$label = label;
+    result$data['label'] = l$label;
+    if (_$data.containsKey('labels')) {
+      final l$labels = labels;
+      result$data['labels'] = (l$labels as List<Input$NlpLabelInput>)
+          .map((e) => e.toJson())
+          .toList();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$NlpConversationInput<Input$NlpConversationInput>
+      get copyWith => CopyWith$Input$NlpConversationInput(
+            this,
+            (i) => i,
+          );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$NlpConversationInput) ||
+        runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$label = label;
+    final lOther$label = other.label;
+    if (l$label != lOther$label) {
+      return false;
+    }
+    final l$labels = labels;
+    final lOther$labels = other.labels;
+    if (_$data.containsKey('labels') != other._$data.containsKey('labels')) {
+      return false;
+    }
+    if (l$labels != null && lOther$labels != null) {
+      if (l$labels.length != lOther$labels.length) {
+        return false;
+      }
+      for (int i = 0; i < l$labels.length; i++) {
+        final l$labels$entry = l$labels[i];
+        final lOther$labels$entry = lOther$labels[i];
+        if (l$labels$entry != lOther$labels$entry) {
+          return false;
+        }
+      }
+    } else if (l$labels != lOther$labels) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$label = label;
+    final l$labels = labels;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      l$label,
+      _$data.containsKey('labels')
+          ? l$labels == null
+              ? null
+              : Object.hashAll(l$labels.map((v) => v))
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$NlpConversationInput<TRes> {
+  factory CopyWith$Input$NlpConversationInput(
+    Input$NlpConversationInput instance,
+    TRes Function(Input$NlpConversationInput) then,
+  ) = _CopyWithImpl$Input$NlpConversationInput;
+
+  factory CopyWith$Input$NlpConversationInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$NlpConversationInput;
+
+  TRes call({
+    String? id,
+    String? label,
+    List<Input$NlpLabelInput>? labels,
+  });
+  TRes labels(
+      Iterable<Input$NlpLabelInput> Function(
+              Iterable<CopyWith$Input$NlpLabelInput<Input$NlpLabelInput>>)
+          _fn);
+}
+
+class _CopyWithImpl$Input$NlpConversationInput<TRes>
+    implements CopyWith$Input$NlpConversationInput<TRes> {
+  _CopyWithImpl$Input$NlpConversationInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$NlpConversationInput _instance;
+
+  final TRes Function(Input$NlpConversationInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? label = _undefined,
+    Object? labels = _undefined,
+  }) =>
+      _then(Input$NlpConversationInput._({
+        ..._instance._$data,
+        if (id != _undefined && id != null) 'id': (id as String),
+        if (label != _undefined && label != null) 'label': (label as String),
+        if (labels != _undefined && labels != null)
+          'labels': (labels as List<Input$NlpLabelInput>),
+      }));
+  TRes labels(
+          Iterable<Input$NlpLabelInput> Function(
+                  Iterable<CopyWith$Input$NlpLabelInput<Input$NlpLabelInput>>)
+              _fn) =>
+      call(
+          labels: _instance.labels != null
+              ? _fn(_instance.labels!.map((e) => CopyWith$Input$NlpLabelInput(
+                    e,
+                    (i) => i,
+                  ))).toList()
+              : null);
+}
+
+class _CopyWithStubImpl$Input$NlpConversationInput<TRes>
+    implements CopyWith$Input$NlpConversationInput<TRes> {
+  _CopyWithStubImpl$Input$NlpConversationInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? label,
+    List<Input$NlpLabelInput>? labels,
+  }) =>
+      _res;
+  labels(_fn) => _res;
+}
+
+class Input$NlpLabelInput {
+  factory Input$NlpLabelInput({
+    Enum$NlpLabelName? name,
+    int? probability,
+    String? createdBy,
+    DateTime? createdAt,
+  }) =>
+      Input$NlpLabelInput._({
+        if (name != null) r'name': name,
+        if (probability != null) r'probability': probability,
+        if (createdBy != null) r'createdBy': createdBy,
+        if (createdAt != null) r'createdAt': createdAt,
+      });
+
+  Input$NlpLabelInput._(this._$data);
+
+  factory Input$NlpLabelInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('name')) {
+      final l$name = data['name'];
+      result$data['name'] = fromJson$Enum$NlpLabelName((l$name as String));
+    }
+    if (data.containsKey('probability')) {
+      final l$probability = data['probability'];
+      result$data['probability'] = (l$probability as int);
+    }
+    if (data.containsKey('createdBy')) {
+      final l$createdBy = data['createdBy'];
+      result$data['createdBy'] = (l$createdBy as String?);
+    }
+    if (data.containsKey('createdAt')) {
+      final l$createdAt = data['createdAt'];
+      result$data['createdAt'] =
+          l$createdAt == null ? null : DateTime.parse((l$createdAt as String));
+    }
+    return Input$NlpLabelInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  Enum$NlpLabelName? get name => (_$data['name'] as Enum$NlpLabelName?);
+  int? get probability => (_$data['probability'] as int?);
+  String? get createdBy => (_$data['createdBy'] as String?);
+  DateTime? get createdAt => (_$data['createdAt'] as DateTime?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('name')) {
+      final l$name = name;
+      result$data['name'] =
+          toJson$Enum$NlpLabelName((l$name as Enum$NlpLabelName));
+    }
+    if (_$data.containsKey('probability')) {
+      final l$probability = probability;
+      result$data['probability'] = (l$probability as int);
+    }
+    if (_$data.containsKey('createdBy')) {
+      final l$createdBy = createdBy;
+      result$data['createdBy'] = l$createdBy;
+    }
+    if (_$data.containsKey('createdAt')) {
+      final l$createdAt = createdAt;
+      result$data['createdAt'] = l$createdAt?.toIso8601String();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$NlpLabelInput<Input$NlpLabelInput> get copyWith =>
+      CopyWith$Input$NlpLabelInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$NlpLabelInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$name = name;
+    final lOther$name = other.name;
+    if (_$data.containsKey('name') != other._$data.containsKey('name')) {
+      return false;
+    }
+    if (l$name != lOther$name) {
+      return false;
+    }
+    final l$probability = probability;
+    final lOther$probability = other.probability;
+    if (_$data.containsKey('probability') !=
+        other._$data.containsKey('probability')) {
+      return false;
+    }
+    if (l$probability != lOther$probability) {
+      return false;
+    }
+    final l$createdBy = createdBy;
+    final lOther$createdBy = other.createdBy;
+    if (_$data.containsKey('createdBy') !=
+        other._$data.containsKey('createdBy')) {
+      return false;
+    }
+    if (l$createdBy != lOther$createdBy) {
+      return false;
+    }
+    final l$createdAt = createdAt;
+    final lOther$createdAt = other.createdAt;
+    if (_$data.containsKey('createdAt') !=
+        other._$data.containsKey('createdAt')) {
+      return false;
+    }
+    if (l$createdAt != lOther$createdAt) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$name = name;
+    final l$probability = probability;
+    final l$createdBy = createdBy;
+    final l$createdAt = createdAt;
+    return Object.hashAll([
+      _$data.containsKey('name') ? l$name : const {},
+      _$data.containsKey('probability') ? l$probability : const {},
+      _$data.containsKey('createdBy') ? l$createdBy : const {},
+      _$data.containsKey('createdAt') ? l$createdAt : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$NlpLabelInput<TRes> {
+  factory CopyWith$Input$NlpLabelInput(
+    Input$NlpLabelInput instance,
+    TRes Function(Input$NlpLabelInput) then,
+  ) = _CopyWithImpl$Input$NlpLabelInput;
+
+  factory CopyWith$Input$NlpLabelInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$NlpLabelInput;
+
+  TRes call({
+    Enum$NlpLabelName? name,
+    int? probability,
+    String? createdBy,
+    DateTime? createdAt,
+  });
+}
+
+class _CopyWithImpl$Input$NlpLabelInput<TRes>
+    implements CopyWith$Input$NlpLabelInput<TRes> {
+  _CopyWithImpl$Input$NlpLabelInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$NlpLabelInput _instance;
+
+  final TRes Function(Input$NlpLabelInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? name = _undefined,
+    Object? probability = _undefined,
+    Object? createdBy = _undefined,
+    Object? createdAt = _undefined,
+  }) =>
+      _then(Input$NlpLabelInput._({
+        ..._instance._$data,
+        if (name != _undefined && name != null)
+          'name': (name as Enum$NlpLabelName),
+        if (probability != _undefined && probability != null)
+          'probability': (probability as int),
+        if (createdBy != _undefined) 'createdBy': (createdBy as String?),
+        if (createdAt != _undefined) 'createdAt': (createdAt as DateTime?),
+      }));
+}
+
+class _CopyWithStubImpl$Input$NlpLabelInput<TRes>
+    implements CopyWith$Input$NlpLabelInput<TRes> {
+  _CopyWithStubImpl$Input$NlpLabelInput(this._res);
+
+  TRes _res;
+
+  call({
+    Enum$NlpLabelName? name,
+    int? probability,
+    String? createdBy,
+    DateTime? createdAt,
+  }) =>
+      _res;
+}
+
+class Input$NlpMessageInput {
+  factory Input$NlpMessageInput({
+    String? id,
+    required String label,
+    List<Input$NlpLabelInput>? labels,
+  }) =>
+      Input$NlpMessageInput._({
+        if (id != null) r'id': id,
+        r'label': label,
+        if (labels != null) r'labels': labels,
+      });
+
+  Input$NlpMessageInput._(this._$data);
+
+  factory Input$NlpMessageInput.fromJson(Map<String, dynamic> data) {
+    final result$data = <String, dynamic>{};
+    if (data.containsKey('id')) {
+      final l$id = data['id'];
+      result$data['id'] = (l$id as String);
+    }
+    final l$label = data['label'];
+    result$data['label'] = (l$label as String);
+    if (data.containsKey('labels')) {
+      final l$labels = data['labels'];
+      result$data['labels'] = (l$labels as List<dynamic>)
+          .map((e) => Input$NlpLabelInput.fromJson((e as Map<String, dynamic>)))
+          .toList();
+    }
+    return Input$NlpMessageInput._(result$data);
+  }
+
+  Map<String, dynamic> _$data;
+
+  String? get id => (_$data['id'] as String?);
+  String get label => (_$data['label'] as String);
+  List<Input$NlpLabelInput>? get labels =>
+      (_$data['labels'] as List<Input$NlpLabelInput>?);
+  Map<String, dynamic> toJson() {
+    final result$data = <String, dynamic>{};
+    if (_$data.containsKey('id')) {
+      final l$id = id;
+      result$data['id'] = (l$id as String);
+    }
+    final l$label = label;
+    result$data['label'] = l$label;
+    if (_$data.containsKey('labels')) {
+      final l$labels = labels;
+      result$data['labels'] = (l$labels as List<Input$NlpLabelInput>)
+          .map((e) => e.toJson())
+          .toList();
+    }
+    return result$data;
+  }
+
+  CopyWith$Input$NlpMessageInput<Input$NlpMessageInput> get copyWith =>
+      CopyWith$Input$NlpMessageInput(
+        this,
+        (i) => i,
+      );
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (!(other is Input$NlpMessageInput) || runtimeType != other.runtimeType) {
+      return false;
+    }
+    final l$id = id;
+    final lOther$id = other.id;
+    if (_$data.containsKey('id') != other._$data.containsKey('id')) {
+      return false;
+    }
+    if (l$id != lOther$id) {
+      return false;
+    }
+    final l$label = label;
+    final lOther$label = other.label;
+    if (l$label != lOther$label) {
+      return false;
+    }
+    final l$labels = labels;
+    final lOther$labels = other.labels;
+    if (_$data.containsKey('labels') != other._$data.containsKey('labels')) {
+      return false;
+    }
+    if (l$labels != null && lOther$labels != null) {
+      if (l$labels.length != lOther$labels.length) {
+        return false;
+      }
+      for (int i = 0; i < l$labels.length; i++) {
+        final l$labels$entry = l$labels[i];
+        final lOther$labels$entry = lOther$labels[i];
+        if (l$labels$entry != lOther$labels$entry) {
+          return false;
+        }
+      }
+    } else if (l$labels != lOther$labels) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    final l$id = id;
+    final l$label = label;
+    final l$labels = labels;
+    return Object.hashAll([
+      _$data.containsKey('id') ? l$id : const {},
+      l$label,
+      _$data.containsKey('labels')
+          ? l$labels == null
+              ? null
+              : Object.hashAll(l$labels.map((v) => v))
+          : const {},
+    ]);
+  }
+}
+
+abstract class CopyWith$Input$NlpMessageInput<TRes> {
+  factory CopyWith$Input$NlpMessageInput(
+    Input$NlpMessageInput instance,
+    TRes Function(Input$NlpMessageInput) then,
+  ) = _CopyWithImpl$Input$NlpMessageInput;
+
+  factory CopyWith$Input$NlpMessageInput.stub(TRes res) =
+      _CopyWithStubImpl$Input$NlpMessageInput;
+
+  TRes call({
+    String? id,
+    String? label,
+    List<Input$NlpLabelInput>? labels,
+  });
+  TRes labels(
+      Iterable<Input$NlpLabelInput> Function(
+              Iterable<CopyWith$Input$NlpLabelInput<Input$NlpLabelInput>>)
+          _fn);
+}
+
+class _CopyWithImpl$Input$NlpMessageInput<TRes>
+    implements CopyWith$Input$NlpMessageInput<TRes> {
+  _CopyWithImpl$Input$NlpMessageInput(
+    this._instance,
+    this._then,
+  );
+
+  final Input$NlpMessageInput _instance;
+
+  final TRes Function(Input$NlpMessageInput) _then;
+
+  static const _undefined = <dynamic, dynamic>{};
+
+  TRes call({
+    Object? id = _undefined,
+    Object? label = _undefined,
+    Object? labels = _undefined,
+  }) =>
+      _then(Input$NlpMessageInput._({
+        ..._instance._$data,
+        if (id != _undefined && id != null) 'id': (id as String),
+        if (label != _undefined && label != null) 'label': (label as String),
+        if (labels != _undefined && labels != null)
+          'labels': (labels as List<Input$NlpLabelInput>),
+      }));
+  TRes labels(
+          Iterable<Input$NlpLabelInput> Function(
+                  Iterable<CopyWith$Input$NlpLabelInput<Input$NlpLabelInput>>)
+              _fn) =>
+      call(
+          labels: _instance.labels != null
+              ? _fn(_instance.labels!.map((e) => CopyWith$Input$NlpLabelInput(
+                    e,
+                    (i) => i,
+                  ))).toList()
+              : null);
+}
+
+class _CopyWithStubImpl$Input$NlpMessageInput<TRes>
+    implements CopyWith$Input$NlpMessageInput<TRes> {
+  _CopyWithStubImpl$Input$NlpMessageInput(this._res);
+
+  TRes _res;
+
+  call({
+    String? id,
+    String? label,
+    List<Input$NlpLabelInput>? labels,
+  }) =>
+      _res;
+  labels(_fn) => _res;
+}
+
 class Input$SidMultiStepActionInput {
   factory Input$SidMultiStepActionInput({
     String? id,
@@ -26416,6 +27062,149 @@ Enum$ChannelInvitationDirection fromJson$Enum$ChannelInvitationDirection(
       return Enum$ChannelInvitationDirection.received;
     default:
       return Enum$ChannelInvitationDirection.$unknown;
+  }
+}
+
+enum Enum$NlpLabelName {
+  askingForEmailForDoc,
+  blocked,
+  concern,
+  confirmedMentoring,
+  error,
+  exit,
+  exitCalendly,
+  exitEmail,
+  exitGoogleMeet,
+  exitLinkedin,
+  exitPhone,
+  exitSkype,
+  exitTeams,
+  exitWhatsapp,
+  exitZoom,
+  genericMentoring,
+  ghosting,
+  negative,
+  notMatch,
+  noMatchCountry,
+  notMatchExpertise,
+  notSet,
+  personalizedMentoring,
+  positive,
+  spam,
+  $unknown
+}
+
+String toJson$Enum$NlpLabelName(Enum$NlpLabelName e) {
+  switch (e) {
+    case Enum$NlpLabelName.askingForEmailForDoc:
+      return r'askingForEmailForDoc';
+    case Enum$NlpLabelName.blocked:
+      return r'blocked';
+    case Enum$NlpLabelName.concern:
+      return r'concern';
+    case Enum$NlpLabelName.confirmedMentoring:
+      return r'confirmedMentoring';
+    case Enum$NlpLabelName.error:
+      return r'error';
+    case Enum$NlpLabelName.exit:
+      return r'exit';
+    case Enum$NlpLabelName.exitCalendly:
+      return r'exitCalendly';
+    case Enum$NlpLabelName.exitEmail:
+      return r'exitEmail';
+    case Enum$NlpLabelName.exitGoogleMeet:
+      return r'exitGoogleMeet';
+    case Enum$NlpLabelName.exitLinkedin:
+      return r'exitLinkedin';
+    case Enum$NlpLabelName.exitPhone:
+      return r'exitPhone';
+    case Enum$NlpLabelName.exitSkype:
+      return r'exitSkype';
+    case Enum$NlpLabelName.exitTeams:
+      return r'exitTeams';
+    case Enum$NlpLabelName.exitWhatsapp:
+      return r'exitWhatsapp';
+    case Enum$NlpLabelName.exitZoom:
+      return r'exitZoom';
+    case Enum$NlpLabelName.genericMentoring:
+      return r'genericMentoring';
+    case Enum$NlpLabelName.ghosting:
+      return r'ghosting';
+    case Enum$NlpLabelName.negative:
+      return r'negative';
+    case Enum$NlpLabelName.notMatch:
+      return r'notMatch';
+    case Enum$NlpLabelName.noMatchCountry:
+      return r'noMatchCountry';
+    case Enum$NlpLabelName.notMatchExpertise:
+      return r'notMatchExpertise';
+    case Enum$NlpLabelName.notSet:
+      return r'notSet';
+    case Enum$NlpLabelName.personalizedMentoring:
+      return r'personalizedMentoring';
+    case Enum$NlpLabelName.positive:
+      return r'positive';
+    case Enum$NlpLabelName.spam:
+      return r'spam';
+    case Enum$NlpLabelName.$unknown:
+      return r'$unknown';
+  }
+}
+
+Enum$NlpLabelName fromJson$Enum$NlpLabelName(String value) {
+  switch (value) {
+    case r'askingForEmailForDoc':
+      return Enum$NlpLabelName.askingForEmailForDoc;
+    case r'blocked':
+      return Enum$NlpLabelName.blocked;
+    case r'concern':
+      return Enum$NlpLabelName.concern;
+    case r'confirmedMentoring':
+      return Enum$NlpLabelName.confirmedMentoring;
+    case r'error':
+      return Enum$NlpLabelName.error;
+    case r'exit':
+      return Enum$NlpLabelName.exit;
+    case r'exitCalendly':
+      return Enum$NlpLabelName.exitCalendly;
+    case r'exitEmail':
+      return Enum$NlpLabelName.exitEmail;
+    case r'exitGoogleMeet':
+      return Enum$NlpLabelName.exitGoogleMeet;
+    case r'exitLinkedin':
+      return Enum$NlpLabelName.exitLinkedin;
+    case r'exitPhone':
+      return Enum$NlpLabelName.exitPhone;
+    case r'exitSkype':
+      return Enum$NlpLabelName.exitSkype;
+    case r'exitTeams':
+      return Enum$NlpLabelName.exitTeams;
+    case r'exitWhatsapp':
+      return Enum$NlpLabelName.exitWhatsapp;
+    case r'exitZoom':
+      return Enum$NlpLabelName.exitZoom;
+    case r'genericMentoring':
+      return Enum$NlpLabelName.genericMentoring;
+    case r'ghosting':
+      return Enum$NlpLabelName.ghosting;
+    case r'negative':
+      return Enum$NlpLabelName.negative;
+    case r'notMatch':
+      return Enum$NlpLabelName.notMatch;
+    case r'noMatchCountry':
+      return Enum$NlpLabelName.noMatchCountry;
+    case r'notMatchExpertise':
+      return Enum$NlpLabelName.notMatchExpertise;
+    case r'notSet':
+      return Enum$NlpLabelName.notSet;
+    case r'personalizedMentoring':
+      return Enum$NlpLabelName.personalizedMentoring;
+    case r'positive':
+      return Enum$NlpLabelName.positive;
+    case r'spam':
+      return Enum$NlpLabelName.spam;
+    default:
+      return Enum$NlpLabelName.$unknown;
   }
 }
 

--- a/lib/providers/invitations_provider.dart
+++ b/lib/providers/invitations_provider.dart
@@ -182,4 +182,29 @@ class InvitationsProvider extends BaseProvider {
           : null,
     );
   }
+
+  Future<OperationResult<String>> markChannelInvitationAsSeenByMe({
+    required String channelInvitationId,
+  }) async {
+    final QueryResult queryResult = await asyncMutation(
+      mutationOptions: MutationOptions(
+        document: documentNodeMutationMarkChannelInvitationAsSeenByMe,
+        fetchPolicy: FetchPolicy.noCache,
+        variables: Variables$Mutation$MarkChannelInvitationAsSeenByMe(
+          channelInvitationInput: Input$ChannelInvitationInput(
+            id: channelInvitationId,
+            readByRecipientAt: DateTime.now().toUtc(),
+          ),
+        ).toJson(),
+      ),
+    );
+    return OperationResult(
+      gqlQueryResult: queryResult,
+      response: queryResult.data != null
+          ? Mutation$MarkChannelInvitationAsSeenByMe.fromJson(
+              queryResult.data!,
+            ).updateChannelInvitation
+          : null,
+    );
+  }
 }

--- a/lib/providers/models/inbox_model.dart
+++ b/lib/providers/models/inbox_model.dart
@@ -40,6 +40,10 @@ class InboxModel extends ChangeNotifier {
       _pendingReceivedInvitations;
   List<SentChannelInvitation>? get pendingSentInvitations =>
       _pendingSentInvitations;
+  List<ReceivedChannelInvitation>? get unseenPendingReceivedInvitations =>
+      _pendingReceivedInvitations
+          ?.where((e) => e.readByRecipientAt == null)
+          .toList();
 
   // Channels
   List<ChannelForUser>? _activeChannels;
@@ -182,8 +186,8 @@ class InboxModel extends ChangeNotifier {
       return;
     } else {
       _pendingReceivedInvitations = result.response ?? [];
-      _inboxInvitesNotifications = _pendingReceivedInvitations!
-          .length; // TODO: Filter for only unread invites
+      _inboxInvitesNotifications =
+          unseenPendingReceivedInvitations?.length ?? 0;
       _pendingReceivedInvitations
           ?.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       _receivedInvitationsState = AsyncState.ready;

--- a/lib/schema/operations_invitation.graphql
+++ b/lib/schema/operations_invitation.graphql
@@ -3,6 +3,7 @@ query FindChannelInvitationById($channelInvitationId: String!) {
         createdAt
         messageText
         status
+        readByRecipientAt
         sender {
             id
             fullName
@@ -95,6 +96,7 @@ query MyReceivedChannelInvitations($direction: ChannelInvitationDirection, $only
         id
         messageText
         status
+        readByRecipientAt
         sender {
             avatarUrl
             fullName
@@ -136,4 +138,8 @@ mutation DeclineChannelInvitation($channelInvitationId: String!) {
 
 mutation DeleteChannelInvitation($deletePhysically: Boolean!, $channelInvitationId: String!) {
     deleteChannelInvitation(deletePhysically: $deletePhysically, channelInvitationId: $channelInvitationId)
+}
+
+mutation MarkChannelInvitationAsSeenByMe($channelInvitationInput: ChannelInvitationInput!) {
+    updateChannelInvitation(input: $channelInvitationInput)
 }

--- a/lib/schema/schema.graphql
+++ b/lib/schema/schema.graphql
@@ -299,6 +299,7 @@ type Query {
   findUserSearchResults(options: FindObjectsOptions, userSearchId: String!): [User!]!
   myUserSearches: [UserSearch!]!
   getMm2Integration: Mm2Integration!
+  findNlpConversation(conversationId: String!): NlpConversation!
   findMyActiveMultiStepAction: [SidMultiStepAction!]!
   getMultiStepActionProgress(
     """
@@ -359,6 +360,7 @@ type User {
   relationships: [UserRelationship!]
   inactivatedAt: DateTimeISO
   inactivatedBy: ID
+  termsAndConditionsAcceptedAt: DateTimeISO
   companyIds: [ID!]
   groupIds: [ID!]!
   parentGroupIds: [ID!]!
@@ -819,6 +821,7 @@ type ChannelInvitation {
   messageText: String
   dismissedFromInboxBySenderAt: DateTimeISO
   dismissedFromInboxByRecipientAt: DateTimeISO
+  readByRecipientAt: DateTimeISO
   status: ChannelInvitationStatus!
   channel: Channel!
   recipient: User!
@@ -1437,6 +1440,7 @@ input UserInput {
   latestActivityAt: DateTimeISO
   inactivatedAt: DateTimeISO
   inactivatedBy: ID
+  termsAndConditionsAcceptedAt: DateTimeISO
   companyIds: [ID!]
   groupIds: [ID!]
   parentGroupIds: [ID!]
@@ -1478,7 +1482,7 @@ input UserInput {
 }
 
 input ModelEventInput {
-  time: DateTimeISO! = "2023-10-02T21:29:33.195Z"
+  time: DateTimeISO! = "2023-10-03T22:37:38.888Z"
   modelEventType: ModelEventType! = info
   message: String! = ""
 }
@@ -1921,6 +1925,63 @@ type Mm2Integration {
   fullSyncAt: DateTimeISO
 }
 
+type NlpConversation {
+  id: ID!
+  userIds: [ID!]!
+  assumedMentorUserId: ID!
+  messages: [NlpMessage!]!
+  label: String
+  labels: [NlpLabel!]
+  updatedAt: DateTimeISO
+  createdAt: DateTimeISO
+}
+
+type NlpMessage {
+  id: ID!
+  conversationId: ID!
+  messageText: String!
+  senderRole: String!
+  label: String
+  labels: [NlpLabel!]
+  createdBy: ID!
+  createdAt: DateTimeISO
+}
+
+type NlpLabel {
+  name: NlpLabelName!
+  probability: Int!
+  createdBy: String!
+  createdAt: DateTimeISO!
+}
+
+enum NlpLabelName {
+  askingForEmailForDoc
+  blocked
+  concern
+  confirmedMentoring
+  error
+  exit
+  exitCalendly
+  exitEmail
+  exitGoogleMeet
+  exitLinkedin
+  exitPhone
+  exitSkype
+  exitTeams
+  exitWhatsapp
+  exitZoom
+  genericMentoring
+  ghosting
+  negative
+  notMatch
+  noMatchCountry
+  notMatchExpertise
+  notSet
+  personalizedMentoring
+  positive
+  spam
+}
+
 type SidMultiStepAction {
   id: ID!
   adminNotes: String
@@ -2153,6 +2214,12 @@ type Mutation {
   deleteMm2Synchronization(mm2SynchronizationId: String!): Mm2Synchronization!
   findMm2SynchronizationById(mm2SynchronizationId: String!): Mm2Synchronization!
   runMm2Synchronization(runAgain: Boolean, id: String!): Mm2Synchronization!
+
+  """Label a platform conversation for the NLP learning process."""
+  updateNlpConversation(input: NlpConversationInput!): String!
+
+  """Label a platform message for the NLP learning process."""
+  updateNlpMessage(input: NlpMessageInput!): String!
   createMultiStepAction(input: SidMultiStepActionInput!): SidMultiStepActionProgress!
   startResetPassword(deviceUuid: String!, input: UserIdentInput!): SidMultiStepActionProgress!
   startVerifyEmail(email: String!): SidMultiStepActionProgress!
@@ -2451,6 +2518,7 @@ input ChannelInvitationInput {
   messageText: String
   dismissedFromInboxBySenderAt: DateTimeISO
   dismissedFromInboxByRecipientAt: DateTimeISO
+  readByRecipientAt: DateTimeISO
   status: ChannelInvitationStatus
 }
 
@@ -2856,6 +2924,25 @@ input Mm2SynchronizationInput {
   Time this object will be deleted from the DB. Default = 10 days after creation.
   """
   expiresAt: DateTimeISO
+}
+
+input NlpConversationInput {
+  id: ID! = ""
+  label: String!
+  labels: [NlpLabelInput!]! = []
+}
+
+input NlpLabelInput {
+  name: NlpLabelName! = notSet
+  probability: Int! = 0
+  createdBy: ID
+  createdAt: DateTimeISO
+}
+
+input NlpMessageInput {
+  id: ID! = ""
+  label: String!
+  labels: [NlpLabelInput!]! = []
 }
 
 input SidMultiStepActionInput {

--- a/lib/widgets/features/home/components/invitation_section.dart
+++ b/lib/widgets/features/home/components/invitation_section.dart
@@ -73,16 +73,16 @@ class _InvitationSectionState extends State<InvitationSection> {
   @override
   Widget build(BuildContext context) {
     return Selector<InboxModel, List<ReceivedChannelInvitation>?>(
-      selector: (_, inboxModel) => inboxModel.pendingReceivedInvitations,
+      selector: (_, inboxModel) => inboxModel.unseenPendingReceivedInvitations,
       shouldRebuild: (oldValue, newValue) =>
           !(const DeepCollectionEquality.unordered()
               .equals(oldValue, newValue)) ||
           _inboxModel.receivedInvitationsState != AsyncState.loading,
-      builder: (context, pendingReceivedInvitations, _) {
+      builder: (context, unseenPendingReceivedInvitations, _) {
         return AppUtility.widgetForAsyncState(
           state: _inboxModel.receivedInvitationsState,
           onReady: () {
-            if (pendingReceivedInvitations?.isEmpty ?? true) {
+            if (unseenPendingReceivedInvitations?.isEmpty ?? true) {
               return const SizedBox(width: 0, height: 0);
             }
             final ThemeData theme = Theme.of(context);
@@ -112,25 +112,28 @@ class _InvitationSectionState extends State<InvitationSection> {
                             ),
                             const SizedBox(width: Insets.paddingSmall),
                             NotificationBubble(
-                              notifications: pendingReceivedInvitations!.length,
+                              notifications:
+                                  unseenPendingReceivedInvitations!.length,
                             )
                           ],
                         ),
-                        InkWell(
-                          onTap: () => context.push(
-                            Routes.inboxInvitesReceived.path,
-                          ),
-                          child: Padding(
-                            padding:
-                                const EdgeInsets.all(Insets.paddingExtraSmall),
-                            child: Text(
-                              _l10n.listSeeAll,
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: theme.colorScheme.onSurface,
+                        if (unseenPendingReceivedInvitations.length >
+                            Limits.homeInvitationsListMaxSize)
+                          InkWell(
+                            onTap: () => context.push(
+                              Routes.inboxInvitesReceived.path,
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(
+                                  Insets.paddingExtraSmall),
+                              child: Text(
+                                _l10n.listSeeAll,
+                                style: theme.textTheme.labelMedium?.copyWith(
+                                  color: theme.colorScheme.onSurface,
+                                ),
                               ),
                             ),
                           ),
-                        ),
                       ],
                     ),
                   ),
@@ -141,7 +144,7 @@ class _InvitationSectionState extends State<InvitationSection> {
                     child: Center(
                       child: Column(
                         children: _createInvitationList(
-                          pendingReceivedInvitations,
+                          unseenPendingReceivedInvitations,
                         ),
                       ),
                     ),

--- a/lib/widgets/features/home/components/profile_header.dart
+++ b/lib/widgets/features/home/components/profile_header.dart
@@ -41,7 +41,7 @@ class ProfileHeader extends StatelessWidget {
             ),
           ),
           const SizedBox(width: Insets.paddingMedium),
-          Flexible(
+          Expanded(
             child: Text(
               profileMessage,
               textAlign: TextAlign.start,

--- a/lib/widgets/features/inbox/components/inbox_list_tile.dart
+++ b/lib/widgets/features/inbox/components/inbox_list_tile.dart
@@ -145,13 +145,11 @@ class InboxListTile extends StatelessWidget {
                 message,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                style: highlightTileText
-                    ? theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onBackground,
-                      )
-                    : theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.hintColor,
-                      ),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: highlightTileText
+                      ? theme.colorScheme.onBackground
+                      : theme.hintColor,
+                ),
               ),
             ),
           ],

--- a/lib/widgets/features/inbox/components/inbox_list_tile.dart
+++ b/lib/widgets/features/inbox/components/inbox_list_tile.dart
@@ -9,6 +9,7 @@ class InboxListTile extends StatelessWidget {
   final DateTime date;
   final String message;
   final int notifications;
+  final bool showPlainNotificationBubble;
   final bool highlightTileTitle;
   final bool highlightTileText;
   final bool simplifyDate;
@@ -22,6 +23,7 @@ class InboxListTile extends StatelessWidget {
     required this.date,
     required this.message,
     this.notifications = 0,
+    this.showPlainNotificationBubble = false,
     this.highlightTileTitle = false,
     this.highlightTileText = false,
     this.simplifyDate = false,
@@ -84,11 +86,28 @@ class InboxListTile extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (notifications > 0)
+                    if (!showPlainNotificationBubble && notifications > 0)
                       Align(
                         alignment: AlignmentDirectional.topStart,
                         child: NotificationBubble(
                           notifications: notifications,
+                        ),
+                      ),
+                    if (showPlainNotificationBubble)
+                      Align(
+                        alignment: AlignmentDirectional.topStart,
+                        child: Padding(
+                          padding: const EdgeInsetsDirectional.only(
+                            top: Insets.paddingExtraSmall,
+                            start: Insets.paddingExtraSmall,
+                          ),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: Container(
+                              color: theme.colorScheme.error,
+                              child: const SizedBox(width: 12, height: 12),
+                            ),
+                          ),
                         ),
                       ),
                   ],

--- a/lib/widgets/features/inbox/inbox_invitation_detail.dart
+++ b/lib/widgets/features/inbox/inbox_invitation_detail.dart
@@ -39,6 +39,7 @@ class _InboxInvitationDetailScreenState
   late final InboxModel _inboxModel;
   late Future<OperationResult<ChannelInvitationById>> _invitation;
   late AppLocalizations _l10n;
+  bool _isMarkedAsRead = false;
 
   @override
   void initState() {
@@ -306,6 +307,14 @@ class _InboxInvitationDetailScreenState
     );
   }
 
+  Future<void> _markReceivedInvitationAsRead() async {
+    await _invitationsProvider.markChannelInvitationAsSeenByMe(
+      channelInvitationId: widget.channelInvitationId,
+    );
+    await _inboxModel.refreshPendingReceivedInvitations();
+    _isMarkedAsRead = true;
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!pageRoute.isCurrent) return const SizedBox.shrink();
@@ -329,6 +338,10 @@ class _InboxInvitationDetailScreenState
                   userId: invitationResult.sender.id,
                   userFullName: invitationResult.sender.fullName!,
                 );
+                if (!_isMarkedAsRead &&
+                    invitationResult.readByRecipientAt == null) {
+                  _markReceivedInvitationAsRead();
+                }
                 break;
               case MessageDirection.sent:
                 userCardCreateFunction = _createRecipientCard;

--- a/lib/widgets/features/inbox/inbox_invites_received.dart
+++ b/lib/widgets/features/inbox/inbox_invites_received.dart
@@ -53,18 +53,18 @@ class _InboxInvitesReceivedScreenState extends State<InboxInvitesReceivedScreen>
   InboxListTile _createTile(
     ReceivedChannelInvitation invitation,
   ) {
+    final bool isUnseenByMe = invitation.readByRecipientAt == null;
     return InboxListTile(
       avatarUrl: invitation.sender.avatarUrl,
       fullName: invitation.sender.fullName ?? '',
       date: invitation.createdAt.toLocal(),
       message: invitation.messageText ?? _l10n.inboxInvitesReceivedMessage,
-      highlightTileTitle:
-          true, // TODO - Highlight and show notification bubble only if unseen
-      highlightTileText: true,
+      highlightTileTitle: isUnseenByMe,
+      highlightTileText: isUnseenByMe,
       simplifyDate: true,
-      onPressed: () => router.push(
-        '${Routes.inboxInvitesReceived.path}/${invitation.id}',
-      ),
+      onPressed: () {
+        router.push('${Routes.inboxInvitesReceived.path}/${invitation.id}');
+      },
     );
   }
 

--- a/lib/widgets/features/inbox/inbox_invites_received.dart
+++ b/lib/widgets/features/inbox/inbox_invites_received.dart
@@ -59,6 +59,7 @@ class _InboxInvitesReceivedScreenState extends State<InboxInvitesReceivedScreen>
       fullName: invitation.sender.fullName ?? '',
       date: invitation.createdAt.toLocal(),
       message: invitation.messageText ?? _l10n.inboxInvitesReceivedMessage,
+      showPlainNotificationBubble: isUnseenByMe,
       highlightTileTitle: isUnseenByMe,
       highlightTileText: isUnseenByMe,
       simplifyDate: true,

--- a/lib/widgets/features/inbox/inbox_invites_sent.dart
+++ b/lib/widgets/features/inbox/inbox_invites_sent.dart
@@ -58,6 +58,7 @@ class _InboxInvitesSentScreenState extends State<InboxInvitesSentScreen>
       date: invitation.createdAt.toLocal(),
       message: invitation.messageText ?? '',
       highlightTileTitle: true,
+      highlightTileText: false,
       simplifyDate: true,
       onPressed: () => router.push(
         '${Routes.inboxInvitesSent.path}/${invitation.id}',

--- a/mm-mock-server/src/mocks/mutations.ts
+++ b/mm-mock-server/src/mocks/mutations.ts
@@ -118,6 +118,14 @@ export function mockMutations(serverState: MockServerState) {
             });
             return channelInvitation.id;
         },
+        updateChannelInvitation: (_: any, args: { input: { id: string, readByRecipientAt: Date | null } }) => {
+            const channelInvitation = serverState.channelInvitations.find((e) => e.id == args.input.id);
+            if(args.input.readByRecipientAt) {
+                channelInvitation.readByRecipientAt = args.input.readByRecipientAt;
+            }
+            serverState.pubsub.publish(PUBSUB_OBJECT_CHANGED, { objectChanged: { objectId: channelInvitation.id }});
+            return channelInvitation.id;
+        },
         deleteChannelMessage: (_: any, args: { channelMessageId: string, deletePhysically: boolean }) => {
             var channelMessage = serverState.channelMessages.find((element) => element.id == args.channelMessageId);
             const currentTime : string = new Date().toISOString();

--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -329,5 +329,6 @@ export function generateChannelInvitation(sender: any, recipient: any, messageTe
         senderId: sender.id,
         sender: sender,
         status: status,
+        readByRecipientAt: null,
     }
 }


### PR DESCRIPTION
Received invitations are marked as read whenever the user opens the invitation detail page. At this point the inbox invite notification for this specific invitation is removed, regardless if the invite was not accepted or declined. I also added a plain notification bubble in the inbox received invitations list tiles whenever the invitation hasn't been opened.

Modified the mock server to support new field readByRecipientAt.

The following video shows the feature in action:

[received-invites-read-receipt.webm](https://github.com/micromentor-team/mm-flutter-app/assets/25093428/a6daa63e-3533-4d18-b2e7-42928442a5b7)
