### PR TITLE
Initialize and maintain state during signup flow

### DIFF
--- a/lib/utilities/router.dart
+++ b/lib/utilities/router.dart
@@ -142,7 +142,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupCredentialsScreen(),
             );
           },
@@ -153,7 +153,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupGroupMembershipScreen(),
             );
           },
@@ -164,7 +164,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupEntrepreneurCompanyStageScreen(),
             );
           },
@@ -175,7 +175,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupExpertisesScreen(),
             );
           },
@@ -186,7 +186,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupEntrepreneurCompanyNameScreen(),
             );
           },
@@ -197,7 +197,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupReasonScreen(),
             );
           },
@@ -208,7 +208,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupCompletedScreen(),
             );
           },
@@ -219,7 +219,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupMentorRoleScreen(),
             );
           },
@@ -230,7 +230,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupPhoneScreen(),
             );
           },
@@ -241,7 +241,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupBirthYearScreen(),
             );
           },
@@ -252,7 +252,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupGenderScreen(),
             );
           },
@@ -263,7 +263,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupLocationScreen(),
             );
           },
@@ -274,7 +274,7 @@ class AppRouter {
           pageBuilder: (BuildContext context, GoRouterState state) {
             return MaterialPage(
               key: state.pageKey,
-              maintainState: false,
+              maintainState: true,
               child: const SignupLanguageScreen(),
             );
           },

--- a/lib/widgets/features/sign_up/screens/sign_up_birth_year.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_birth_year.dart
@@ -19,7 +19,7 @@ class SignupBirthYearScreen extends StatefulWidget {
 class _SignupBirthYearScreenState extends State<SignupBirthYearScreen> {
   final _formKey = GlobalKey<FormState>();
   late final UserRegistrationModel _registrationModel;
-  String? _year;
+  late final TextEditingController _yearController;
 
   @override
   void initState() {
@@ -28,6 +28,15 @@ class _SignupBirthYearScreenState extends State<SignupBirthYearScreen> {
       context,
       listen: false,
     );
+    _yearController = TextEditingController(
+      text: _registrationModel.updateUserInput.birthYear?.toString(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _yearController.dispose();
+    super.dispose();
   }
 
   @override
@@ -53,19 +62,18 @@ class _SignupBirthYearScreenState extends State<SignupBirthYearScreen> {
                 icon: const Icon(Icons.today),
                 onPressed: () {},
               ),
-              onChanged: (value) {
-                setState(() {
-                  _year = value;
-                });
-              },
+              textController: _yearController,
+              onChanged: (_) => setState(() {}),
             ),
           ],
         ),
       ),
-      isNextEnabled: _year?.isNotEmpty ?? false,
+      isNextEnabled: _yearController.text.isNotEmpty,
       onNextPressed: () {
         if (_formKey.currentState!.validate()) {
-          _registrationModel.updateUserInput.birthYear = int.parse(_year!);
+          _registrationModel.updateUserInput.birthYear = int.parse(
+            _yearController.text,
+          );
           context.push(Routes.signupLocation.path);
         }
       },

--- a/lib/widgets/features/sign_up/screens/sign_up_credentials.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_credentials.dart
@@ -20,12 +20,12 @@ class SignupCredentialsScreen extends StatefulWidget {
 class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   late final UserRegistrationModel _registrationModel;
-  String? _firstName;
-  String? _lastName;
-  String? _email;
-  String? _password;
-  String? _confirmPassword;
-  bool _enableUpdatesAndNews = false;
+  late final TextEditingController _firstNameController;
+  late final TextEditingController _lastNameController;
+  late final TextEditingController _emailController;
+  late final TextEditingController _passwordController;
+  late final TextEditingController _confirmPasswordController;
+  late bool _enableUpdatesAndNews;
 
   @override
   void initState() {
@@ -34,7 +34,33 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
       context,
       listen: false,
     );
-    _registrationModel.clear();
+    _firstNameController = TextEditingController(
+      text: _registrationModel.updateUserInput.firstName,
+    );
+    _lastNameController = TextEditingController(
+      text: _registrationModel.updateUserInput.lastName,
+    );
+    _emailController = TextEditingController(
+      text: _registrationModel.signUpUserInput.email,
+    );
+    _passwordController = TextEditingController(
+      text: _registrationModel.signUpUserInput.password,
+    );
+    _confirmPasswordController = TextEditingController(
+      text: _registrationModel.signUpUserInput.password,
+    );
+    _enableUpdatesAndNews =
+        _registrationModel.userPreferencesInput.enableUpdatesAndNews ?? false;
+  }
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
   }
 
   @override
@@ -55,11 +81,8 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
                   child: TextFormFieldWidget(
                     label: l10n.signupCredentialsNameFirstInputLabel,
                     hint: l10n.signupCredentialsNameFirstInputHint,
-                    onChanged: (value) {
-                      setState(() {
-                        _firstName = value;
-                      });
-                    },
+                    textController: _firstNameController,
+                    onChanged: (_) => setState(() {}),
                   ),
                 ),
                 const SizedBox(width: Insets.paddingMedium),
@@ -67,11 +90,8 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
                   child: TextFormFieldWidget(
                     label: l10n.signupCredentialsNameLastInputLabel,
                     hint: l10n.signupCredentialsNameLastInputHint,
-                    onChanged: (value) {
-                      setState(() {
-                        _lastName = value;
-                      });
-                    },
+                    textController: _lastNameController,
+                    onChanged: (_) => setState(() {}),
                   ),
                 ),
               ],
@@ -80,11 +100,8 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
             TextFormFieldWidget(
               label: l10n.signupCredentialsEmailInputLabel,
               hint: l10n.signupCredentialsEmailInputHint,
-              onChanged: (value) {
-                setState(() {
-                  _email = value;
-                });
-              },
+              textController: _emailController,
+              onChanged: (_) => setState(() {}),
               validator: (value) {
                 bool validEmail = EmailValidator.validate(value!);
                 if (validEmail != true) {
@@ -100,32 +117,26 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
                 if (val == null) {
                   return 'Empty';
                 }
-                if (val != _confirmPassword) {
+                if (val != _confirmPasswordController.text) {
                   return 'Not Match';
                 }
                 return null;
               },
               label: l10n.signupCredentialsPasswordInputLabel,
-              onChanged: (value) {
-                setState(() {
-                  _password = value;
-                });
-              },
+              textController: _passwordController,
+              onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: Insets.paddingMedium),
             TextFormFieldWidget(
               isPassword: true,
               label: l10n.signupCredentialsPasswordConfirmInputLabel,
-              onChanged: (value) {
-                setState(() {
-                  _confirmPassword = value;
-                });
-              },
+              textController: _confirmPasswordController,
+              onChanged: (_) => setState(() {}),
               validator: (val) {
                 if (val == null) {
                   return 'Empty';
                 }
-                if (val != _password) {
+                if (val != _passwordController.text) {
                   return 'Not Match';
                 }
                 return null;
@@ -149,19 +160,20 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
           ],
         ),
       ),
-      isNextEnabled: (_firstName?.isNotEmpty ?? false) &&
-          (_lastName?.isNotEmpty ?? false) &&
-          (_email?.isNotEmpty ?? false) &&
-          (_password?.isNotEmpty ?? false) &&
-          (_confirmPassword?.isNotEmpty ?? false),
+      isNextEnabled: _firstNameController.text.isNotEmpty &&
+          _lastNameController.text.isNotEmpty &&
+          _emailController.text.isNotEmpty &&
+          _passwordController.text.isNotEmpty &&
+          _confirmPasswordController.text.isNotEmpty,
       onNextPressed: () async {
         if (!_formKey.currentState!.validate()) {
           return;
         }
-        _registrationModel.signUpUserInput.email = _email;
-        _registrationModel.signUpUserInput.password = _password;
-        _registrationModel.updateUserInput.firstName = _firstName;
-        _registrationModel.updateUserInput.lastName = _lastName;
+        _registrationModel.signUpUserInput.email = _emailController.text;
+        _registrationModel.signUpUserInput.password = _passwordController.text;
+        _registrationModel.updateUserInput.firstName =
+            _firstNameController.text;
+        _registrationModel.updateUserInput.lastName = _lastNameController.text;
         _registrationModel.userPreferencesInput.enableUpdatesAndNews =
             _enableUpdatesAndNews;
         router.push(Routes.signupPhone.path);

--- a/lib/widgets/features/sign_up/screens/sign_up_entrepreneur_company_name.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_entrepreneur_company_name.dart
@@ -19,7 +19,7 @@ class SignupEntrepreneurCompanyNameScreen extends StatefulWidget {
 class _SignupEntrepreneurCompanyNameScreenState
     extends State<SignupEntrepreneurCompanyNameScreen> {
   late final UserRegistrationModel _registrationModel;
-  String? _businessName;
+  late final TextEditingController _businessNameController;
 
   @override
   void initState() {
@@ -28,6 +28,15 @@ class _SignupEntrepreneurCompanyNameScreenState
       context,
       listen: false,
     );
+    _businessNameController = TextEditingController(
+      text: _registrationModel.updateUserInput.companyName,
+    );
+  }
+
+  @override
+  void dispose() {
+    _businessNameController.dispose();
+    super.dispose();
   }
 
   @override
@@ -43,16 +52,14 @@ class _SignupEntrepreneurCompanyNameScreenState
           label: l10n.signupBusinessNameInputLabel,
           maxLength: 50,
           hint: l10n.signupBusinessNameInputHint,
-          onChanged: (value) {
-            setState(() {
-              _businessName = value;
-            });
-          },
+          textController: _businessNameController,
+          onChanged: (_) => setState(() {}),
         ),
       ),
-      isNextEnabled: _businessName?.isNotEmpty ?? false,
+      isNextEnabled: _businessNameController.text.isNotEmpty,
       onNextPressed: () {
-        _registrationModel.updateUserInput.companyName = _businessName;
+        _registrationModel.updateUserInput.companyName =
+            _businessNameController.text;
         context.push(Routes.signupReason.path);
       },
     );

--- a/lib/widgets/features/sign_up/screens/sign_up_entrepreneur_company_stage.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_entrepreneur_company_stage.dart
@@ -19,7 +19,13 @@ class SignupEntrepreneurCompanyStageScreen extends StatefulWidget {
 class _SignupEntrepreneurCompanyStageScreenState
     extends State<SignupEntrepreneurCompanyStageScreen> {
   late final UserRegistrationModel _registrationModel;
-  int _selectedStageIndex = 0;
+  final List<String> _companyStages = [
+    CompanyStageTextId.idea.name,
+    CompanyStageTextId.operational.name,
+    CompanyStageTextId.earning.name,
+    CompanyStageTextId.profitable.name,
+  ];
+  late int _selectedStageIndex;
 
   @override
   void initState() {
@@ -28,6 +34,12 @@ class _SignupEntrepreneurCompanyStageScreenState
       context,
       listen: false,
     );
+    _selectedStageIndex =
+        _registrationModel.updateUserInput.companyStageTextId != null
+            ? _companyStages.indexOf(
+                _registrationModel.updateUserInput.companyStageTextId!,
+              )
+            : 0;
   }
 
   @override
@@ -60,31 +72,13 @@ class _SignupEntrepreneurCompanyStageScreenState
             ],
             imageAssetName: const [null, null, null, null],
             onSelectedCardChanged: (index) => _selectedStageIndex = index,
+            initialSelection: _selectedStageIndex,
           ),
         ],
       ),
       onNextPressed: () {
-        switch (_selectedStageIndex) {
-          case 0:
-            _registrationModel.updateUserInput.companyStageTextId =
-                CompanyStageTextId.idea.name;
-            break;
-          case 1:
-            _registrationModel.updateUserInput.companyStageTextId =
-                CompanyStageTextId.operational.name;
-            break;
-          case 2:
-            _registrationModel.updateUserInput.companyStageTextId =
-                CompanyStageTextId.earning.name;
-            break;
-          case 3:
-            _registrationModel.updateUserInput.companyStageTextId =
-                CompanyStageTextId.profitable.name;
-            break;
-          default:
-            _registrationModel.updateUserInput.companyStageTextId = null;
-            break;
-        }
+        _registrationModel.updateUserInput.companyStageTextId =
+            _companyStages[_selectedStageIndex];
         context.push(Routes.signupEntrepreneurCompanyName.path);
       },
     );

--- a/lib/widgets/features/sign_up/screens/sign_up_expertises.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_expertises.dart
@@ -23,7 +23,8 @@ class _SignupExpertisesScreenState extends State<SignupExpertisesScreen> {
   late final bool _isEntrepreneur;
   final int maxSelections = 3;
 
-  List<SelectChip> _selectedChips = [];
+  late List<SelectChip> _selectedChips;
+  late final List<SelectChip> _initialSelection;
 
   @override
   void initState() {
@@ -44,6 +45,25 @@ class _SignupExpertisesScreenState extends State<SignupExpertisesScreen> {
         )
         .toList();
     _expertiseChips.sort((a, b) => a.chipName.compareTo(b.chipName));
+    // Initialize with pre-selected values
+    if (_isEntrepreneur) {
+      _initialSelection = _registrationModel
+              .updateUserInput.menteeSoughtExpertisesTextIds
+              ?.map((e) =>
+                  _expertiseChips.where((c) => c.textId == e).firstOrNull)
+              .nonNulls
+              .toList() ??
+          [];
+    } else {
+      _initialSelection = _registrationModel
+              .updateUserInput.mentorExpertisesTextIds
+              ?.map((e) =>
+                  _expertiseChips.where((c) => c.textId == e).firstOrNull)
+              .nonNulls
+              .toList() ??
+          [];
+    }
+    _selectedChips = _initialSelection;
   }
 
   @override
@@ -60,6 +80,7 @@ class _SignupExpertisesScreenState extends State<SignupExpertisesScreen> {
       body: CreateMultiSelectChips(
         chips: _expertiseChips,
         maxSelection: maxSelections,
+        initialSelection: _initialSelection,
         onSelectedChipsChanged: (chips) =>
             setState(() => _selectedChips = chips),
       ),

--- a/lib/widgets/features/sign_up/screens/sign_up_gender.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_gender.dart
@@ -30,6 +30,14 @@ class _SignupGenderScreenState extends State<SignupGenderScreen> {
       context,
       listen: false,
     );
+    if (_registrationModel.updateUserInput.genderTextId != null) {
+      final selectedGender = _contentProvider.presetGenderOptions
+          ?.where((e) =>
+              e.textId == _registrationModel.updateUserInput.genderTextId)
+          .firstOrNull;
+      _genderValue = selectedGender?.translatedValue;
+      _genderTextId = selectedGender?.textId;
+    }
   }
 
   Widget _createGenderOption(ThemeData theme, String value, String textId) {

--- a/lib/widgets/features/sign_up/screens/sign_up_group_membership.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_group_membership.dart
@@ -19,7 +19,11 @@ class SignupGroupMembershipScreen extends StatefulWidget {
 class _SignupGroupMembershipScreenState
     extends State<SignupGroupMembershipScreen> {
   late final UserRegistrationModel _registrationModel;
-  int? selectedNumber = 0;
+  final List<UserType> _groupMemberships = [
+    UserType.entrepreneur,
+    UserType.mentor,
+  ];
+  late int _selectedIndex;
 
   @override
   void initState() {
@@ -28,6 +32,10 @@ class _SignupGroupMembershipScreenState
       context,
       listen: false,
     );
+    _selectedIndex = _registrationModel.updateUserInput.userType != null
+        ? _groupMemberships
+            .indexOf(_registrationModel.updateUserInput.userType!)
+        : 0;
   }
 
   @override
@@ -53,17 +61,18 @@ class _SignupGroupMembershipScreenState
               Image(image: AssetImage(Assets.mentorIcon))
             ],
             titleIcon: const [null, null],
+            initialSelection: _selectedIndex,
             onSelectedCardChanged: (value) =>
-                setState(() => selectedNumber = value),
+                setState(() => _selectedIndex = value),
           ),
         ],
       ),
       onNextPressed: () {
-        if (selectedNumber == 0) {
-          _registrationModel.updateUserInput.userType = UserType.entrepreneur;
+        _registrationModel.updateUserInput.userType =
+            _groupMemberships[_selectedIndex];
+        if (_groupMemberships[_selectedIndex] == UserType.entrepreneur) {
           _registrationModel.updateUserInput.clearMentorFields();
         } else {
-          _registrationModel.updateUserInput.userType = UserType.mentor;
           _registrationModel.updateUserInput.clearEntrepreneurFields();
         }
         context.push(Routes.signupExpertises.path);

--- a/lib/widgets/features/sign_up/screens/sign_up_language.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_language.dart
@@ -21,6 +21,7 @@ class _SignupLanguageScreenState extends State<SignupLanguageScreen> {
   final _preferredLanguagesController = TextfieldTagsController();
   late final ContentProvider _contentProvider;
   late final UserRegistrationModel _registrationModel;
+  final Set<String> _initialSelection = {};
   bool _selectedPreferredLanguage = false;
 
   @override
@@ -31,6 +32,14 @@ class _SignupLanguageScreenState extends State<SignupLanguageScreen> {
       context,
       listen: false,
     );
+    if (_registrationModel.updateUserInput.preferredLanguageTextId != null) {
+      _initialSelection.add(_contentProvider.languageOptions!
+          .firstWhere((e) =>
+              e.textId ==
+              _registrationModel.updateUserInput.preferredLanguageTextId!)
+          .translatedValue!);
+      _selectedPreferredLanguage = true;
+    }
     _preferredLanguagesController.addListener(() {
       setState(() {
         _selectedPreferredLanguage = _preferredLanguagesController.hasTags;
@@ -60,6 +69,7 @@ class _SignupLanguageScreenState extends State<SignupLanguageScreen> {
             label: l10n.signupLanguageInputLabel,
             hint: l10n.signupLanguageInputHint,
             controller: _preferredLanguagesController,
+            selectedOptions: _initialSelection,
             options: _contentProvider.languageOptions!
                 .map((e) => e.translatedValue!)
                 .toList(),

--- a/lib/widgets/features/sign_up/screens/sign_up_location.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_location.dart
@@ -17,7 +17,7 @@ class SignupLocationScreen extends StatefulWidget {
 
 class _SignupLocationScreenState extends State<SignupLocationScreen> {
   late final UserRegistrationModel _registrationModel;
-  String? _location;
+  late final TextEditingController _locationController;
 
   @override
   void initState() {
@@ -26,6 +26,16 @@ class _SignupLocationScreenState extends State<SignupLocationScreen> {
       context,
       listen: false,
     );
+    // TODO - also set region and country
+    _locationController = TextEditingController(
+      text: _registrationModel.updateUserInput.cityOfResidence,
+    );
+  }
+
+  @override
+  void dispose() {
+    _locationController.dispose();
+    super.dispose();
   }
 
   @override
@@ -41,15 +51,15 @@ class _SignupLocationScreenState extends State<SignupLocationScreen> {
           prefixIcon: const Icon(Icons.search),
           label: l10n.signupLocationInputLabel,
           hint: l10n.signupLocationInputHint,
-          onChanged: (value) => setState(() {
-            _location = value;
-          }),
+          textController: _locationController,
+          onChanged: (_) => setState(() {}),
         ),
       ),
-      isNextEnabled: _location?.isNotEmpty ?? false,
+      isNextEnabled: _locationController.text.isNotEmpty,
       onNextPressed: () {
         // TODO - also set region and country
-        _registrationModel.updateUserInput.cityOfResidence = _location;
+        _registrationModel.updateUserInput.cityOfResidence =
+            _locationController.text;
         context.push(Routes.signupLanguage.path);
       },
     );

--- a/lib/widgets/features/sign_up/screens/sign_up_mentor_role.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_mentor_role.dart
@@ -17,8 +17,8 @@ class SignupMentorRoleScreen extends StatefulWidget {
 
 class _SignupMentorRoleScreenState extends State<SignupMentorRoleScreen> {
   late final UserRegistrationModel _registrationModel;
-  String? _jobTitle;
-  String? _companyName;
+  late final TextEditingController _jobTitleController;
+  late final TextEditingController _companyNameController;
 
   @override
   void initState() {
@@ -27,6 +27,19 @@ class _SignupMentorRoleScreenState extends State<SignupMentorRoleScreen> {
       context,
       listen: false,
     );
+    _jobTitleController = TextEditingController(
+      text: _registrationModel.updateUserInput.experienceJobTitle,
+    );
+    _companyNameController = TextEditingController(
+      text: _registrationModel.updateUserInput.experienceBusinessName,
+    );
+  }
+
+  @override
+  void dispose() {
+    _jobTitleController.dispose();
+    _companyNameController.dispose();
+    super.dispose();
   }
 
   @override
@@ -43,11 +56,8 @@ class _SignupMentorRoleScreenState extends State<SignupMentorRoleScreen> {
             child: TextFormFieldWidget(
               label: l10n.signupRoleJobTitleInputLabel,
               hint: l10n.signupRoleJobTitleInputHint,
-              onChanged: (value) {
-                setState(() {
-                  _jobTitle = value;
-                });
-              },
+              textController: _jobTitleController,
+              onChanged: (_) => setState(() {}),
             ),
           ),
           const SizedBox(
@@ -57,21 +67,19 @@ class _SignupMentorRoleScreenState extends State<SignupMentorRoleScreen> {
             child: TextFormFieldWidget(
               label: l10n.signupRoleCompanyInputLabel,
               hint: l10n.signupRoleCompanyInputHint,
-              onChanged: (value) {
-                setState(() {
-                  _companyName = value;
-                });
-              },
+              textController: _companyNameController,
+              onChanged: (_) => setState(() {}),
             ),
           ),
         ],
       ),
-      isNextEnabled: (_jobTitle?.isNotEmpty ?? false) &&
-          (_companyName?.isNotEmpty ?? false),
+      isNextEnabled: _jobTitleController.text.isNotEmpty &&
+          _companyNameController.text.isNotEmpty,
       onNextPressed: () {
-        _registrationModel.updateUserInput.experienceJobTitle = _jobTitle;
+        _registrationModel.updateUserInput.experienceJobTitle =
+            _jobTitleController.text;
         _registrationModel.updateUserInput.experienceBusinessName =
-            _companyName;
+            _companyNameController.text;
         context.push(Routes.signupReason.path);
       },
     );

--- a/lib/widgets/features/sign_up/screens/sign_up_method.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_method.dart
@@ -2,14 +2,30 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mm_flutter_app/models/user_registration_model.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../constants/constants.dart';
 import '../../../shared/social_sign_in_button.dart';
 import '../components/sign_up_template.dart';
 
-class SignupMethodScreen extends StatelessWidget {
+class SignupMethodScreen extends StatefulWidget {
   const SignupMethodScreen({super.key});
+
+  @override
+  State<SignupMethodScreen> createState() => _SignupMethodScreenState();
+}
+
+class _SignupMethodScreenState extends State<SignupMethodScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Provider.of<UserRegistrationModel>(
+      context,
+      listen: false,
+    ).clear();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/features/sign_up/screens/sign_up_phone.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_phone.dart
@@ -21,7 +21,7 @@ class SignupPhoneScreen extends StatefulWidget {
 class _SignupPhoneScreenState extends State<SignupPhoneScreen> {
   final _formKey = GlobalKey<FormState>();
   late final UserRegistrationModel _registrationModel;
-  String? _phoneNumber;
+  late final TextEditingController _phoneNumberController;
   String? _selectedCountryCode = _countryCode[0];
 
   @override
@@ -31,6 +31,16 @@ class _SignupPhoneScreenState extends State<SignupPhoneScreen> {
       context,
       listen: false,
     );
+    _phoneNumberController = TextEditingController(
+      text: _registrationModel.updateUserInput.phoneNumber,
+    );
+    //TODO: Implement Country code dropdown and initialize here
+  }
+
+  @override
+  void dispose() {
+    _phoneNumberController.dispose();
+    super.dispose();
   }
 
   @override
@@ -96,21 +106,19 @@ class _SignupPhoneScreenState extends State<SignupPhoneScreen> {
                 ],
                 label: l10n.signupPhoneInputLabel,
                 hint: l10n.signupPhoneInputHint,
-                onChanged: (value) {
-                  setState(() {
-                    _phoneNumber = value;
-                  });
-                },
+                textController: _phoneNumberController,
+                onChanged: (_) => setState(() {}),
               ),
             ),
           ],
         ),
       ),
-      isNextEnabled: _phoneNumber?.isNotEmpty ?? false,
+      isNextEnabled: _phoneNumberController.text.isNotEmpty,
       onNextPressed: () {
         if (_formKey.currentState!.validate()) {
           _registrationModel.updateUserInput.phoneNumber =
-              '$_selectedCountryCode $_phoneNumber';
+              _phoneNumberController.value.text;
+          //TODO: Add country code
           context.push(Routes.signupGender.path);
         }
       },

--- a/lib/widgets/features/sign_up/screens/sign_up_reason.dart
+++ b/lib/widgets/features/sign_up/screens/sign_up_reason.dart
@@ -18,7 +18,7 @@ class SignupReasonScreen extends StatefulWidget {
 class _SignupReasonScreenState extends State<SignupReasonScreen> {
   late final UserRegistrationModel _registrationModel;
   late final bool _isEntrepreneur;
-  String? _text;
+  late final TextEditingController _reasonController;
 
   @override
   void initState() {
@@ -29,6 +29,17 @@ class _SignupReasonScreenState extends State<SignupReasonScreen> {
     );
     _isEntrepreneur =
         _registrationModel.updateUserInput.userType == UserType.entrepreneur;
+    _reasonController = TextEditingController(
+      text: _isEntrepreneur
+          ? _registrationModel.updateUserInput.menteeReasonForStartingBusiness
+          : _registrationModel.updateUserInput.mentorReasonForMentoring,
+    );
+  }
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
   }
 
   @override
@@ -49,19 +60,17 @@ class _SignupReasonScreenState extends State<SignupReasonScreen> {
             : l10n.signupReasonMentorInputHint,
         maxLength: 1000,
         maxLines: 6,
-        onChanged: (value) {
-          setState(() {
-            _text = value;
-          });
-        },
+        textController: _reasonController,
+        onChanged: (_) => setState(() {}),
       ),
-      isNextEnabled: _text?.isNotEmpty ?? false,
+      isNextEnabled: _reasonController.text.isNotEmpty,
       onNextPressed: () {
         if (_isEntrepreneur) {
           _registrationModel.updateUserInput.menteeReasonForStartingBusiness =
-              _text;
+              _reasonController.text;
         } else {
-          _registrationModel.updateUserInput.mentorReasonForMentoring = _text;
+          _registrationModel.updateUserInput.mentorReasonForMentoring =
+              _reasonController.text;
         }
         context.push(Routes.signupCompleted.path);
       },


### PR DESCRIPTION
This PR makes it so that users can navigate back and forward in the signup flow pages without losing the values that were previously entered.

This is done primarily in two ways:

1. PageRoutes in the router are set to maintain state, which means that once created the screens will remain active and maintain the state of their variables even if there is another page in the top of the navigation stack. This helps when navigating to previous pages. * Note that performance is not a concern here because there can only be one copy of each signup screen in the navigation stack, and the stack is cleared once signup completes.
2. The Stateful Widget screens are initialized using values from the UserRegistrationModel, if any. This helps when navigating forward to a page you had filled out already, given that said page had to be popped and disposed of in order to get to a previous page, meaning that the maintain state method discussed above won't help in this case.

The following video demonstrates the feature:

[signup-save-state.webm](https://github.com/micromentor-team/mm-flutter-app/assets/25093428/2e06f6af-6120-4ee9-9ca0-46d5e56f4e3d)
