### PR TITLE
Minor mock server fixes: UserSearchInput & chat replies

### DIFF
--- a/mm-mock-server/src/mocks/util/generators.ts
+++ b/mm-mock-server/src/mocks/util/generators.ts
@@ -131,8 +131,8 @@ export function generateWebsite() {
 }
 
 export function generateUserSearch(userSearchInput: any, users: any) {
-    const filterSeeksHelp = userSearchInput.seeksHelp == "isTrue";
-    const filterOffersHelp = userSearchInput.offersHelp == "isTrue";
+    const filterSeeksHelp = userSearchInput.filter.seeksHelp == "isTrue";
+    const filterOffersHelp = userSearchInput.filter.offersHelp == "isTrue";
     const searchResults = users.filter(
         (e: any) => (e.seeksHelp && filterSeeksHelp) || (e.offersHelp && filterOffersHelp)
     );

--- a/mm-mock-server/src/mocks/util/state.ts
+++ b/mm-mock-server/src/mocks/util/state.ts
@@ -66,11 +66,11 @@ export class MockServerState {
         const message1 = generators.generateChannelMessage('👋', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:34:01-00:00'), true, false, false);
         const message2 = generators.generateChannelMessage('Are you available for a quick chat next week?', this.channels[0], this.loggedInUser, new Date('2023-07-26T12:35:01-00:00'), true);
         const message3 = generators.generateChannelMessage('Hello, there!', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true);
-        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, false, true, message2.id);
-        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, true, false, message2.id);
+        const message4 = generators.generateChannelMessage('Sorry, I am busy...', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, false, true);
+        const message5 = generators.generateChannelMessage('Of course! Grab any open spot from my calendar.', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:23:01-00:00'), true, true, false);
         const message6 = generators.generateChannelMessage('👍', this.channels[0], this.otherUsers[0], new Date('2023-07-27T08:24:01-00:00'), true);
         const message7 = generators.generateChannelMessage('dsflkjsadlkfjlk', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-00:00'), true, false, true);
-        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-00:00'), true, true, false, message5.id);
+        const message8 = generators.generateChannelMessage('Thanks! I will set up some time 😊', this.channels[0], this.loggedInUser, new Date('2023-07-28T00:56:01-00:00'), true, true, false);
         const message9 = generators.generateChannelMessage('You got it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:00:01-00:00'), false);
         const message10 = generators.generateChannelMessage('Let me know when you schedule it.', this.channels[0], this.otherUsers[0], new Date('2023-07-28T20:01:01-00:00'), false);
         this.channels[0].latestMessage = message10;


### PR DESCRIPTION
- Adds 'filter' to UserSearchInput in mock server, which was added to backend in https://github.com/micromentor-team/mm-flutter-app/pull/183. Without this the recommended section (Home) and the Explore page don't show any results.
- Remove reply comments from mock conversations, since replies are no longer supported by the UI (even though the code is still there for whenever this gets added again)