### PR TITLE
Return pronouns from mock server

### DIFF
--- a/mm-mock-server/src/mocks/queries.ts
+++ b/mm-mock-server/src/mocks/queries.ts
@@ -81,6 +81,9 @@ export function mockQueries(serverState: MockServerState) {
         findLanguages: () => {
             return constants.languages;
         },
+        findPronouns: () => {
+            return constants.pronouns;
+        },
         // groups
         findGroups: () => {
             return serverState.groups;


### PR DESCRIPTION
Mock server was missing a resolver to return list of pronouns.

This should fix https://trello.com/c/Gx0SWLc3/132-bug-sign-up-pronoun-page-is-broken-in-the-sign-up and the related query from the edit profile page.