### PR TITLE
Remove ShaderMask from signup flow to fix Web issues

### DIFF
--- a/lib/widgets/features/sign_up/components/sign_up_template.dart
+++ b/lib/widgets/features/sign_up/components/sign_up_template.dart
@@ -60,52 +60,39 @@ class SignUpTemplate extends StatelessWidget {
               top: 0,
               right: 0,
               bottom: navigationBarHeight,
-              child: ShaderMask(
-                shaderCallback: (Rect bounds) {
-                  return LinearGradient(
-                    begin: const Alignment(0, -0.92),
-                    end: const Alignment(0, -0.87),
-                    colors: [
-                      theme.colorScheme.surface,
-                      Colors.transparent,
-                    ],
-                  ).createShader(bounds);
-                },
-                blendMode: BlendMode.dstOut,
-                child: SingleChildScrollView(
-                  clipBehavior: Clip.none,
-                  child: Padding(
-                    padding: const EdgeInsets.all(Insets.paddingExtraLarge),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        const SizedBox(height: Insets.paddingLarge),
-                        LinearProgressIndicator(
-                          value: _signUpProgressToDouble(progress),
+              child: SingleChildScrollView(
+                clipBehavior: Clip.none,
+                child: Padding(
+                  padding: const EdgeInsets.all(Insets.paddingExtraLarge),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const SizedBox(height: Insets.paddingLarge),
+                      LinearProgressIndicator(
+                        value: _signUpProgressToDouble(progress),
+                      ),
+                      const SizedBox(height: Insets.paddingMedium),
+                      Text(
+                        title,
+                        softWrap: true,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          color: theme.colorScheme.primary,
                         ),
-                        const SizedBox(height: Insets.paddingMedium),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: Insets.paddingLarge),
+                      if (subtitle != null) ...[
                         Text(
-                          title,
-                          softWrap: true,
-                          style: theme.textTheme.headlineSmall?.copyWith(
-                            color: theme.colorScheme.primary,
+                          subtitle!,
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            color: theme.colorScheme.secondary,
                           ),
                           textAlign: TextAlign.center,
                         ),
-                        const SizedBox(height: Insets.paddingLarge),
-                        if (subtitle != null) ...[
-                          Text(
-                            subtitle!,
-                            style: theme.textTheme.bodyLarge?.copyWith(
-                              color: theme.colorScheme.secondary,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: Insets.paddingMedium),
-                        ],
-                        body,
+                        const SizedBox(height: Insets.paddingMedium),
                       ],
-                    ),
+                      body,
+                    ],
                   ),
                 ),
               ),


### PR DESCRIPTION
For some reason this widget makes it impossible to see the SignUp flow in the web version. Figured it was easier to remove it, since all it does is add a subtle fade effect at the top of the screen when scrolling vertically. No one will miss having this.