### PR TITLE
Fix late variable error, relative import

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:mm_flutter_app/services/firebase/firebase_service.dart';
 import 'package:provider/provider.dart';
 
 import '__generated/schema/schema.graphql.dart';
@@ -13,6 +12,7 @@ import 'models/inbox_model.dart';
 import 'models/locale_model.dart';
 import 'models/scaffold_model.dart';
 import 'models/user_registration_model.dart';
+import 'services/firebase/firebase_service.dart';
 import 'services/graphql/graphql.dart';
 import 'services/graphql/providers/base/operation_result.dart';
 import 'services/graphql/providers/channels_provider.dart';

--- a/lib/services/firebase/firebase_service.dart
+++ b/lib/services/firebase/firebase_service.dart
@@ -21,7 +21,7 @@ mixin FirebaseServiceOwner {
 
 // see: https://firebase.google.com/docs/cloud-messaging/flutter/receive
 class FirebaseService with ChangeNotifier {
-  late StreamSubscription<String> _tokenSubscriptionStream;
+  StreamSubscription<String>? _tokenSubscriptionStream;
   // FirebaseApp? _firebaseApp;
   String? _firebaseToken;
   String? _deviceUuid;
@@ -63,7 +63,9 @@ class FirebaseService with ChangeNotifier {
   }
 
   void shutDownService() {
-    _tokenSubscriptionStream.cancel();
+    if (_tokenSubscriptionStream != null) {
+      _tokenSubscriptionStream!.cancel();
+    }
   }
 
   // This callback is fired at each app startup and whenever a new


### PR DESCRIPTION
Minor changes - in the debugger there was an exception when `_tokenSubscriptionStream.cancel();` was called, which this fixes. Not sure if that has any effect on the app.

In my local, I am unable to view the app's onboarding flow after pressing "Get Started", which is what this PR was attempting to fix.